### PR TITLE
refactor: big refactor that addresses multiple issues

### DIFF
--- a/yara-x-macros/src/wasm_export.rs
+++ b/yara-x-macros/src/wasm_export.rs
@@ -37,6 +37,7 @@ impl<'ast> FuncSignatureParser<'ast> {
             "PatternId" | "RuleId" => Ok(Cow::Borrowed("i")),
             "RegexpId" => Ok(Cow::Borrowed("r")),
             "RuntimeString" => Ok(Cow::Borrowed("s")),
+            "RuntimeObjectRef" => Ok(Cow::Borrowed("i")),
             type_ident => Err(syn::Error::new_spanned(
                 type_path,
                 format!(

--- a/yara-x-macros/src/wasm_export.rs
+++ b/yara-x-macros/src/wasm_export.rs
@@ -38,6 +38,7 @@ impl<'ast> FuncSignatureParser<'ast> {
             "RegexpId" => Ok(Cow::Borrowed("r")),
             "RuntimeString" => Ok(Cow::Borrowed("s")),
             "RuntimeObjectRef" => Ok(Cow::Borrowed("i")),
+            "Rc" => Ok(Cow::Borrowed("i")),
             type_ident => Err(syn::Error::new_spanned(
                 type_path,
                 format!(

--- a/yara-x-macros/src/wasm_export.rs
+++ b/yara-x-macros/src/wasm_export.rs
@@ -37,7 +37,7 @@ impl<'ast> FuncSignatureParser<'ast> {
             "PatternId" | "RuleId" => Ok(Cow::Borrowed("i")),
             "RegexpId" => Ok(Cow::Borrowed("r")),
             "RuntimeString" => Ok(Cow::Borrowed("s")),
-            "RuntimeObjectRef" => Ok(Cow::Borrowed("i")),
+            "RuntimeObjectHandle" => Ok(Cow::Borrowed("i")),
             "Rc" => Ok(Cow::Borrowed("i")),
             type_ident => Err(syn::Error::new_spanned(
                 type_path,

--- a/yara-x-parser/src/ast/ascii_tree.rs
+++ b/yara-x-parser/src/ast/ascii_tree.rs
@@ -259,11 +259,8 @@ pub(crate) fn expr_ascii_tree(expr: &Expr) -> Tree {
             ],
         ),
         Expr::FieldAccess(expr) => Node(
-            "<struct>.<field>".to_string(),
-            vec![
-                Node("<struct>".to_string(), vec![expr_ascii_tree(&expr.lhs)]),
-                Node("<field>".to_string(), vec![expr_ascii_tree(&expr.rhs)]),
-            ],
+            "field access".to_string(),
+            expr.operands().map(expr_ascii_tree).collect(),
         ),
         Expr::FuncCall(expr) => {
             // Create a vector where each argument is accompanied by a label

--- a/yara-x-parser/src/ast/mod.rs
+++ b/yara-x-parser/src/ast/mod.rs
@@ -465,7 +465,7 @@ pub enum Expr<'src> {
     Lookup(Box<Lookup<'src>>),
 
     /// A field lookup expression (e.g. `foo.bar`)
-    FieldAccess(Box<BinaryExpr<'src>>),
+    FieldAccess(Box<NAryExpr<'src>>),
 
     /// A function call expression (e.g. `foo()`, `bar(1,2)`)
     FuncCall(Box<FuncCall<'src>>),
@@ -791,6 +791,12 @@ impl<'src> NAryExpr<'src> {
     #[inline]
     pub fn as_slice(&self) -> &[Expr<'src>] {
         self.operands.as_slice()
+    }
+}
+
+impl<'src> From<Vec<Expr<'src>>> for NAryExpr<'src> {
+    fn from(value: Vec<Expr<'src>>) -> Self {
+        Self { operands: value }
     }
 }
 

--- a/yara-x-parser/src/parser/tests/testdata/general.yaml
+++ b/yara-x-parser/src/parser/tests/testdata/general.yaml
@@ -202,30 +202,21 @@
     └─ rule test
        └─ condition
           └─ eq
-             ├─ <struct>.<field>
-             │  ├─ <struct>
-             │  │  └─ <expr>[<index>]
-             │  │     ├─ <expr>
-             │  │     │  └─ <struct>.<field>
-             │  │     │     ├─ <struct>
-             │  │     │     │  └─ foo
-             │  │     │     └─ <field>
-             │  │     │        └─ bar
-             │  │     └─ <index>
-             │  │        └─ 0
-             │  └─ <field>
-             │     └─ baz
+             ├─ field access
+             │  ├─ <expr>[<index>]
+             │  │  ├─ <expr>
+             │  │  │  └─ field access
+             │  │  │     ├─ foo
+             │  │  │     └─ bar
+             │  │  └─ <index>
+             │  │     └─ 0
+             │  └─ baz
              └─ <callable>()
                 └─ <callable>
-                   └─ <struct>.<field>
-                      ├─ <struct>
-                      │  └─ <struct>.<field>
-                      │     ├─ <struct>
-                      │     │  └─ foo
-                      │     └─ <field>
-                      │        └─ bar
-                      └─ <field>
-                         └─ baz
+                   └─ field access
+                      ├─ foo
+                      ├─ bar
+                      └─ baz
 
 ###############################################################################
 
@@ -238,21 +229,17 @@
     root
     └─ rule test
        └─ condition
-          └─ <struct>.<field>
-             ├─ <struct>
-             │  └─ <callable>(<arg0>, <arg1>)
-             │     ├─ <callable>
-             │     │  └─ <struct>.<field>
-             │     │     ├─ <struct>
-             │     │     │  └─ foo
-             │     │     └─ <field>
-             │     │        └─ bar
-             │     ├─ <arg0>
-             │     │  └─ 1
-             │     └─ <arg1>
-             │        └─ 2
-             └─ <field>
-                └─ baz
+          └─ field access
+             ├─ <callable>(<arg0>, <arg1>)
+             │  ├─ <callable>
+             │  │  └─ field access
+             │  │     ├─ foo
+             │  │     └─ bar
+             │  ├─ <arg0>
+             │  │  └─ 1
+             │  └─ <arg1>
+             │     └─ 2
+             └─ baz
 
 ###############################################################################
 
@@ -282,19 +269,15 @@
     root
     └─ rule test
        └─ condition
-          └─ <struct>.<field>
-             ├─ <struct>
-             │  └─ <expr>[<index>]
-             │     ├─ <expr>
-             │     │  └─ <struct>.<field>
-             │     │     ├─ <struct>
-             │     │     │  └─ foo
-             │     │     └─ <field>
-             │     │        └─ bar
-             │     └─ <index>
-             │        └─ 0
-             └─ <field>
-                └─ baz
+          └─ field access
+             ├─ <expr>[<index>]
+             │  ├─ <expr>
+             │  │  └─ field access
+             │  │     ├─ foo
+             │  │     └─ bar
+             │  └─ <index>
+             │     └─ 0
+             └─ baz
 
 ###############################################################################
 

--- a/yara-x/src/compiler/context.rs
+++ b/yara-x/src/compiler/context.rs
@@ -187,7 +187,7 @@ impl VarStack {
 ///
 /// Frames are stacked one in top of another, individual variables are
 /// allocated within a frame.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct VarStackFrame {
     pub start: i32,
     pub used: i32,

--- a/yara-x/src/compiler/context.rs
+++ b/yara-x/src/compiler/context.rs
@@ -129,21 +129,7 @@ impl<'a, 'src, 'sym> CompileContext<'a, 'src, 'sym> {
 /// top of another. Each frame can contain one or more variables.
 ///
 /// This stack is stored in WASM main memory, in a memory region that goes
-/// from [`wasm::VARS_STACK_START`] to [`wasm::VARS_STACK_END`]. The stack
-/// is also mirrored at host-side (with host-side we refer to Rust code
-/// called from WASM code), because values like structures, maps, and
-/// arrays can't be handled by WASM code directly, and they must be
-/// accessible to Rust functions called from WASM. These two stacks (the
-/// WASM-side stack and the host-side stack) could be fully independent,
-/// but they are mirrored for simplicity. This means that calls to this
-/// function reserves space in both stacks at the same time, and therefore
-/// their sizes are always the same.
-///
-/// However, each stack slot is used either by WASM-side code or by
-/// host-side code, but not by both. The slots that are used by WASM-side
-/// remain with empty values in the host-side stack, while the slots that
-/// are used by host-side code remain unused and undefined in WASM
-/// memory.
+/// from [`wasm::VARS_STACK_START`] to [`wasm::VARS_STACK_END`].
 pub(crate) struct VarStack {
     pub used: i32,
 }

--- a/yara-x/src/compiler/emit.rs
+++ b/yara-x/src/compiler/emit.rs
@@ -417,9 +417,10 @@ fn emit_expr(
             emit_pattern_length(ctx, instr, expr);
         }
 
-        Expr::FieldAccess { lhs, rhs } => {
-            emit_expr(ctx, instr, lhs);
-            emit_expr(ctx, instr, rhs);
+        Expr::FieldAccess { operands } => {
+            for operand in operands {
+                emit_expr(ctx, instr, operand);
+            }
         }
 
         Expr::Defined { operand } => {

--- a/yara-x/src/compiler/emit.rs
+++ b/yara-x/src/compiler/emit.rs
@@ -309,7 +309,8 @@ fn emit_expr(
                 // already there.
                 let literal_id = ctx.lit_pool.get_or_intern(value.as_bstr());
 
-                instr.i64_const(RuntimeString::Literal(literal_id).as_wasm());
+                instr
+                    .i64_const(RuntimeString::Literal(literal_id).into_wasm());
             }
             TypeValue::Regexp(Some(regexp)) => {
                 let re_id = ctx.regexp_pool.get_or_intern(regexp.as_str());

--- a/yara-x/src/compiler/emit.rs
+++ b/yara-x/src/compiler/emit.rs
@@ -353,7 +353,8 @@ fn emit_expr(
                 SymbolKind::Func(func) => {
                     emit_func_call(ctx, instr, func);
                 }
-                SymbolKind::FieldIndex(index) => {
+                SymbolKind::StructField(index)
+                | SymbolKind::RootStructField(index) => {
                     ctx.lookup_stack.push_back((*index).try_into().unwrap());
 
                     match symbol.type_value() {
@@ -417,7 +418,7 @@ fn emit_expr(
             emit_pattern_length(ctx, instr, expr);
         }
 
-        Expr::FieldAccess { operands } => {
+        Expr::FieldAccess { operands, .. } => {
             for operand in operands {
                 emit_expr(ctx, instr, operand);
             }

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -1,11 +1,12 @@
 /*! Functions for converting an AST into an IR. */
 
-use itertools::Itertools;
 use std::borrow::Borrow;
 use std::iter;
-use std::ops::{Deref, RangeInclusive};
+use std::ops::RangeInclusive;
 use std::rc::Rc;
 
+use bstr::ByteSlice;
+use itertools::Itertools;
 use yara_x_parser::ast::{HasSpan, Span};
 use yara_x_parser::report::ReportBuilder;
 use yara_x_parser::{ast, ErrorInfo, Warning};
@@ -209,25 +210,23 @@ pub(in crate::compiler) fn expr_from_ast(
         ast::Expr::Filesize { .. } => Ok(Expr::Filesize),
 
         ast::Expr::True { .. } => {
-            Ok(Expr::Const { type_value: TypeValue::Bool(Value::Const(true)) })
+            Ok(Expr::Const { type_value: TypeValue::const_bool_from(true) })
         }
 
-        ast::Expr::False { .. } => Ok(Expr::Const {
-            type_value: TypeValue::Bool(Value::Const(false)),
-        }),
+        ast::Expr::False { .. } => {
+            Ok(Expr::Const { type_value: TypeValue::const_bool_from(false) })
+        }
 
         ast::Expr::LiteralInteger(literal) => Ok(Expr::Const {
-            type_value: TypeValue::Integer(Value::Const(literal.value)),
+            type_value: TypeValue::const_integer_from(literal.value),
         }),
 
         ast::Expr::LiteralFloat(literal) => Ok(Expr::Const {
-            type_value: TypeValue::Float(Value::Const(literal.value)),
+            type_value: TypeValue::const_float_from(literal.value),
         }),
 
         ast::Expr::LiteralString(literal) => Ok(Expr::Const {
-            type_value: TypeValue::String(Value::Const(
-                literal.value.deref().to_owned().into(),
-            )),
+            type_value: TypeValue::const_string_from(literal.value.as_bytes()),
         }),
 
         ast::Expr::Regexp(regexp) => {

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -735,7 +735,7 @@ fn for_of_expr_from_ast(
         "$",
         Symbol::new(
             TypeValue::Integer(Value::Unknown),
-            SymbolKind::WasmVar(next_pattern_id),
+            SymbolKind::Var(next_pattern_id),
         ),
     );
 
@@ -822,37 +822,13 @@ fn for_in_expr_from_ast(
 
     // TODO: raise warning when the loop identifier (e.g: "i") hides
     // an existing identifier with the same name.
-    for (var, type_value) in iter::zip(loop_vars, expected_vars) {
-        let symbol_kind = match type_value {
-            TypeValue::Integer(_) => {
-                let var = stack_frame.new_var(Type::Integer);
-                variables.push(var);
-                SymbolKind::WasmVar(var)
-            }
-            TypeValue::Bool(_) => {
-                let var = stack_frame.new_var(Type::Bool);
-                variables.push(var);
-                SymbolKind::WasmVar(var)
-            }
-            TypeValue::String(_) => {
-                let var = stack_frame.new_var(Type::String);
-                variables.push(var);
-                SymbolKind::WasmVar(var)
-            }
-            TypeValue::Float(_) => {
-                let var = stack_frame.new_var(Type::Float);
-                variables.push(var);
-                SymbolKind::WasmVar(var)
-            }
-            TypeValue::Struct(_) => {
-                let var = stack_frame.new_var(Type::Struct);
-                variables.push(var);
-                SymbolKind::HostVar(var)
-            }
-            _ => unreachable!(),
-        };
-
-        symbols.insert(var.name, Symbol::new(type_value, symbol_kind));
+    for (loop_var, type_value) in iter::zip(loop_vars, expected_vars) {
+        let var = stack_frame.new_var(type_value.ty());
+        variables.push(var);
+        symbols.insert(
+            loop_var.name,
+            Symbol::new(type_value, SymbolKind::Var(var)),
+        );
     }
 
     // Put the loop variables into scope.

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -226,7 +226,7 @@ pub(in crate::compiler) fn expr_from_ast(
 
         ast::Expr::LiteralString(literal) => Ok(Expr::Const {
             type_value: TypeValue::String(Value::Const(
-                literal.value.deref().to_owned(),
+                literal.value.deref().to_owned().into(),
             )),
         }),
 

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -384,13 +384,15 @@ pub(in crate::compiler) fn expr_from_ast(
                 }
             }
 
-            let type_value = symbol.type_value();
-
-            if type_value.is_const() {
-                Ok(Expr::Const { type_value: type_value.clone() })
-            } else {
-                Ok(Expr::Ident { symbol })
+            #[cfg(feature = "constant-folding")]
+            {
+                let type_value = symbol.type_value();
+                if type_value.is_const() {
+                    return Ok(Expr::Const { type_value });
+                }
             }
+
+            Ok(Expr::Ident { symbol })
         }
 
         ast::Expr::PatternMatch(p) => {

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -388,7 +388,7 @@ pub(in crate::compiler) fn expr_from_ast(
             {
                 let type_value = symbol.type_value();
                 if type_value.is_const() {
-                    return Ok(Expr::Const { type_value });
+                    return Ok(Expr::Const { type_value: type_value.clone() });
                 }
             }
 

--- a/yara-x/src/compiler/ir/mod.rs
+++ b/yara-x/src/compiler/ir/mod.rs
@@ -381,10 +381,9 @@ pub(in crate::compiler) enum Expr {
         lhs: Box<Expr>,
     },
 
-    /// Field access expression (e.g. `foo.bar`)
+    /// Field access expression (e.g. `foo.bar.baz`)
     FieldAccess {
-        rhs: Box<Expr>,
-        lhs: Box<Expr>,
+        operands: Vec<Expr>,
     },
 
     /// A `defined` expression (e.g. `defined foo`)
@@ -629,7 +628,7 @@ impl Expr {
             | Expr::Shl { .. }
             | Expr::Shr { .. } => Type::Integer,
 
-            Expr::FieldAccess { rhs, .. } => rhs.ty(),
+            Expr::FieldAccess { operands } => operands.last().unwrap().ty(),
             Expr::Ident { symbol, .. } => symbol.type_value().ty(),
             Expr::FuncCall(fn_call) => fn_call.type_value.ty(),
             Expr::Lookup(lookup) => lookup.type_value.ty(),
@@ -698,7 +697,9 @@ impl Expr {
             | Expr::Shl { .. }
             | Expr::Shr { .. } => TypeValue::Integer(Value::Unknown),
 
-            Expr::FieldAccess { rhs, .. } => rhs.type_value(),
+            Expr::FieldAccess { operands } => {
+                operands.last().unwrap().type_value().clone()
+            }
             Expr::Ident { symbol, .. } => symbol.type_value().clone(),
             Expr::FuncCall(fn_call) => fn_call.type_value.clone(),
             Expr::Lookup(lookup) => lookup.type_value.clone(),

--- a/yara-x/src/compiler/ir/mod.rs
+++ b/yara-x/src/compiler/ir/mod.rs
@@ -207,6 +207,7 @@ pub(in crate::compiler) struct RegexpPattern {
 }
 
 /// Intermediate representation (IR) for an expression.
+#[derive(Debug)]
 pub(in crate::compiler) enum Expr {
     /// Constant value (i.e: the value is known at compile time). The value
     /// in `type_value` is not `None`.
@@ -460,6 +461,7 @@ pub(in crate::compiler) enum Expr {
 }
 
 /// A lookup operation in an array or dictionary.
+#[derive(Debug)]
 pub(in crate::compiler) struct Lookup {
     pub type_value: TypeValue,
     pub primary: Box<Expr>,
@@ -467,6 +469,7 @@ pub(in crate::compiler) struct Lookup {
 }
 
 /// An expression representing a function call.
+#[derive(Debug)]
 pub(in crate::compiler) struct FuncCall {
     /// The callable expression, which must resolve in some function identifier.
     pub callable: Expr,
@@ -482,6 +485,7 @@ pub(in crate::compiler) struct FuncCall {
 
 /// An `of` expression (e.g. `1 of ($a, $b)`, `all of them`,
 /// `any of (true, false)`)
+#[derive(Debug)]
 pub(in crate::compiler) struct Of {
     pub quantifier: Quantifier,
     pub items: OfItems,
@@ -491,6 +495,7 @@ pub(in crate::compiler) struct Of {
 
 /// A `for .. of` expression (e.g `for all of them : (..)`,
 /// `for 1 of ($a,$b) : (..)`)
+#[derive(Debug)]
 pub(in crate::compiler) struct ForOf {
     pub quantifier: Quantifier,
     pub variable: Var,
@@ -500,6 +505,7 @@ pub(in crate::compiler) struct ForOf {
 }
 
 /// A `for .. in` expression (e.g `for all x in iterator : (..)`)
+#[derive(Debug)]
 pub(in crate::compiler) struct ForIn {
     pub quantifier: Quantifier,
     pub variables: Vec<Var>,
@@ -509,6 +515,7 @@ pub(in crate::compiler) struct ForIn {
 }
 
 /// A quantifier used in `for` and `of` expressions.
+#[derive(Debug)]
 pub(in crate::compiler) enum Quantifier {
     None,
     All,
@@ -523,6 +530,7 @@ pub(in crate::compiler) enum Quantifier {
 /// The anchor is the part of the expression that restricts the offset range
 /// where the match can occur.
 /// (e.g. `at <expr>`, `in <range>`).
+#[derive(Debug)]
 pub(in crate::compiler) enum MatchAnchor {
     None,
     At(Box<Expr>),
@@ -548,18 +556,21 @@ impl MatchAnchor {
 }
 
 /// Items in a `of` expression.
+#[derive(Debug)]
 pub(in crate::compiler) enum OfItems {
     PatternSet(Vec<PatternId>),
     BoolExprTuple(Vec<Expr>),
 }
 
 /// A pair of values conforming a range (e.g. `(0..10)`).
+#[derive(Debug)]
 pub(in crate::compiler) struct Range {
     pub lower_bound: Box<Expr>,
     pub upper_bound: Box<Expr>,
 }
 
 /// Possible iterable expressions that can use in a [`ForIn`].
+#[derive(Debug)]
 pub(in crate::compiler) enum Iterable {
     Range(Range),
     ExprTuple(Vec<Expr>),
@@ -698,7 +709,7 @@ impl Expr {
             | Expr::Shr { .. } => TypeValue::Integer(Value::Unknown),
 
             Expr::FieldAccess { operands } => {
-                operands.last().unwrap().type_value().clone()
+                operands.last().unwrap().type_value()
             }
             Expr::Ident { symbol, .. } => symbol.type_value().clone(),
             Expr::FuncCall(fn_call) => fn_call.type_value.clone(),

--- a/yara-x/src/compiler/ir/mod.rs
+++ b/yara-x/src/compiler/ir/mod.rs
@@ -639,7 +639,9 @@ impl Expr {
             | Expr::Shl { .. }
             | Expr::Shr { .. } => Type::Integer,
 
-            Expr::FieldAccess { operands } => operands.last().unwrap().ty(),
+            Expr::FieldAccess { operands, .. } => {
+                operands.last().unwrap().ty()
+            }
             Expr::Ident { symbol, .. } => symbol.type_value().ty(),
             Expr::FuncCall(fn_call) => fn_call.type_value.ty(),
             Expr::Lookup(lookup) => lookup.type_value.ty(),
@@ -708,7 +710,7 @@ impl Expr {
             | Expr::Shl { .. }
             | Expr::Shr { .. } => TypeValue::Integer(Value::Unknown),
 
-            Expr::FieldAccess { operands } => {
+            Expr::FieldAccess { operands, .. } => {
                 operands.last().unwrap().type_value()
             }
             Expr::Ident { symbol, .. } => symbol.type_value().clone(),

--- a/yara-x/src/compiler/ir/mod.rs
+++ b/yara-x/src/compiler/ir/mod.rs
@@ -737,8 +737,7 @@ impl Expr {
                 // also true.
                 if operands.is_empty() {
                     return Expr::Const {
-                        // TODO: create a method in TypeValue for making this simpler?
-                        type_value: TypeValue::Bool(Value::Const(true)),
+                        type_value: TypeValue::const_bool_from(true),
                     };
                 }
 
@@ -747,8 +746,7 @@ impl Expr {
                 // regardless of the operands with unknown values.
                 if operands.iter().any(|op| op.type_value().is_const()) {
                     return Expr::Const {
-                        // TODO: create a method in TypeValue for making this simpler?
-                        type_value: TypeValue::Bool(Value::Const(false)),
+                        type_value: TypeValue::const_bool_from(false),
                     };
                 }
 
@@ -770,8 +768,7 @@ impl Expr {
                 // also false.
                 if operands.is_empty() {
                     return Expr::Const {
-                        // TODO: create a method in TypeValue for making this simpler?
-                        type_value: TypeValue::Bool(Value::Const(false)),
+                        type_value: TypeValue::const_bool_from(false),
                     };
                 }
 
@@ -780,8 +777,7 @@ impl Expr {
                 // regardless of the operands with unknown values.
                 if operands.iter().any(|op| op.type_value().is_const()) {
                     return Expr::Const {
-                        // TODO: create a method in TypeValue for making this simpler?
-                        type_value: TypeValue::Bool(Value::Const(true)),
+                        type_value: TypeValue::const_bool_from(true),
                     };
                 }
 
@@ -805,13 +801,11 @@ impl Expr {
                 }
                 if is_float {
                     Expr::Const {
-                        type_value: TypeValue::Float(Value::Const(sum)),
+                        type_value: TypeValue::const_float_from(sum),
                     }
                 } else {
                     Expr::Const {
-                        type_value: TypeValue::Integer(Value::Const(
-                            sum as i64,
-                        )),
+                        type_value: TypeValue::const_integer_from(sum as i64),
                     }
                 }
             }

--- a/yara-x/src/compiler/mod.rs
+++ b/yara-x/src/compiler/mod.rs
@@ -817,8 +817,6 @@ impl<'a> Compiler<'a> {
             }
         };
 
-        dbg!(&condition);
-
         // Create a new symbol of bool type for the rule.
         let new_symbol = Symbol::new(
             TypeValue::Bool(Value::Unknown),

--- a/yara-x/src/compiler/mod.rs
+++ b/yara-x/src/compiler/mod.rs
@@ -817,6 +817,8 @@ impl<'a> Compiler<'a> {
             }
         };
 
+        dbg!(&condition);
+
         // Create a new symbol of bool type for the rule.
         let new_symbol = Symbol::new(
             TypeValue::Bool(Value::Unknown),
@@ -880,7 +882,6 @@ impl<'a> Compiler<'a> {
             wasm_symbols: &self.wasm_symbols,
             wasm_exports: &self.wasm_exports,
             exception_handler_stack: Vec::new(),
-            lookup_start: None,
             lookup_stack: VecDeque::new(),
             vars: VarStack::new(),
         };

--- a/yara-x/src/compiler/mod.rs
+++ b/yara-x/src/compiler/mod.rs
@@ -299,7 +299,7 @@ impl<'a> Compiler<'a> {
             atoms: Vec::new(),
             re_code: Vec::new(),
             imported_modules: Vec::new(),
-            root_struct: Struct::new(),
+            root_struct: Struct::new().make_root(),
             report_builder: ReportBuilder::new(),
             lit_pool: BStringPool::new(),
             regexp_pool: StringPool::new(),
@@ -378,17 +378,13 @@ impl<'a> Compiler<'a> {
         let var: Variable = value.try_into()?;
         let type_value: TypeValue = var.into();
 
-        if self.root_struct.add_field(ident, type_value.clone()).is_some() {
+        if self.root_struct.add_field(ident, type_value).is_some() {
             return Err(VariableError::AlreadyExists(ident.to_string()));
         }
 
-        self.global_symbols.borrow_mut().insert(
-            ident,
-            Symbol::new(
-                type_value,
-                SymbolKind::FieldIndex(self.root_struct.index_of(ident)),
-            ),
-        );
+        self.global_symbols
+            .borrow_mut()
+            .insert(ident, self.root_struct.lookup(ident).unwrap());
 
         Ok(self)
     }
@@ -1497,18 +1493,7 @@ impl<'a> Compiler<'a> {
             if !symbol_table.contains(module_name) {
                 symbol_table.insert(
                     module_name,
-                    Symbol::new(
-                        // At this point the module must be found in
-                        // `self.root_struct`.
-                        self.root_struct
-                            .field_by_name(module_name)
-                            .unwrap()
-                            .type_value
-                            .clone(),
-                        SymbolKind::FieldIndex(
-                            self.root_struct.index_of(module_name),
-                        ),
-                    ),
+                    self.root_struct.lookup(module_name).unwrap(),
                 );
             }
         }

--- a/yara-x/src/modules/test_proto2/tests/mod.rs
+++ b/yara-x/src/modules/test_proto2/tests/mod.rs
@@ -255,10 +255,3 @@ fn test_proto2_module() {
         "#
     );
 }
-
-#[test]
-fn foo() {
-    condition_true!(
-        r#"for any k,v in test_proto2.map_int64_int64: ( k == 100 and v == 1000 )"#
-    );
-}

--- a/yara-x/src/modules/test_proto2/tests/mod.rs
+++ b/yara-x/src/modules/test_proto2/tests/mod.rs
@@ -242,7 +242,7 @@ fn test_proto2_module() {
     condition_true!(r#"test_proto2.to_int("123") == 123"#);
 
     // This field is named `bool_proto` in the protobuf definition, but it's
-    // name for YARA wsa changed to `bool_yara`, with:
+    // name for YARA was changed to `bool_yara`, with:
     //
     //   [(yara.field_options).name = "bool_yara"];
     //
@@ -253,5 +253,12 @@ fn test_proto2_module() {
         test_proto2.add(test_proto2.int64_one, test_proto2.int64_one) == 2 and
         test_proto2.add(test_proto2.int64_one, test_proto2.int64_zero) == 1
         "#
+    );
+}
+
+#[test]
+fn foo() {
+    condition_true!(
+        r#"for any k,v in test_proto2.map_int64_int64: ( k == 100 and v == 1000 )"#
     );
 }

--- a/yara-x/src/modules/tests.rs
+++ b/yara-x/src/modules/tests.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::io::Read;
-use std::io::Write;
 use std::path::Path;
 
 /// Utility function that receives the content of an [`Intel HEX`][1] (ihex)

--- a/yara-x/src/scanner/context.rs
+++ b/yara-x/src/scanner/context.rs
@@ -33,7 +33,7 @@ use crate::re::Action;
 use crate::scanner::matches::{Match, MatchList, UnconfirmedMatch};
 use crate::scanner::{RuntimeStringId, HEARTBEAT_COUNTER};
 use crate::string_pool::BStringPool;
-use crate::types::{Array, Map, Struct, TypeValue};
+use crate::types::{Array, Map, Struct};
 use crate::wasm::MATCHING_RULES_BITMAP_BASE;
 use crate::ScanError;
 

--- a/yara-x/src/scanner/context.rs
+++ b/yara-x/src/scanner/context.rs
@@ -1251,33 +1251,6 @@ pub enum RuntimeObject {
 }
 
 impl RuntimeObject {
-    pub fn as_struct_ref(&self) -> &Struct {
-        if let Self::Struct(s) = self {
-            s.as_ref()
-        } else {
-            panic!(
-                "calling `as_struct_ref` in a RuntimeObject that is not a struct"
-            )
-        }
-    }
-
-    pub fn as_array_ref(&self) -> &Array {
-        if let Self::Array(a) = self {
-            a.as_ref()
-        } else {
-            panic!(
-                "calling `as_array_ref` in a RuntimeObject that is not an array"
-            )
-        }
-    }
-    pub fn as_map_ref(&self) -> &Map {
-        if let Self::Map(a) = self {
-            a.as_ref()
-        } else {
-            panic!("calling `as_map_ref` in a RuntimeObject that is not a map")
-        }
-    }
-
     pub fn as_struct(&self) -> Rc<Struct> {
         if let Self::Struct(s) = self {
             s.clone()

--- a/yara-x/src/scanner/context.rs
+++ b/yara-x/src/scanner/context.rs
@@ -40,11 +40,10 @@ use crate::ScanError;
 pub(crate) struct ScanContext<'r> {
     /// Pointer to the WASM store.
     pub wasm_store: NonNull<Store<ScanContext<'r>>>,
-    /// Map where keys are object references and keys are objects
-    /// used during the evaluation of rule conditions. Object references
-    /// are opaque integer values that can be passed to and received from
-    /// WASM code. Each of reference identify an object (string, struct,
-    /// array or map).
+    /// Map where keys are object handles and keys are objects used during the
+    /// evaluation of rule conditions. Handles are opaque integer values that
+    /// can be passed to and received from WASM code. Each handle identify an
+    /// object (string, struct, array or map).
     pub runtime_objects: IndexMap<RuntimeObjectHandle, RuntimeObject>,
     /// Pointer to the data being scanned.
     pub scanned_data: *const u8,
@@ -1240,9 +1239,9 @@ struct VM<'r> {
 /// evaluation of a rule condition. Instances of these types can't cross the
 /// WASM-Rust boundary, as integers and floats can do. Therefore, they are
 /// stored in a hash map in [`ScanContext`], using a [`RuntimeObjectHandler`]
-/// as the key that identifies each instance. Object handlers are actually
-/// 64-bits integers that can cross the WASM-Rust boundary, and used to
-/// retrieve the original object.
+/// as the key that identifies each object. Handlers are actually 64-bits
+/// integers that can cross the WASM-Rust boundary, and used to retrieve the
+/// original object from [`ScanContext`].
 pub enum RuntimeObject {
     Struct(Rc<Struct>),
     Array(Rc<Array>),

--- a/yara-x/src/scanner/context.rs
+++ b/yara-x/src/scanner/context.rs
@@ -227,6 +227,12 @@ impl ScanContext<'_> {
         obj_ref
     }
 
+    pub(crate) fn store_string(&mut self, s: Rc<String>) -> RuntimeObjectRef {
+        let obj_ref = RuntimeObjectRef(Rc::<String>::as_ptr(&s) as i64);
+        self.runtime_objects.insert_full(obj_ref, RuntimeObject::String(s));
+        obj_ref
+    }
+
     /// Called during the scan process when a global rule didn't match.
     ///
     /// When this happen any other global rule in the same namespace that
@@ -1230,6 +1236,7 @@ pub enum RuntimeObject {
     Struct(Rc<Struct>),
     Array(Rc<Array>),
     Map(Rc<Map>),
+    String(Rc<String>),
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
@@ -1239,8 +1246,8 @@ impl RuntimeObjectRef {
     pub(crate) const NULL: Self = RuntimeObjectRef(-1);
 }
 
-impl From<&RuntimeObjectRef> for i64 {
-    fn from(value: &RuntimeObjectRef) -> Self {
+impl From<RuntimeObjectRef> for i64 {
+    fn from(value: RuntimeObjectRef) -> Self {
         value.0
     }
 }

--- a/yara-x/src/scanner/mod.rs
+++ b/yara-x/src/scanner/mod.rs
@@ -121,7 +121,7 @@ impl<'r> Scanner<'r> {
                 compiled_rules: rules,
                 string_pool: BStringPool::new(),
                 current_struct: None,
-                root_struct: rules.globals(),
+                root_struct: rules.globals().make_root(),
                 scanned_data: null(),
                 scanned_data_len: 0,
                 private_matching_rules: Vec::new(),

--- a/yara-x/src/scanner/mod.rs
+++ b/yara-x/src/scanner/mod.rs
@@ -19,6 +19,7 @@ use std::{cmp, fs, thread};
 
 use bitvec::prelude::*;
 use fmmap::{MmapFile, MmapFileExt};
+use indexmap::IndexMap;
 use protobuf::MessageDyn;
 use rustc_hash::FxHashMap;
 use thiserror::Error;
@@ -118,6 +119,7 @@ impl<'r> Scanner<'r> {
             &crate::wasm::ENGINE,
             ScanContext {
                 wasm_store: NonNull::dangling(),
+                runtime_objects: IndexMap::new(),
                 compiled_rules: rules,
                 string_pool: BStringPool::new(),
                 current_struct: None,
@@ -128,7 +130,6 @@ impl<'r> Scanner<'r> {
                 non_private_matching_rules: Vec::new(),
                 global_matching_rules: FxHashMap::default(),
                 main_memory: None,
-                vars_stack: Vec::new(),
                 module_outputs: FxHashMap::default(),
                 pattern_matches: FxHashMap::default(),
                 unconfirmed_matches: FxHashMap::default(),
@@ -438,6 +439,9 @@ impl<'r> Scanner<'r> {
         if ctx.string_pool.size() > 1_000_000 {
             ctx.string_pool = BStringPool::new();
         }
+
+        // TODO
+        ctx.runtime_objects.clear();
 
         for module_name in ctx.compiled_rules.imports() {
             // Lookup the module in the list of built-in modules.

--- a/yara-x/src/string_pool.rs
+++ b/yara-x/src/string_pool.rs
@@ -197,12 +197,6 @@ where
                     .expect("using BStringPool::get_str with a string that is not valid UTF-8")
             })
     }
-
-    /// Returns the total size in bytes of all the strings stored in the pool.
-    #[inline]
-    pub fn size(&self) -> usize {
-        self.size
-    }
 }
 
 impl<T> Serialize for BStringPool<T>

--- a/yara-x/src/symbols/mod.rs
+++ b/yara-x/src/symbols/mod.rs
@@ -25,14 +25,14 @@ pub(crate) struct Symbol {
 /// accesses the symbol.
 #[derive(Clone, Debug)]
 pub(crate) enum SymbolKind {
-    /// The symbol refers to a variable stored in WASM memory.
-    WasmVar(Var),
-    /// The symbol refers to a variable stored in the host.
-    HostVar(Var),
-    /// The symbol refers to some field in a structure.
-    StructField(usize),
-    /// The symbol refers to some field in the root structure.
-    RootStructField(usize),
+    /// The symbol refers to a WASM-side variable.
+    Var(Var),
+    /// The symbol refers to a field in a structure. Fields in the tuple
+    /// are a `usize` containing the index the field occupies in the
+    /// structure and `bool` that is `true` if the symbol refers to a
+    /// field in the root structure. If it is `false` it refers to the
+    /// structure whose reference is at the top of the WASM stack.
+    Field(usize, bool),
     /// The symbol refers to a rule.
     Rule(RuleId),
     /// The symbol refers to a function.

--- a/yara-x/src/symbols/mod.rs
+++ b/yara-x/src/symbols/mod.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use bstr::{BStr, ByteSlice};
 
 use crate::compiler::{RuleId, Var};
-use crate::types::{Func, Struct, TypeValue};
+use crate::types::{Func, TypeValue};
 
 /// Trait implemented by types that allow looking up for a symbol.
 pub(crate) trait SymbolLookup {
@@ -30,7 +30,9 @@ pub(crate) enum SymbolKind {
     /// The symbol refers to a variable stored in the host.
     HostVar(Var),
     /// The symbol refers to some field in a structure.
-    FieldIndex(usize),
+    StructField(usize),
+    /// The symbol refers to some field in the root structure.
+    RootStructField(usize),
     /// The symbol refers to a rule.
     Rule(RuleId),
     /// The symbol refers to a function.
@@ -100,15 +102,6 @@ impl SymbolLookup for Option<Symbol> {
         } else {
             None
         }
-    }
-}
-
-impl SymbolLookup for Struct {
-    fn lookup(&self, ident: &str) -> Option<Symbol> {
-        Some(Symbol::new(
-            self.field_by_name(ident)?.type_value.clone(),
-            SymbolKind::FieldIndex(self.index_of(ident)),
-        ))
     }
 }
 

--- a/yara-x/src/symbols/mod.rs
+++ b/yara-x/src/symbols/mod.rs
@@ -13,7 +13,7 @@ pub(crate) trait SymbolLookup {
     fn lookup(&self, ident: &str) -> Option<Symbol>;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Symbol {
     type_value: TypeValue,
     kind: SymbolKind,
@@ -23,7 +23,7 @@ pub(crate) struct Symbol {
 ///
 /// Used by the compiler to determine how to generate code that
 /// accesses the symbol.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum SymbolKind {
     /// The symbol refers to a variable stored in WASM memory.
     WasmVar(Var),

--- a/yara-x/src/types/array.rs
+++ b/yara-x/src/types/array.rs
@@ -10,7 +10,7 @@ pub enum Array {
     Integers(Vec<i64>),
     Floats(Vec<f64>),
     Bools(Vec<bool>),
-    Strings(Vec<BString>),
+    Strings(Vec<Rc<BString>>),
     Structs(Vec<Rc<Struct>>),
 }
 
@@ -59,7 +59,7 @@ impl Array {
         }
     }
 
-    pub fn as_string_array(&self) -> &Vec<BString> {
+    pub fn as_string_array(&self) -> &Vec<Rc<BString>> {
         if let Self::Strings(v) = self {
             v
         } else {

--- a/yara-x/src/types/func.rs
+++ b/yara-x/src/types/func.rs
@@ -112,7 +112,7 @@ where
 ///
 /// YARA modules allow function overloading, therefore functions can have the
 /// same name but different arguments.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct FuncSignature {
     pub mangled_name: MangledFnName,
     pub args: Vec<TypeValue>,
@@ -149,7 +149,7 @@ impl From<String> for FuncSignature {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Func {
     signatures: Vec<FuncSignature>,
 }

--- a/yara-x/src/types/mod.rs
+++ b/yara-x/src/types/mod.rs
@@ -161,7 +161,7 @@ pub enum TypeValue {
     Integer(Value<i64>),
     Float(Value<f64>),
     Bool(Value<bool>),
-    String(Value<BString>),
+    String(Value<Rc<BString>>),
     Regexp(Option<Regexp>),
     Struct(Rc<Struct>),
     Array(Rc<Array>),
@@ -391,6 +391,30 @@ impl TypeValue {
         } else {
             None
         }
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a variable integer.
+    #[inline]
+    pub fn variable_integer_from<T: Into<i64>>(i: T) -> Self {
+        Self::Integer(Value::Var(i.into()))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a variable string.
+    #[inline]
+    pub fn variable_float_from<T: Into<f64>>(f: T) -> Self {
+        Self::Float(Value::Var(f.into()))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a variable boolean.
+    #[inline]
+    pub fn variable_bool_from<T: Into<bool>>(i: T) -> Self {
+        Self::Bool(Value::Var(i.into()))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a variable string.
+    #[inline]
+    pub fn variable_string_from<T: AsRef<[u8]>>(s: T) -> Self {
+        Self::String(Value::Var(BString::from(s.as_ref()).into()))
     }
 }
 

--- a/yara-x/src/types/mod.rs
+++ b/yara-x/src/types/mod.rs
@@ -1,8 +1,7 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::rc::Rc;
 
-use bstr::ByteSlice;
-use bstr::{BStr, BString};
+use bstr::BString;
 use serde::{Deserialize, Serialize};
 use walrus::ValType;
 
@@ -278,14 +277,15 @@ impl TypeValue {
         }
     }
 
-    pub fn as_bstr(&self) -> &BStr {
-        if let TypeValue::String(v) = self {
-            v.extract()
+    pub fn as_string(&self) -> Rc<BString> {
+        if let TypeValue::String(value) = self {
+            value
+                .extract()
+                .cloned()
                 .expect("TypeValue doesn't have an associated value")
-                .as_bstr()
         } else {
             panic!(
-                "called `as_bstr` on a TypeValue that is not TypeValue::String, it is: {:?}",
+                "called `as_string` on a TypeValue that is not TypeValue::String, it is: {:?}",
                 self
             )
         }

--- a/yara-x/src/types/mod.rs
+++ b/yara-x/src/types/mod.rs
@@ -395,26 +395,50 @@ impl TypeValue {
 
     /// Creates a new [`TypeValue`] consisting on a variable integer.
     #[inline]
-    pub fn variable_integer_from<T: Into<i64>>(i: T) -> Self {
+    pub fn var_integer_from<T: Into<i64>>(i: T) -> Self {
         Self::Integer(Value::Var(i.into()))
     }
 
-    /// Creates a new [`TypeValue`] consisting on a variable string.
+    /// Creates a new [`TypeValue`] consisting on a variable float.
     #[inline]
-    pub fn variable_float_from<T: Into<f64>>(f: T) -> Self {
+    pub fn var_float_from<T: Into<f64>>(f: T) -> Self {
         Self::Float(Value::Var(f.into()))
     }
 
     /// Creates a new [`TypeValue`] consisting on a variable boolean.
     #[inline]
-    pub fn variable_bool_from<T: Into<bool>>(i: T) -> Self {
-        Self::Bool(Value::Var(i.into()))
+    pub fn var_bool_from(i: bool) -> Self {
+        Self::Bool(Value::Var(i))
     }
 
     /// Creates a new [`TypeValue`] consisting on a variable string.
     #[inline]
-    pub fn variable_string_from<T: AsRef<[u8]>>(s: T) -> Self {
+    pub fn var_string_from<T: AsRef<[u8]>>(s: T) -> Self {
         Self::String(Value::Var(BString::from(s.as_ref()).into()))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a constant integer.
+    #[inline]
+    pub fn const_integer_from<T: Into<i64>>(i: T) -> Self {
+        Self::Integer(Value::Const(i.into()))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a constant float.
+    #[inline]
+    pub fn const_float_from<T: Into<f64>>(f: T) -> Self {
+        Self::Float(Value::Const(f.into()))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a constant boolean.
+    #[inline]
+    pub fn const_bool_from(i: bool) -> Self {
+        Self::Bool(Value::Const(i))
+    }
+
+    /// Creates a new [`TypeValue`] consisting on a constant string.
+    #[inline]
+    pub fn const_string_from<T: AsRef<[u8]>>(s: T) -> Self {
+        Self::String(Value::Const(BString::from(s.as_ref()).into()))
     }
 }
 

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -991,14 +991,8 @@ mod tests {
         root.add_field("foo", TypeValue::Struct(Rc::new(foo)));
         root.add_field("bar", TypeValue::Integer(Value::Var(1)));
 
-        let foo_index = root.index_of("foo");
-        let bar_index = root.index_of("bar");
-
-        assert_eq!(foo_index, 0);
-        assert_eq!(bar_index, 1);
-
         let field1 = root.field_by_name("foo").unwrap();
-        let field2 = root.field_by_index(foo_index).unwrap();
+        let field2 = root.field_by_index(0).unwrap();
 
         assert_eq!(field1.type_value.ty(), Type::Struct);
         assert_eq!(field1.type_value.ty(), field2.type_value.ty());

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -737,7 +737,7 @@ impl Struct {
                         repeated
                             .into_iter()
                             .map(|value| {
-                                BString::from(value.to_str().unwrap())
+                                Rc::new(BString::from(value.to_str().unwrap()))
                             })
                             .collect(),
                     )
@@ -751,7 +751,9 @@ impl Struct {
                         repeated
                             .into_iter()
                             .map(|value| {
-                                BString::from(value.to_bytes().unwrap())
+                                Rc::new(BString::from(
+                                    value.to_bytes().unwrap(),
+                                ))
                             })
                             .collect(),
                     )

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -611,7 +611,7 @@ impl Struct {
             }
             RuntimeType::Bool => {
                 if let Some(v) = value {
-                    TypeValue::Bool(Value::Var(Self::value_as_bool(v)))
+                    TypeValue::variable_integer_from(Self::value_as_bool(v))
                 } else if syntax == Syntax::Proto3 {
                     // In proto3 unknown values are set to their default
                     // values.
@@ -622,11 +622,11 @@ impl Struct {
             }
             RuntimeType::String | RuntimeType::VecU8 => {
                 if let Some(v) = value {
-                    TypeValue::String(Value::Var(Self::value_as_bstring(v)))
+                    TypeValue::variable_string_from(Self::value_as_string(v))
                 } else if syntax == Syntax::Proto3 {
                     // In proto3 unknown values are set to their default
                     // values.
-                    TypeValue::String(Value::Var(BString::default()))
+                    TypeValue::variable_string_from(b"")
                 } else {
                     TypeValue::String(Value::Unknown)
                 }
@@ -874,7 +874,7 @@ impl Struct {
             let mut result = IndexMap::default();
             for (key, value) in map.into_iter() {
                 result.insert(
-                    Self::value_as_bstring(key),
+                    BString::from(Self::value_as_string(key)),
                     Self::new_value(
                         value_ty,
                         Some(value),
@@ -939,10 +939,10 @@ impl Struct {
         }
     }
 
-    fn value_as_bstring(value: ReflectValueRef) -> BString {
+    fn value_as_string(value: ReflectValueRef) -> &[u8] {
         match value {
-            ReflectValueRef::String(v) => BString::from(v),
-            ReflectValueRef::Bytes(v) => BString::from(v),
+            ReflectValueRef::String(v) => v.as_bytes(),
+            ReflectValueRef::Bytes(v) => v,
             _ => panic!(),
         }
     }

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -336,9 +336,9 @@ impl Struct {
                         fields.push((
                             item.name().to_owned(),
                             StructField {
-                                type_value: TypeValue::Integer(Value::Const(
+                                type_value: TypeValue::const_integer_from(
                                     Self::enum_value(&item),
-                                )),
+                                ),
                                 number: 0,
                             },
                         ));
@@ -352,9 +352,9 @@ impl Struct {
                         if enum_struct
                             .add_field(
                                 item.name(),
-                                TypeValue::Integer(Value::Const(
+                                TypeValue::const_integer_from(
                                     Self::enum_value(&item),
-                                )),
+                                ),
                             )
                             .is_some()
                         {
@@ -589,44 +589,44 @@ impl Struct {
             | RuntimeType::U64
             | RuntimeType::Enum(_) => {
                 if let Some(v) = value {
-                    TypeValue::Integer(Value::Var(Self::value_as_i64(v)))
+                    TypeValue::var_integer_from(Self::value_as_i64(v))
                 } else if syntax == Syntax::Proto3 {
                     // In proto3 unknown values are set to their default
                     // values.
-                    TypeValue::Integer(Value::Var(0))
+                    TypeValue::var_integer_from(0)
                 } else {
                     TypeValue::Integer(Value::Unknown)
                 }
             }
             RuntimeType::F32 | RuntimeType::F64 => {
                 if let Some(v) = value {
-                    TypeValue::Float(Value::Var(Self::value_as_f64(v)))
+                    TypeValue::var_float_from(Self::value_as_f64(v))
                 } else if syntax == Syntax::Proto3 {
                     // In proto3 unknown values are set to their default
                     // values.
-                    TypeValue::Float(Value::Var(0_f64))
+                    TypeValue::var_float_from(0_f64)
                 } else {
                     TypeValue::Float(Value::Unknown)
                 }
             }
             RuntimeType::Bool => {
                 if let Some(v) = value {
-                    TypeValue::variable_integer_from(Self::value_as_bool(v))
+                    TypeValue::var_bool_from(Self::value_as_bool(v))
                 } else if syntax == Syntax::Proto3 {
                     // In proto3 unknown values are set to their default
                     // values.
-                    TypeValue::Bool(Value::Var(false))
+                    TypeValue::var_bool_from(false)
                 } else {
                     TypeValue::Bool(Value::Unknown)
                 }
             }
             RuntimeType::String | RuntimeType::VecU8 => {
                 if let Some(v) = value {
-                    TypeValue::variable_string_from(Self::value_as_string(v))
+                    TypeValue::var_string_from(Self::value_as_string(v))
                 } else if syntax == Syntax::Proto3 {
                     // In proto3 unknown values are set to their default
                     // values.
-                    TypeValue::variable_string_from(b"")
+                    TypeValue::var_string_from(b"")
                 } else {
                     TypeValue::String(Value::Unknown)
                 }

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -65,11 +65,7 @@ impl SymbolLookup for Struct {
         let (field, index) = self.field_and_index_by_name(ident)?;
         Some(Symbol::new(
             field.type_value.clone(),
-            if self.is_root {
-                SymbolKind::RootStructField(index)
-            } else {
-                SymbolKind::StructField(index)
-            },
+            SymbolKind::Field(index, self.is_root),
         ))
     }
 }

--- a/yara-x/src/variables.rs
+++ b/yara-x/src/variables.rs
@@ -70,91 +70,91 @@ pub enum VariableError {
 impl TryFrom<bool> for Variable {
     type Error = VariableError;
     fn try_from(value: bool) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Bool(Value::Var(value))))
+        Ok(Variable(TypeValue::variable_bool_from(value)))
     }
 }
 
 impl TryFrom<i64> for Variable {
     type Error = VariableError;
     fn try_from(value: i64) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<i32> for Variable {
     type Error = VariableError;
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<i16> for Variable {
     type Error = VariableError;
     fn try_from(value: i16) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<i8> for Variable {
     type Error = VariableError;
     fn try_from(value: i8) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<u32> for Variable {
     type Error = VariableError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<u16> for Variable {
     type Error = VariableError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<u8> for Variable {
     type Error = VariableError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Integer(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_integer_from(value)))
     }
 }
 
 impl TryFrom<f64> for Variable {
     type Error = VariableError;
     fn try_from(value: f64) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Float(Value::Var(value))))
+        Ok(Variable(TypeValue::variable_float_from(value)))
     }
 }
 
 impl TryFrom<f32> for Variable {
     type Error = VariableError;
     fn try_from(value: f32) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::Float(Value::Var(value.into()))))
+        Ok(Variable(TypeValue::variable_float_from(value)))
     }
 }
 
 impl TryFrom<&str> for Variable {
     type Error = VariableError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::String(Value::Var(BString::from(value)))))
+        Ok(Variable(TypeValue::variable_string_from(value)))
     }
 }
 
 impl TryFrom<&[u8]> for Variable {
     type Error = VariableError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::String(Value::Var(BString::from(value)))))
+        Ok(Variable(TypeValue::variable_string_from(value)))
     }
 }
 
 impl TryFrom<String> for Variable {
     type Error = VariableError;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::String(Value::Var(BString::from(value)))))
+        Ok(Variable(TypeValue::variable_string_from(value)))
     }
 }
 
@@ -187,9 +187,9 @@ impl TryFrom<&serde_json::Value> for Variable {
                     unreachable!()
                 }
             }
-            serde_json::Value::String(s) => Ok(Variable(TypeValue::String(
-                Value::Var(BString::from(s.as_str())),
-            ))),
+            serde_json::Value::String(s) => {
+                Ok(Variable(TypeValue::variable_string_from(s)))
+            }
             serde_json::Value::Array(values) => {
                 let mut array = None;
                 // Try to determine the type of the array by looking at the

--- a/yara-x/src/variables.rs
+++ b/yara-x/src/variables.rs
@@ -70,91 +70,91 @@ pub enum VariableError {
 impl TryFrom<bool> for Variable {
     type Error = VariableError;
     fn try_from(value: bool) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_bool_from(value)))
+        Ok(Variable(TypeValue::var_bool_from(value)))
     }
 }
 
 impl TryFrom<i64> for Variable {
     type Error = VariableError;
     fn try_from(value: i64) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<i32> for Variable {
     type Error = VariableError;
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<i16> for Variable {
     type Error = VariableError;
     fn try_from(value: i16) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<i8> for Variable {
     type Error = VariableError;
     fn try_from(value: i8) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<u32> for Variable {
     type Error = VariableError;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<u16> for Variable {
     type Error = VariableError;
     fn try_from(value: u16) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<u8> for Variable {
     type Error = VariableError;
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_integer_from(value)))
+        Ok(Variable(TypeValue::var_integer_from(value)))
     }
 }
 
 impl TryFrom<f64> for Variable {
     type Error = VariableError;
     fn try_from(value: f64) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_float_from(value)))
+        Ok(Variable(TypeValue::var_float_from(value)))
     }
 }
 
 impl TryFrom<f32> for Variable {
     type Error = VariableError;
     fn try_from(value: f32) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_float_from(value)))
+        Ok(Variable(TypeValue::var_float_from(value)))
     }
 }
 
 impl TryFrom<&str> for Variable {
     type Error = VariableError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_string_from(value)))
+        Ok(Variable(TypeValue::var_string_from(value)))
     }
 }
 
 impl TryFrom<&[u8]> for Variable {
     type Error = VariableError;
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_string_from(value)))
+        Ok(Variable(TypeValue::var_string_from(value)))
     }
 }
 
 impl TryFrom<String> for Variable {
     type Error = VariableError;
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        Ok(Variable(TypeValue::variable_string_from(value)))
+        Ok(Variable(TypeValue::var_string_from(value)))
     }
 }
 
@@ -180,15 +180,15 @@ impl TryFrom<&serde_json::Value> for Variable {
                             .map_err(|_| VariableError::IntegerOutOfRange)?,
                     ))))
                 } else if let Some(n) = n.as_i64() {
-                    Ok(Variable(TypeValue::Integer(Value::Var(n))))
+                    Ok(Variable(TypeValue::var_integer_from(n)))
                 } else if let Some(n) = n.as_f64() {
-                    Ok(Variable(TypeValue::Float(Value::Var(n))))
+                    Ok(Variable(TypeValue::var_float_from(n)))
                 } else {
                     unreachable!()
                 }
             }
             serde_json::Value::String(s) => {
-                Ok(Variable(TypeValue::variable_string_from(s)))
+                Ok(Variable(TypeValue::var_string_from(s)))
             }
             serde_json::Value::Array(values) => {
                 let mut array = None;

--- a/yara-x/src/variables.rs
+++ b/yara-x/src/variables.rs
@@ -265,7 +265,7 @@ impl TryFrom<&serde_json::Value> for Variable {
                         for v in values {
                             match v.as_str() {
                                 Some(v) => {
-                                    strings.push(BString::from(v));
+                                    strings.push(BString::from(v).into());
                                 }
                                 None => {
                                     return Err(VariableError::InvalidArray);

--- a/yara-x/src/wasm/mod.rs
+++ b/yara-x/src/wasm/mod.rs
@@ -376,7 +376,7 @@ impl WasmResult for bool {
 
 impl WasmResult for RuntimeString {
     fn values(self, ctx: &mut ScanContext) -> WasmResultArray<ValRaw> {
-        smallvec![ValRaw::i64(self.as_wasm_with_ctx(ctx))]
+        smallvec![ValRaw::i64(self.into_wasm_with_ctx(ctx))]
     }
 
     fn types() -> WasmResultArray<wasmtime::ValType> {
@@ -397,7 +397,7 @@ impl WasmResult for RuntimeObjectHandle {
 impl WasmResult for Rc<BString> {
     fn values(self, ctx: &mut ScanContext) -> WasmResultArray<ValRaw> {
         let s = RuntimeString::Rc(self);
-        smallvec![ValRaw::i64(s.as_wasm_with_ctx(ctx))]
+        smallvec![ValRaw::i64(s.into_wasm_with_ctx(ctx))]
     }
 
     fn types() -> WasmResultArray<wasmtime::ValType> {
@@ -1165,7 +1165,6 @@ macro_rules! gen_map_lookup_by_index_fn {
             map: Rc<Map>,
             index: i64,
         ) -> (Rc<BString>, $val) {
-            // TODO: optimize
             map.with_string_keys()
                 .get_index(index as usize)
                 .map(|(key, value)| (Rc::new(key.clone()), value.$as()))

--- a/yara-x/src/wasm/mod.rs
+++ b/yara-x/src/wasm/mod.rs
@@ -85,7 +85,7 @@ use crate::compiler::{LiteralId, PatternId, RegexpId, RuleId};
 use crate::modules::BUILTIN_MODULES;
 use crate::scanner::{RuntimeObjectHandle, ScanContext};
 use crate::types::{Array, Map, Struct, TypeValue, Value};
-use crate::wasm::string::{RuntimeString, RuntimeStringWasm};
+use crate::wasm::string::RuntimeString;
 use crate::ScanError;
 
 pub(crate) mod builder;
@@ -262,7 +262,7 @@ impl WasmArg<RegexpId> for ValRaw {
 impl WasmArg<RuntimeString> for ValRaw {
     #[inline]
     fn raw_into(self, ctx: &mut ScanContext) -> RuntimeString {
-        RuntimeString::from_wasm(ctx, RuntimeStringWasm::from(self.get_i64()))
+        RuntimeString::from_wasm(ctx, self.get_i64())
     }
 }
 

--- a/yara-x/src/wasm/mod.rs
+++ b/yara-x/src/wasm/mod.rs
@@ -301,13 +301,6 @@ impl WasmArg<Option<Rc<Struct>>> for ValRaw {
     }
 }
 
-impl WasmArg<RuntimeObjectHandle> for ValRaw {
-    #[inline]
-    fn raw_into(self, _: &mut ScanContext) -> RuntimeObjectHandle {
-        RuntimeObjectHandle::from(self.get_i64())
-    }
-}
-
 /// A trait for converting a function result into an array of [`ValRaw`] values
 /// suitable to be passed to WASM code.
 ///
@@ -504,9 +497,13 @@ fn type_id_to_wasmtime(
         return &[];
     } else if type_id == TypeId::of::<RuntimeString>() {
         return &[wasmtime::ValType::I64];
-    } else if type_id == TypeId::of::<RuntimeObjectHandle>() {
+    } else if type_id == TypeId::of::<Option<Rc<Struct>>>() {
+        return &[wasmtime::ValType::I64];
+    } else if type_id == TypeId::of::<Rc<Struct>>() {
         return &[wasmtime::ValType::I64];
     } else if type_id == TypeId::of::<Rc<Array>>() {
+        return &[wasmtime::ValType::I64];
+    } else if type_id == TypeId::of::<Rc<Map>>() {
         return &[wasmtime::ValType::I64];
     }
     panic!("type `{}` can't be an argument", type_name)

--- a/yara-x/src/wasm/mod.rs
+++ b/yara-x/src/wasm/mod.rs
@@ -79,13 +79,12 @@ use wasmtime::{
     AsContextMut, Caller, Config, Engine, FuncType, Linker, ValRaw,
 };
 
-use crate::utils::cast;
 use yara_x_macros::wasm_export;
 
 use crate::compiler::{LiteralId, PatternId, RegexpId, RuleId};
 use crate::modules::BUILTIN_MODULES;
-use crate::scanner::{RuntimeObject, RuntimeObjectRef, ScanContext};
-use crate::types::{Array, Struct, TypeValue, Value};
+use crate::scanner::{RuntimeObjectRef, ScanContext};
+use crate::types::{Array, TypeValue, Value};
 use crate::wasm::string::{RuntimeString, RuntimeStringWasm};
 use crate::ScanError;
 
@@ -903,10 +902,10 @@ pub(crate) fn lookup_string(
 ) -> Option<RuntimeString> {
     match lookup_field(caller, structure, num_lookup_indexes) {
         TypeValue::String(Value::Var(value)) => Some(RuntimeString::Owned(
-            caller.data_mut().string_pool.get_or_intern(value),
+            caller.data_mut().string_pool.get_or_intern(value.as_slice()),
         )),
         TypeValue::String(Value::Const(value)) => Some(RuntimeString::Owned(
-            caller.data_mut().string_pool.get_or_intern(value),
+            caller.data_mut().string_pool.get_or_intern(value.as_slice()),
         )),
         TypeValue::String(Value::Unknown) => None,
         _ => unreachable!(),

--- a/yara-x/src/wasm/string.rs
+++ b/yara-x/src/wasm/string.rs
@@ -23,11 +23,11 @@ use crate::utils::cast;
 ///    If the two lower bits are equal to 1, it's a literal string, where the
 ///    remaining bits represent the `LiteralId`.
 ///
-/// * `RuntimeString:Owned`  -> `RuntimeStringId << 2 | 2`
+/// * `RuntimeString:Rc`  -> `RuntimeStringId << 2 | 2`
 ///    If the two lower bits are equal to 2, it's a runtime string, where the
-///    remaining bits represent the `RuntimeStringId`.
+///    remaining bits represent the handle of a string object.
 ///
-/// * `RuntimeString:Owned`  -> `Offset << 18 | Len << 2 | 3)`
+/// * `RuntimeString:ScannedDataSlice` -> `Offset << 18 | Len << 2 | 3)`
 ///    If the two lower bits are 3, it's a string backed by the scanned data.
 ///    Bits 18:3 ar used for representing the string length (up to 64KB),
 ///    while bits 64:19 represents the offset (up to 70,368,744,177,663).


### PR DESCRIPTION
This refactor started as an attempt to fix a bug in the logic for structure field lookups, but fixing this issue required more fundamental changes. Some of the changes are:

* TypeValue::String now has a reference-counted string
* WasmArg has been refactored for making Rust-to-WASM type conversions simpler
* ScanContext now contains a map of used objects (structs, arrays, maps or strings) for tracking values that are passed from Rust to WASM and back to Rust.
* The field lookup mechanism for finding fields a structure has been refactored.