### PR TITLE
ci: fix workflow for detecting unused dependencies

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -39,5 +39,5 @@ jobs:
     - name: Run cargo-udeps
       uses: aig787/cargo-udeps-action@v1
       with:
-        version: 0.1.35
+        version: v0.1.35
         args: '--all-targets'

--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -39,5 +39,5 @@ jobs:
     - name: Run cargo-udeps
       uses: aig787/cargo-udeps-action@v1
       with:
-        version: 'latest'
+        version: 0.1.35
         args: '--all-targets'


### PR DESCRIPTION
Fix the error: Couldn't find a release tarball containing binaries for latest. 

See: https://github.com/est31/cargo-udeps/issues/157