### PR TITLE
feat: implement method calls

### DIFF
--- a/yara-x-macros/src/lib.rs
+++ b/yara-x-macros/src/lib.rs
@@ -156,16 +156,16 @@ pub fn error_macro_derive(input: TokenStream) -> TokenStream {
 /// The `module_main` macro is used for indicating which is the main function
 /// in a YARA module.
 ///
-/// The main function in a YARA module must receive a reference to `ScanContext`]
-/// and must return the protobuf structure that corresponds to the module. The
-/// function can have any name, as long as it is marked with `#[module_main]`, but
-/// it's a good practice to name it `main`.
+/// The main function in a YARA module receives a slice that contains the
+/// data being scanned, and must return the protobuf structure that corresponds
+/// to the module. The function can have any name, as long as it is marked with
+/// `#[module_main]`, but it's a good practice to name it `main`.
 ///
 /// # Example
 ///
 /// ```text
 /// #[module_main]
-/// fn main(ctx: &ScanContext) -> SomeProto {   
+/// fn main(data: &[u8]) -> SomeProto {   
 ///     let some_proto = SomeProto::new();
 ///     // ... fill some_proto with data ...
 ///     some_proto
@@ -195,6 +195,11 @@ pub fn module_main(_attr: TokenStream, input: TokenStream) -> TokenStream {
 /// - `f64`
 /// - `bool`
 /// - `RuntimeString`
+/// - `RuleId`
+/// - `PatternId`
+/// - `Rc<Struct>`
+/// - `Rc<Map>`
+/// - `Rc<Array>`
 ///
 /// # Example
 ///

--- a/yara-x/src/compiler/context.rs
+++ b/yara-x/src/compiler/context.rs
@@ -20,10 +20,10 @@ pub(in crate::compiler) struct CompileContext<'a, 'src, 'sym> {
     /// functions, etc.
     pub symbol_table: &'a mut StackedSymbolTable<'sym>,
 
-    /// Symbol table for the currently active structure. When this contains
-    /// some value, symbols are looked up in this table and the main symbol
-    /// table (i.e: `symbol_table`) is ignored.
-    pub current_struct: Option<Rc<dyn SymbolLookup + 'a>>,
+    /// Symbol table for the currently active type. When this contains some
+    /// value, symbols are looked up in this table, and the main symbol table
+    /// (i.e: `symbol_table`) is ignored.
+    pub current_symbol_table: Option<Rc<dyn SymbolLookup + 'a>>,
 
     /// Information about the rules compiled so far.
     pub rules: &'a Vec<RuleInfo>,

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -1128,8 +1128,15 @@ fn func_call_from_ast(
     // Determine if any of the signatures for the called function matches
     // the provided arguments.
     for (i, signature) in func.signatures().iter().enumerate() {
-        let expected_arg_types: Vec<Type> =
-            signature.args.iter().map(|arg| arg.ty()).collect();
+        // If the function is actually a method, the first argument is always
+        // the type the method belongs to (i.e: the self pointer). This
+        // argument appears in the function's signature, but is not expected
+        // to appear among the arguments in the call statement.
+        let expected_arg_types: Vec<Type> = if func.method_of().is_some() {
+            signature.args.iter().skip(1).map(|arg| arg.ty()).collect()
+        } else {
+            signature.args.iter().map(|arg| arg.ty()).collect()
+        };
 
         if arg_types == expected_arg_types {
             matching_signature = Some((i, signature.result.clone()));

--- a/yara-x/src/compiler/ir/mod.rs
+++ b/yara-x/src/compiler/ir/mod.rs
@@ -158,9 +158,8 @@ impl<'src> PatternInRule<'src> {
 /// This type represents a pattern independently of the rule in which it was
 /// declared. Multiple rules declaring exactly the same pattern will share the
 /// same instance of [`Pattern`]. For representing a pattern in the context of
-/// a specific rule we have the [`PatternInRule`], which contains a [`Pattern`]
-/// and additional information about how the pattern in declared or used in
-/// rule.
+/// a specific rule we have [`PatternInRule`], which contains a [`Pattern`] and
+/// additional information about how the pattern is used in a rule.
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub(in crate::compiler) enum Pattern {
     /// A literal pattern is one that doesn't contain wildcards, alternatives,
@@ -218,17 +217,17 @@ pub(in crate::compiler) enum Expr {
     Filesize,
     Entrypoint,
 
-    /// Boolean `not` expression
+    /// Boolean `not` expression.
     Not {
         operand: Box<Expr>,
     },
 
-    /// Boolean `and` expression
+    /// Boolean `and` expression.
     And {
         operands: Vec<Expr>,
     },
 
-    /// Boolean `or` expression
+    /// Boolean `or` expression.
     Or {
         operands: Vec<Expr>,
     },

--- a/yara-x/src/compiler/mod.rs
+++ b/yara-x/src/compiler/mod.rs
@@ -672,7 +672,7 @@ impl<'a> Compiler<'a> {
         // yes, search for functions exported by the module.
         if let Some(rust_module_name) = module.rust_module_name {
             // Find all WASM public functions that belong to the current module.
-            let mut functions = WasmExport::find_functions(|e| {
+            let mut functions = WasmExport::get_functions(|e| {
                 e.public && e.rust_module_path.contains(rust_module_name)
             });
 

--- a/yara-x/src/compiler/mod.rs
+++ b/yara-x/src/compiler/mod.rs
@@ -795,7 +795,7 @@ impl<'a> Compiler<'a> {
         // (IR).
         let condition = bool_expr_from_ast(
             &mut CompileContext {
-                current_struct: None,
+                current_symbol_table: None,
                 symbol_table: &mut self.symbol_table,
                 ident_pool: &mut self.ident_pool,
                 report_builder: &self.report_builder,
@@ -806,6 +806,8 @@ impl<'a> Compiler<'a> {
             },
             &rule.condition,
         );
+
+        dbg!(&condition);
 
         // In case of error, restore the compiler to the state it was before
         // entering this function.

--- a/yara-x/src/modules/protos/test_proto2.proto
+++ b/yara-x/src/modules/protos/test_proto2.proto
@@ -200,5 +200,6 @@ message NestedProto2 {
   optional int64              nested_int64_zero = 2;
   optional int32              nested_int32_one = 3;
   optional int64              nested_int64_one = 4;
-  repeated int64              nested_array_int64 = 5;
+  optional bool               nested_bool = 5;
+  repeated int64              nested_array_int64 = 6;
 }

--- a/yara-x/src/modules/test_proto2/mod.rs
+++ b/yara-x/src/modules/test_proto2/mod.rs
@@ -1,6 +1,8 @@
 use crate::modules::prelude::*;
 use crate::modules::protos::test_proto2::NestedProto2;
 use crate::modules::protos::test_proto2::TestProto2;
+use crate::types::Struct;
+use std::rc::Rc;
 
 #[cfg(test)]
 mod tests;
@@ -25,6 +27,17 @@ pub(crate) fn uppercase(
 
 #[module_export(name = "nested.nested_func")]
 pub(crate) fn nested_func(_ctx: &mut ScanContext) -> bool {
+    true
+}
+
+#[module_export(
+    name = "nested_method",
+    method_of = "test_proto2.NestedProto2"
+)]
+pub(crate) fn nested_method(
+    _ctx: &mut ScanContext,
+    _structure: Rc<Struct>,
+) -> bool {
     true
 }
 
@@ -88,6 +101,9 @@ fn main(data: &[u8]) -> TestProto2 {
     test.set_bytes_foo("foo".as_bytes().to_vec());
     test.set_bytes_bar("bar".as_bytes().to_vec());
 
+    test.set_bool_proto(true);
+    test.set_file_size(data.len() as u64);
+
     test.array_int64.push(1);
     test.array_int64.push(10);
     test.array_int64.push(100);
@@ -109,13 +125,13 @@ fn main(data: &[u8]) -> TestProto2 {
     nested.set_nested_int64_zero(0);
     nested.set_nested_int32_one(1);
     nested.set_nested_int64_one(1);
+    nested.set_nested_bool(false);
+
     nested.nested_array_int64.push(1);
     nested.nested_array_int64.push(10);
     nested.nested_array_int64.push(100);
 
     test.nested = Some(nested.clone()).into();
-
-    test.array_struct.push(nested.clone());
 
     test.map_string_struct.insert("foo".to_string(), nested.clone());
     test.map_string_int64.insert("one".to_string(), 1);
@@ -129,9 +145,12 @@ fn main(data: &[u8]) -> TestProto2 {
     test.map_int64_string.insert(100, "one thousand".to_string());
     test.map_int64_bool.insert(100, true);
 
-    test.set_bool_proto(true);
+    test.array_struct.push(nested.clone());
 
-    test.set_file_size(data.len() as u64);
+    let mut nested = nested.clone();
+    nested.set_nested_bool(true);
+
+    test.array_struct.push(nested);
 
     test
 }

--- a/yara-x/src/modules/test_proto2/mod.rs
+++ b/yara-x/src/modules/test_proto2/mod.rs
@@ -36,9 +36,9 @@ pub(crate) fn nested_func(_ctx: &mut ScanContext) -> bool {
 )]
 pub(crate) fn nested_method(
     _ctx: &mut ScanContext,
-    _structure: Rc<Struct>,
+    structure: Rc<Struct>,
 ) -> bool {
-    true
+    structure.field_by_name("nested_bool").unwrap().type_value.as_bool()
 }
 
 #[module_export]

--- a/yara-x/src/modules/test_proto2/tests/mod.rs
+++ b/yara-x/src/modules/test_proto2/tests/mod.rs
@@ -257,19 +257,19 @@ fn test_proto2_module() {
 
     condition_true!(
         r#"
-        test_proto2.nested.nested_method()
+        not test_proto2.nested.nested_method()
         "#
     );
 
     condition_true!(
         r#"
-        test_proto2.array_struct[0].nested_method()
+        not test_proto2.array_struct[0].nested_method()
         "#
     );
 
     condition_true!(
         r#"
-        not test_proto2.array_struct[1].nested_method()
+        test_proto2.array_struct[1].nested_method()
         "#
     );
 }

--- a/yara-x/src/modules/test_proto2/tests/mod.rs
+++ b/yara-x/src/modules/test_proto2/tests/mod.rs
@@ -166,7 +166,7 @@ fn test_proto2_module() {
     );
 
     condition_false!(
-        r#"for 2 s in test_proto2.array_struct : (
+        r#"for 3 s in test_proto2.array_struct : (
             s.nested_int32_zero == 0
           )"#
     );
@@ -252,6 +252,24 @@ fn test_proto2_module() {
         r#"
         test_proto2.add(test_proto2.int64_one, test_proto2.int64_one) == 2 and
         test_proto2.add(test_proto2.int64_one, test_proto2.int64_zero) == 1
+        "#
+    );
+
+    condition_true!(
+        r#"
+        test_proto2.nested.nested_method()
+        "#
+    );
+
+    condition_true!(
+        r#"
+        test_proto2.array_struct[0].nested_method()
+        "#
+    );
+
+    condition_true!(
+        r#"
+        not test_proto2.array_struct[1].nested_method()
         "#
     );
 }

--- a/yara-x/src/scanner/context.rs
+++ b/yara-x/src/scanner/context.rs
@@ -1242,7 +1242,7 @@ struct VM<'r> {
 /// as the key that identifies each object. Handlers are actually 64-bits
 /// integers that can cross the WASM-Rust boundary, and used to retrieve the
 /// original object from [`ScanContext`].
-pub enum RuntimeObject {
+pub(crate) enum RuntimeObject {
     Struct(Rc<Struct>),
     Array(Rc<Array>),
     Map(Rc<Map>),

--- a/yara-x/src/symbols/mod.rs
+++ b/yara-x/src/symbols/mod.rs
@@ -124,7 +124,7 @@ pub(crate) struct SymbolTable {
 
 impl SymbolTable {
     /// Creates a new symbol table.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self { map: HashMap::new() }
     }
 
@@ -133,11 +133,7 @@ impl SymbolTable {
     /// If the symbol was already in the table it gets updated and the old
     /// value is returned. If the symbol was not in the table [`None`] is
     /// returned.
-    pub(crate) fn insert<I>(
-        &mut self,
-        ident: I,
-        symbol: Symbol,
-    ) -> Option<Symbol>
+    pub fn insert<I>(&mut self, ident: I, symbol: Symbol) -> Option<Symbol>
     where
         I: Into<String>,
     {
@@ -147,7 +143,7 @@ impl SymbolTable {
     /// Returns true if the symbol table already contains a symbol with
     /// the given identifier.
     #[inline]
-    pub(crate) fn contains<I>(&self, ident: I) -> bool
+    pub fn contains<I>(&self, ident: I) -> bool
     where
         I: AsRef<str>,
     {

--- a/yara-x/src/types/array.rs
+++ b/yara-x/src/types/array.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::{Struct, TypeValue, Value};
 
 #[derive(Serialize, Deserialize)]
-pub enum Array {
+pub(crate) enum Array {
     Integers(Vec<i64>),
     Floats(Vec<f64>),
     Bools(Vec<bool>),

--- a/yara-x/src/types/func.rs
+++ b/yara-x/src/types/func.rs
@@ -150,15 +150,36 @@ impl<T: Into<String>> From<T> for FuncSignature {
     }
 }
 
+/// A type representing a function.
+///
+/// Represents both functions and methods. As in any programming language
+/// methods are functions associated to a type that receive an instance
+/// of that type as their first argument.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub(crate) struct Func {
+    /// The list of signatures for this function. Functions can be overloaded,
+    /// so they may more than one signature.
     signatures: Vec<FuncSignature>,
+    /// If this function is a method, contains the name of the type the method
+    /// is associated to. For standard functions this is [`None`].
+    method_of: Option<String>,
 }
 
 impl Func {
     /// Creates a new [`Func`] from a mangled function name.
     pub fn from_mangled_name(name: &str) -> Self {
-        Self { signatures: vec![FuncSignature::from(name)] }
+        Self { signatures: vec![FuncSignature::from(name)], method_of: None }
+    }
+
+    /// Makes this function a method of the specified type.
+    pub fn make_method_of(&mut self, type_name: &str) {
+        self.method_of = Some(type_name.to_string())
+    }
+
+    /// If this function is a method of some type, returns the name of the
+    /// type. Returns [`None`] if the function is not a method.
+    pub fn method_of(&self) -> Option<&str> {
+        self.method_of.as_deref()
     }
 
     /// Add a signature to the function.

--- a/yara-x/src/types/func.rs
+++ b/yara-x/src/types/func.rs
@@ -93,7 +93,8 @@ impl MangledFnName {
         (args, result)
     }
 
-    // Returns true if the function's result may be undefined.
+    /// Returns true if the function's result may be undefined.
+    #[inline]
     pub fn result_may_be_undef(&self) -> bool {
         self.0.ends_with('u')
     }
@@ -140,9 +141,9 @@ impl PartialEq for FuncSignature {
     }
 }
 
-impl From<String> for FuncSignature {
-    fn from(value: String) -> Self {
-        let mangled_name = MangledFnName::from(value);
+impl<T: Into<String>> From<T> for FuncSignature {
+    fn from(value: T) -> Self {
+        let mangled_name = MangledFnName::from(value.into());
         let result_may_be_undef = mangled_name.result_may_be_undef();
         let (args, result) = mangled_name.unmangle();
         Self { mangled_name, args, result, result_may_be_undef }
@@ -155,10 +156,16 @@ pub(crate) struct Func {
 }
 
 impl Func {
-    pub fn with_signature(signature: FuncSignature) -> Self {
-        Self { signatures: vec![signature] }
+    /// Creates a new [`Func`] from a mangled function name.
+    pub fn from_mangled_name(name: &str) -> Self {
+        Self { signatures: vec![FuncSignature::from(name)] }
     }
 
+    /// Add a signature to the function.
+    ///
+    /// # Panics
+    ///
+    /// If the function already has the given signature.
     pub fn add_signature(&mut self, signature: FuncSignature) {
         // Signatures are inserted into self.signatures sorted by
         // mangled named.
@@ -173,6 +180,8 @@ impl Func {
         }
     }
 
+    /// Returns all the signatures for this function.
+    #[inline]
     pub fn signatures(&self) -> &[FuncSignature] {
         self.signatures.as_slice()
     }

--- a/yara-x/src/types/func.rs
+++ b/yara-x/src/types/func.rs
@@ -47,7 +47,7 @@ use crate::types::{TypeValue, Value};
 /// foo() -> Option<(f64,f64)>     ->  foo@@ffu
 /// ```
 #[derive(Serialize, Deserialize)]
-pub struct MangledFnName(String);
+pub(crate) struct MangledFnName(String);
 
 impl MangledFnName {
     #[inline]
@@ -113,7 +113,7 @@ where
 /// YARA modules allow function overloading, therefore functions can have the
 /// same name but different arguments.
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct FuncSignature {
+pub(crate) struct FuncSignature {
     pub mangled_name: MangledFnName,
     pub args: Vec<TypeValue>,
     pub result: TypeValue,
@@ -150,7 +150,7 @@ impl From<String> for FuncSignature {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct Func {
+pub(crate) struct Func {
     signatures: Vec<FuncSignature>,
 }
 

--- a/yara-x/src/types/map.rs
+++ b/yara-x/src/types/map.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::TypeValue;
 
 #[derive(Serialize, Deserialize)]
-pub enum Map {
+pub(crate) enum Map {
     /// A map that has integer keys.
     IntegerKeys {
         // The deputy value is one that acts as a representative of the values

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -376,16 +376,12 @@ impl Struct {
             }
         }
 
-        // Find the methods implemented for this struct type and add function
-        // fields for method.
-        let struct_type_name = msg_descriptor.full_name();
-        let struct_methods = WasmExport::find_functions(|export| {
-            export
-                .method_of
-                .is_some_and(|type_name| type_name == struct_type_name)
-        });
+        // Get the methods implemented for this struct type.
+        let methods = WasmExport::get_methods(msg_descriptor.full_name());
 
-        for (name, method) in struct_methods {
+        // For each method implemented by this struct field, add a field
+        // to the struct of function type.
+        for (name, method) in methods {
             fields.push((
                 name.to_owned(),
                 StructField {

--- a/yara-x/src/types/structure.rs
+++ b/yara-x/src/types/structure.rs
@@ -22,7 +22,7 @@ use crate::types::{Array, Map, TypeValue, Value};
 
 /// A field in a [`Struct`].
 #[derive(Debug, Serialize, Deserialize)]
-pub struct StructField {
+pub(crate) struct StructField {
     /// For structures derived from a protobuf this contains the field number
     /// specified in the .proto file. For other structures this is set to 0.
     pub number: u64,
@@ -45,7 +45,7 @@ pub struct StructField {
 /// associated to that module. Functions [`Struct::from_proto_msg`] and
 /// [`Struct::from_proto_descriptor_and_msg`] are used for that purpose.
 #[derive(Debug, Serialize, Deserialize, Default)]
-pub struct Struct {
+pub(crate) struct Struct {
     /// Fields in this structure.
     ///
     /// An `IndexMap` is used instead of a `HashMap` because we want to be

--- a/yara-x/src/wasm/builder.rs
+++ b/yara-x/src/wasm/builder.rs
@@ -470,38 +470,38 @@ mod tests {
         assert_eq!(
             text,
             r#"(module
-  (func (;125;) (type 1) (result i32)
+  (func (;126;) (type 1) (result i32)
     i32.const 0
     global.set 2
     i32.const 0
     global.set 3
-    call 126
     call 127
+    call 128
     global.get 3
   )
-  (func (;126;) (type 0)
-    block ;; label = @1
-      call 128
-    end
+  (func (;127;) (type 0)
     block ;; label = @1
       call 129
     end
-  )
-  (func (;127;) (type 0)
     block ;; label = @1
       call 130
     end
   )
   (func (;128;) (type 0)
-    i32.const 4
+    block ;; label = @1
+      call 131
+    end
   )
   (func (;129;) (type 0)
-    i32.const 5
+    i32.const 4
   )
   (func (;130;) (type 0)
+    i32.const 5
+  )
+  (func (;131;) (type 0)
     i32.const 6
   )
-  (export "main" (func 125))
+  (export "main" (func 126))
 )"#
         );
     }

--- a/yara-x/src/wasm/builder.rs
+++ b/yara-x/src/wasm/builder.rs
@@ -231,6 +231,9 @@ impl WasmModuleBuilder {
         self.wasm_symbols.clone()
     }
 
+    /// Returns a hash map where keys are fully qualified mangled function
+    /// names (i.e: `my_module.my_struct.my_func@ii@i`) and values are function
+    /// identifiers returned by the `walrus` crate. ([`walrus::FunctionId`]).
     pub fn wasm_exports(&self) -> FxHashMap<String, FunctionId> {
         self.wasm_exports.clone()
     }


### PR DESCRIPTION
A mechanism for supporting method calls is now implemented. Only structs can have methods at this time, but in the future this can be extended to other types like maps and arrays.

The `module_export` and `wasm_export` now have a new argument `method_of` that allows to specify that a WASM-exported function is a method of some type. For example:

```
#[module_export(method_of = "test_proto2.NestedProto2")]
fn some_function(ctx: &mut ScanContext, structure: Rc<Struct>) {
  ... // here the `structure` argument is a `NestedProto2`
}
```