### PR TITLE
Added time module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2416,6 +2416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2579,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -3136,6 +3153,7 @@ dependencies = [
  "rustc-hash",
  "smallvec",
  "thiserror",
+ "time",
  "walrus",
  "wasmtime",
  "yaml-rust",

--- a/yara-x/Cargo.toml
+++ b/yara-x/Cargo.toml
@@ -24,6 +24,9 @@ test_proto3-module = []
 text-module = [
     "dep:lingua"
 ]
+# The Magic module allows you to identify the type of the file based on 
+# the output of file(1), the standard Unix command. 
+time-module = []
 
 # Features that are enabled by default.
 default = [
@@ -59,7 +62,7 @@ yara-x-parser = { workspace = true }
 yara-x-proto = { workspace = true }
 
 lingua = { version = "1.4.0", optional = true, default-features = false, features = ["english", "german", "french", "spanish"] }
-
+time = { version = "0.1", optional = true, default-features = false }
 
 [build-dependencies]
 protobuf = { workspace = true }

--- a/yara-x/src/lib.rs
+++ b/yara-x/src/lib.rs
@@ -31,6 +31,3 @@ mod scanner;
 mod string_pool;
 mod symbols;
 mod wasm;
-
-#[cfg(test)]
-mod tests;

--- a/yara-x/src/modules/mod.rs
+++ b/yara-x/src/modules/mod.rs
@@ -22,6 +22,9 @@ pub(crate) mod prelude {
 
 include!("modules.rs");
 
+#[cfg(test)]
+mod tests;
+
 /// Type of module's main function.
 type MainFn = fn(&ScanContext) -> Box<dyn MessageDyn>;
 

--- a/yara-x/src/modules/modules.rs
+++ b/yara-x/src/modules/modules.rs
@@ -3,5 +3,7 @@
 pub mod text;
 #[cfg(feature = "test_proto2-module")]
 pub mod test_proto2;
+#[cfg(feature = "time-module")]
+pub mod time;
 #[cfg(feature = "test_proto3-module")]
 pub mod test_proto3;

--- a/yara-x/src/modules/protos/time.proto
+++ b/yara-x/src/modules/protos/time.proto
@@ -1,0 +1,13 @@
+syntax = "proto2";
+
+import "yara.proto";
+
+option (yara.module_options) = {
+  name : "time"
+  root_message: "Time"
+  rust_module: "time"
+};
+
+message Time {
+  // This module contains only exported functions, and doesn't return any data
+}

--- a/yara-x/src/modules/tests/mod.rs
+++ b/yara-x/src/modules/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "time-module")]
+mod time; 

--- a/yara-x/src/modules/tests/time.rs
+++ b/yara-x/src/modules/tests/time.rs
@@ -1,0 +1,21 @@
+use pretty_assertions::assert_eq;
+
+#[test]
+fn e2e_test(){
+    let mut src = String::new();
+    src.push_str(r#"import "time""#);
+    src.push_str(r#"rule t {condition: time.now() >= 1680547861}"#);
+
+    let rules = crate::compiler::Compiler::new()
+        .add_source(src.as_str())
+        .unwrap()
+        .build()
+        .unwrap();
+
+    let data = b"Maestro\r";
+
+    let mut scanner = crate::scanner::Scanner::new(&rules);
+    let results = scanner.scan(data);
+
+    assert_eq!(results.num_matching_rules(), 1);
+}

--- a/yara-x/src/modules/time.rs
+++ b/yara-x/src/modules/time.rs
@@ -1,0 +1,18 @@
+use crate::modules::prelude::*;
+use crate::modules::protos::time::*;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[module_main]
+fn main(_ctx: &ScanContext) -> Time {
+    // Nothing to do, but we have to return our protobuf
+    let time_proto = Time::new();
+    time_proto
+}
+
+#[module_export(name = "now")]
+fn now(ctx: &ScanContext) -> Option<i64> {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(n) => return Some(n.as_secs() as i64),
+        Err(_) => return None,
+    }
+}


### PR DESCRIPTION
Port of the time module.

I've implemented time.now(), no rule changes should be needed. Used @BlackSyke magic module as template for this module. @wxsBSD and @blacksyke decided it was best to add a minimal protobuf specification rather than hack the build scripts to account for modules that only have exported functions and return no data, like this one.

```
cargo test --package yara-x --lib --features time-module -- modules::tests::time::e2e_test --exact --nocapture

   Compiling yara-x v0.1.0 (yara-x/yara-x)
    Finished test [unoptimized + debuginfo] target(s) in 1.76s
     Running unittests src/lib.rs (target/debug/deps/yara_x-56a7c9914ffab9dd)

running 1 test
test modules::tests::time::e2e_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.13s
```
