### PR TITLE
fix: multiple issues in `dotnet` module

### DIFF
--- a/yara-x/src/modules/dotnet/parser.rs
+++ b/yara-x/src/modules/dotnet/parser.rs
@@ -1148,8 +1148,12 @@ impl<'a> Dotnet<'a> {
                     if size > 0 {
                         let l =
                             lower_bounds.get(i as usize).cloned().unwrap_or(0);
-                        let h = l + (size as i32) - 1;
-                        write!(output, "{}...{}", l, h)?;
+                        let h = l + (size as i32);
+                        if l == 0 {
+                            write!(output, "{}", size)?;
+                        } else {
+                            write!(output, "{}...{}", l, h)?;
+                        }
                     }
                     // If not the last item, prepend a comma.
                     if i + 1 != dimensions {

--- a/yara-x/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
+++ b/yara-x/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
@@ -12085,7 +12085,7 @@ classes:
           - name: "stomizeService"
             type: "dLine.Definitions.solverDef<erSerializer.estComparator,object[]>"
           - name: "eField"
-            type: "erSerializer.Prototype<ototypeAuth,erSerializer.estComparator>[0...667,-55...-54,-64...-47,-55...53,1...29,7...34,-61...-55,1...10,-54...-53,9...26,534...1593,-63...-46,-55...53,0...10,-55...-35,-64...-47,-55...1012,1...3,,,]"
+            type: "erSerializer.Prototype<ototypeAuth,erSerializer.estComparator>[668,-55...-53,-64...-46,-55...54,1...30,7...35,-61...-54,1...11,-54...-52,9...27,534...1594,-63...-45,-55...54,11,-55...-34,-64...-46,-55...1013,1...4,,,]"
           - name: "wField"
             type: "byte"
           - name: "lComparator"

--- a/yara-x/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
+++ b/yara-x/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
@@ -121,22 +121,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "onInstance.mContainerSerializer"
-    methods:
-      - name: "antiateProxy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "andLine.Producers.ates"
     name: "ates"
     namespace: "andLine.Producers"
@@ -146,36 +133,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "m1"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "parator"
-            type: "r"
-          - name: "m"
-            type: "int"
-      - name: "r"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "r"
   - fullname: "DatabaseFilterProperty"
     name: "DatabaseFilterProperty"
     visibility: "private"
@@ -219,40 +179,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "6"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "ref void"
-        number_of_generic_parameters: 0
-        number_of_parameters: 10
-        parameters:
-          - name: "rator"
-            type: "void"
-          - name: "re"
-            type: "int"
-          - name: "omparator"
-            type: "or.pComparator<r>"
-          - name: "irst"
-            type: "ulong"
-          - name: "InstantiateComparator"
-            type: "ref void"
-          - name: "ntiateComparator"
-            type: "void"
-          - name: "rator"
-            type: "r"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "sitor2"
-            type: "long"
-          - name: "insertivk4"
-            type: "ref void"
       - name: ""
         visibility: "internal"
         abstract: false
@@ -285,18 +215,6 @@ classes:
             type: "bool"
           - name: "uptProxy"
             type: "short"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "char"
   - fullname: "ine.Instances"
     name: "Instances"
     namespace: "ine"
@@ -306,7 +224,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -324,18 +242,6 @@ classes:
             type: "bool"
           - name: "uptProxy"
             type: "uint"
-      - name: "parator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
   - fullname: "nces"
     name: "nces"
     visibility: "private"
@@ -377,22 +283,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "config"
-            type: "char"
   - fullname: "erInterpreterCandidate"
     name: "erInterpreterCandidate"
     visibility: "private"
@@ -450,7 +343,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 8
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -494,158 +387,6 @@ classes:
             type: "andLine.Producers.mlTreeNodeState"
           - name: "r"
             type: "char"
-      - name: "tions"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "fo"
-            type: "object[]"
-          - name: "rtProxy"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "fineComparator"
-            type: "ref void"
-          - name: "rtProxy"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "tor"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "re"
-            type: "long"
-          - name: "esult"
-            type: "void"
-          - name: ""
-            type: "ners.der"
-          - name: "fineComparator"
-            type: "byte"
-          - name: "ception"
-            type: "long"
-      - name: "ertyType"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "fo"
-            type: "object[]"
-          - name: "rtProxy"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "fineComparator"
-            type: "ref void"
-          - name: "rtProxy"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "tor"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "re"
-            type: "long"
-          - name: "esult"
-            type: "void"
-          - name: ""
-            type: "ners.der"
-          - name: "fineComparator"
-            type: "byte"
-          - name: "ception"
-            type: "long"
-      - name: "t_IsEnum"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "fo"
-            type: "object[]"
-          - name: "rtProxy"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "fineComparator"
-            type: "ref void"
-          - name: "rtProxy"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "tor"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "re"
-            type: "long"
-          - name: "esult"
-            type: "void"
-          - name: ""
-            type: "ners.der"
-          - name: "fineComparator"
-            type: "byte"
-          - name: "ception"
-            type: "long"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "fo"
-            type: "object[]"
-          - name: "rtProxy"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "fineComparator"
-            type: "ref void"
-          - name: "rtProxy"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "tor"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "re"
-            type: "long"
-          - name: "esult"
-            type: "void"
-          - name: ""
-            type: "ners.der"
-          - name: "fineComparator"
-            type: "byte"
-          - name: "ception"
-            type: "long"
       - name: "xy"
         visibility: "internal"
         abstract: false
@@ -658,18 +399,6 @@ classes:
         parameters:
           - name: "r"
             type: "bool"
-      - name: "GetTypeInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: "rSetterMap"
     name: "rSetterMap"
     visibility: "internal"
@@ -678,7 +407,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -691,18 +420,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "y"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: "ool.nerSetterMap"
     name: "nerSetterMap"
     namespace: "ool"
@@ -712,7 +429,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -725,18 +442,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "Proxy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
   - fullname: "onInstance.etterMap"
     name: "etterMap"
     namespace: "onInstance"
@@ -746,24 +451,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "tor"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "esult"
-            type: "r"
-          - name: "tor"
-            type: "ulong"
   - fullname: "ndLine.Authentication.nt"
     name: "nt"
     namespace: "ndLine.Authentication"
@@ -773,22 +463,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "arator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "char"
   - fullname: "dLine.Definitions.n"
     name: "n"
     namespace: "dLine.Definitions"
@@ -810,22 +487,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "ht"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: ""
         visibility: "internal"
         abstract: false
@@ -866,44 +531,6 @@ classes:
             type: "int"
           - name: ""
             type: "ushort"
-      - name: "iteSpace"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "eflectComparator"
-            type: "byte"
-          - name: "eflectComparator"
-            type: "object[]"
-          - name: "parator"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "lComparator"
-            type: "ref void"
-          - name: ""
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "h"
-            type: "o.or"
-          - name: "parator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "esult"
-            type: "void"
-          - name: "ePool"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "config"
-            type: "long"
   - fullname: "ool.Mapping"
     name: "Mapping"
     namespace: "ool"
@@ -913,22 +540,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "ceOption.rviceFieldDic"
     methods:
-      - name: "l"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
       - name: "l"
         visibility: "internal"
         abstract: false
@@ -946,23 +561,10 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "object"
       - "bool"
-    methods:
-      - name: "electComposer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "eInterpreterCandidate.gerSetterMap"
     name: "gerSetterMap"
     namespace: "eInterpreterCandidate"
@@ -972,22 +574,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ceOption.rviceFieldDic"
-    methods:
-      - name: "ol"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "ueType.e"
     name: "e"
     namespace: "ueType"
@@ -997,22 +586,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ceOption.rviceFieldDic"
-    methods:
-      - name: "l"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "char"
   - fullname: "ool.emplateWriter"
     name: "emplateWriter"
     namespace: "ool"
@@ -1022,7 +598,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1035,18 +611,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "zePool"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
   - fullname: "eInterpreterCandidate.mmandLine.Writers"
     name: "Writers"
     namespace: "eInterpreterCandidate.mmandLine"
@@ -1080,22 +644,9 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "ool"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: ".Dictionaries.icy"
     name: "icy"
     namespace: ".Dictionaries"
@@ -1105,7 +656,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1123,18 +674,6 @@ classes:
             type: "int"
           - name: "onException"
             type: "byte"
-      - name: "Error"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: "andLine.Producers.sSearchTaskStatus"
     name: "sSearchTaskStatus"
     namespace: "andLine.Producers"
@@ -1144,22 +683,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
-    methods:
-      - name: "latePrototype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "kStatus"
     name: "kStatus"
     visibility: "internal"
@@ -1257,22 +783,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "nfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
   - fullname: "istener"
     name: "istener"
     visibility: "private"
@@ -1281,22 +794,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "rs"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "CommandLine.Listeners"
     name: "Listeners"
     namespace: "CommandLine"
@@ -1318,7 +818,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1331,18 +831,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "map"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "chant.ce"
     name: "ce"
     namespace: "chant"
@@ -1352,74 +840,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 0
     base_types:
       - "ScopeInitInfo.eterCandidate"
-    methods:
-      - name: "iateIterator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "onException"
-            type: "char"
-      - name: "dIterator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "onException"
-            type: "r"
-          - name: "fineComparator"
-            type: "int"
-      - name: "lectIterator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "onException"
-            type: "byte"
-          - name: "fineComparator"
-            type: "object[]"
-          - name: "parator"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "re"
-            type: "ref void"
-          - name: ""
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "ble"
-            type: "o.or"
-          - name: "e"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "rtProxy"
-            type: "void"
-          - name: "onException"
-            type: "ners.der"
-          - name: "mparator"
-            type: "byte"
-          - name: "e"
-            type: "long"
   - fullname: "ices.ine.Services"
     name: "Services"
     namespace: "ices.ine"
@@ -1429,7 +852,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1442,18 +865,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "erator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "eInterpreterCandidate.onsumers"
     name: "onsumers"
     namespace: "eInterpreterCandidate"
@@ -1463,7 +874,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1476,18 +887,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "tIterator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "eInterpreterCandidate.mmandLine.Identifiers"
     name: "Identifiers"
     namespace: "eInterpreterCandidate.mmandLine"
@@ -1497,22 +896,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "ototype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rtProxy"
-            type: "char"
   - fullname: "ndLine.Authentication.ne.Identifiers"
     name: "Identifiers"
     namespace: "ndLine.Authentication.ne"
@@ -1522,22 +908,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "onInstance.mContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "onException"
-            type: "char"
   - fullname: "ateWriter.seTemplateWriter"
     name: "seTemplateWriter"
     namespace: "ateWriter"
@@ -1547,7 +920,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1583,18 +956,6 @@ classes:
             type: "bool"
           - name: ""
             type: "short"
-      - name: "le"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ullOrEmpty"
-            type: "char"
       - name: "connection"
         visibility: "internal"
         abstract: false
@@ -1617,48 +978,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "onException"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: ""
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "parator"
-            type: "ref void"
-          - name: "ception"
-            type: "void"
-          - name: "tor"
-            type: "or.pComparator<r>"
-          - name: "eProxy"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "ection"
-            type: "long"
-          - name: "reader"
-            type: "void"
-          - name: "dconnection6"
-            type: "ners.der"
-          - name: "r"
-            type: "byte"
-          - name: "Pool"
-            type: "long"
   - fullname: "Mapper"
     name: "Mapper"
     visibility: "internal"
@@ -1667,32 +989,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "byte"
-    methods:
-      - name: ""
-        visibility: "public"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "string"
-        number_of_generic_parameters: 0
-        number_of_parameters: 6
-        parameters:
-          - name: "onException"
-            type: "er.eleteIterator"
-          - name: "parator"
-            type: "short"
-          - name: ""
-            type: "string"
-          - name: "r"
-            type: "er.type"
-          - name: "parator"
-            type: "uint"
-          - name: "ception"
-            type: "ateWriter.StrategyExporterListener<r,r>"
   - fullname: "ateWriter.terProperty"
     name: "terProperty"
     namespace: "ateWriter"
@@ -1702,22 +1001,10 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.roperty"
     methods:
-      - name: "e"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "FindLastIndex"
         visibility: "internal"
         abstract: false
@@ -1744,7 +1031,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1762,44 +1049,6 @@ classes:
             type: "bool"
           - name: "arator"
             type: "uint"
-      - name: "eIterator"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
-      - name: "tPrototype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "string[]"
-        number_of_generic_parameters: 0
-        number_of_parameters: 8
-        parameters:
-          - name: "arator"
-            type: "short"
-          - name: "5"
-            type: "erSerializer.ype<string>"
-          - name: "ception"
-            type: "string"
-          - name: "esult"
-            type: "ref void"
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: "eflectComparator"
-            type: "int"
-          - name: "m"
-            type: "r[]"
-          - name: "esult"
-            type: "erSerializer.ype<r>"
   - fullname: "rCandidate"
     name: "rCandidate"
     visibility: "private"
@@ -1808,22 +1057,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "char"
   - fullname: "Map.aSetterMap"
     name: "aSetterMap"
     namespace: "Map"
@@ -1833,37 +1069,11 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
       - "erSerializer.tor"
     methods:
-      - name: ""
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "bool"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "ool.ss<r>"
-      - name: "e"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "ool.ss<r>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "parator"
-            type: "ool.ss<r>"
-          - name: "fineComparator"
-            type: "object"
       - name: "isitem"
         visibility: "private"
         abstract: false
@@ -1888,18 +1098,6 @@ classes:
         parameters:
           - name: "rtProxy"
             type: "bool"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "ationConsumer"
     name: "ationConsumer"
     visibility: "private"
@@ -1908,7 +1106,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -1940,18 +1138,6 @@ classes:
             type: "string"
           - name: "rator"
             type: "short"
-      - name: "tePrototype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "acade"
     name: "acade"
     visibility: "private"
@@ -1960,22 +1146,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "comparatorPrototype"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "object"
   - fullname: "onInstance.Line.Structs"
     name: "Structs"
     namespace: "onInstance.Line"
@@ -1985,22 +1158,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "ceOption.rviceFieldDic"
     methods:
-      - name: "Prototype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
       - name: "startPrinter"
         visibility: "internal"
         abstract: false
@@ -2022,7 +1183,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 4
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2044,18 +1205,6 @@ classes:
         return_type: "sbyte"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "ValueOrDefault"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "fineComparator"
-            type: "char"
       - name: "t"
         visibility: "internal"
         abstract: false
@@ -2116,22 +1265,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
   - fullname: "ingletonPrototype"
     name: "ingletonPrototype"
     visibility: "private"
@@ -2152,7 +1288,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2165,18 +1301,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "r"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "ss"
     name: "ss"
     visibility: "internal"
@@ -2196,7 +1320,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2224,44 +1348,6 @@ classes:
         parameters:
           - name: "rototype"
             type: "or.pComparator<ScopeInitInfo.eterCandidate>"
-      - name: "ateStrategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "lComparator"
-            type: "byte"
-          - name: "uptProxy"
-            type: "object[]"
-          - name: "tor"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "nfo"
-            type: "ref void"
-          - name: "parator"
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "ection"
-            type: "o.or"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "lComparator"
-            type: "long"
-          - name: "ection"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "r"
-            type: "byte"
-          - name: "config"
-            type: "long"
   - fullname: "erCandidate"
     name: "erCandidate"
     visibility: "private"
@@ -2282,22 +1368,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "onInstance.mContainerSerializer"
     methods:
-      - name: "ncelPrinter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
       - name: "onnectPrinter"
         visibility: "internal"
         abstract: false
@@ -2319,22 +1393,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "byte"
-    methods:
-      - name: "rderPrinter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
   - fullname: "ndLine.Authentication.r"
     name: "r"
     namespace: "ndLine.Authentication"
@@ -2344,7 +1405,7 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.hPrinter"
@@ -2363,18 +1424,6 @@ classes:
             type: "string"
           - name: "nfo"
             type: "short"
-      - name: "eHelpers"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "andLine.Producers.onnections"
     name: "onnections"
     namespace: "andLine.Producers"
@@ -2384,7 +1433,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 7
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2418,106 +1467,6 @@ classes:
             type: "bool"
           - name: "nfo"
             type: "short"
-      - name: "ts"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "config"
-            type: "object[]"
-          - name: "nfo"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "y"
-            type: "void"
-          - name: "ception"
-            type: "or.pComparator<r>"
-          - name: "e"
-            type: "o.or"
-          - name: "h"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-          - name: "config"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "tor"
-            type: "byte"
-          - name: "lComparator"
-            type: "long"
-      - name: "egy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
-      - name: "ny"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "erSerializer.or<r,or.pComparator<r>>"
-      - name: "r"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "config"
-            type: "object[]"
-          - name: "nfo"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "y"
-            type: "void"
-          - name: "ception"
-            type: "or.pComparator<r>"
-          - name: "e"
-            type: "o.or"
-          - name: "h"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-          - name: "config"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "tor"
-            type: "byte"
-          - name: "lComparator"
-            type: "long"
       - name: "ter"
         visibility: "internal"
         abstract: false
@@ -2538,24 +1487,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "nitPrinter"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "r"
-            type: "or.pComparator<r>"
-          - name: "config"
-            type: "TypedReference"
   - fullname: "ners.rProperty"
     name: "rProperty"
     namespace: "ners"
@@ -2576,7 +1510,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2616,44 +1550,6 @@ classes:
         parameters:
           - name: "config"
             type: "bool"
-      - name: "NewStrategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "tor"
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "r"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "nfo"
-            type: "or.pComparator<r>"
-          - name: "e"
-            type: "o.or"
-          - name: "vePrototype"
-            type: "byte"
-          - name: "totype"
-            type: "long"
-          - name: "ePrototype"
-            type: "void"
-          - name: "type"
-            type: "ners.der"
-          - name: "ResetSpecification"
-            type: "byte"
-          - name: "Specification"
-            type: "long"
   - fullname: "eterTemplateService"
     name: "eterTemplateService"
     visibility: "private"
@@ -2673,7 +1569,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2701,18 +1597,6 @@ classes:
         parameters:
           - name: ""
             type: "or.pComparator<ScopeInitInfo.eterCandidate>"
-      - name: "ification"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
       - name: "y"
         visibility: "internal"
         abstract: false
@@ -2736,7 +1620,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2752,32 +1636,6 @@ classes:
         parameters:
           - name: "r"
             type: "ScopeInitInfo.eterCandidate"
-      - name: "omizeComparator"
-        visibility: "public"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "onException"
-            type: "r"
-          - name: "nfo"
-            type: "erSerializer.or<r,r>"
-      - name: "cification"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
   - fullname: "ocationFilterProperty.orter"
     name: "orter"
     namespace: "ocationFilterProperty"
@@ -2800,7 +1658,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "ool.ine.Pools"
     methods:
@@ -2858,18 +1716,6 @@ classes:
         parameters:
           - name: "nfo"
             type: "char"
-      - name: "shStrategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "char"
   - fullname: "chant.rMap"
     name: "rMap"
     namespace: "chant"
@@ -2879,7 +1725,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2892,18 +1738,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "fication"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lComparator"
-            type: "char"
   - fullname: "chant.etterMap"
     name: "etterMap"
     namespace: "chant"
@@ -2913,7 +1747,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2926,18 +1760,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "iteStrategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "onInstance.onsumer"
     name: "onsumer"
     namespace: "onInstance"
@@ -2958,7 +1780,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -2985,18 +1807,6 @@ classes:
         return_type: "or.pe<erSerializer.Prototype<dLine.Definitions.sitorResolverDef,.Dictionaries.icy<andLine.Producers.VsExportSharingPolicy>>>"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "gy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "onException"
-            type: "char"
   - fullname: "nConsumer"
     name: "nConsumer"
     visibility: "private"
@@ -3005,7 +1815,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -3023,94 +1833,6 @@ classes:
             type: "ool.lectionTemplateWriter"
           - name: "rator"
             type: "int"
-      - name: "ification"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: "lComparator"
-            type: "float"
-          - name: "rototype"
-            type: "ref void"
-          - name: "SearchComparator"
-            type: "void"
-          - name: "rtProxy"
-            type: "or.pComparator<r>"
-          - name: "mparator"
-            type: "o.or"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "Pool"
-            type: "long"
-          - name: "2"
-            type: "void"
-          - name: "lComparator"
-            type: "ners.der"
-          - name: "ion`2"
-            type: "byte"
-          - name: "eHandle"
-            type: "long"
-      - name: "rategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: "lComparator"
-            type: "float"
-          - name: "rototype"
-            type: "ref void"
-          - name: "SearchComparator"
-            type: "void"
-          - name: "rtProxy"
-            type: "or.pComparator<r>"
-          - name: "mparator"
-            type: "o.or"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "Pool"
-            type: "long"
-          - name: "2"
-            type: "void"
-          - name: "lComparator"
-            type: "ners.der"
-          - name: "ion`2"
-            type: "byte"
-          - name: "eHandle"
-            type: "long"
-      - name: "ustomizeSpecification"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
       - name: "riteSpecification"
         visibility: "internal"
         abstract: false
@@ -3128,7 +1850,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -3146,18 +1868,6 @@ classes:
             type: "ool.lectionTemplateWriter"
           - name: "stem.Reflection"
             type: "int"
-      - name: "otype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
   - fullname: "ateWriter.StrategyExporterListener"
     name: "StrategyExporterListener"
     namespace: "ateWriter"
@@ -3167,22 +1877,9 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "ontainer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
   - fullname: "Listener"
     name: "Listener"
     visibility: "private"
@@ -3203,7 +1900,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 12
+    number_of_methods: 5
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -3216,82 +1913,6 @@ classes:
         return_type: "bool"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "nce"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "uptProxy"
-            type: "byte"
-          - name: "eflectComparator"
-            type: "object[]"
-          - name: "esult"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "mparator"
-            type: "ref void"
-          - name: "rototype"
-            type: "void"
-          - name: "CheckComparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: ""
-            type: "byte"
-          - name: "rototype"
-            type: "long"
-          - name: "ection"
-            type: "void"
-          - name: "Instance"
-            type: "ners.der"
-          - name: "parator"
-            type: "byte"
-          - name: "pInstance"
-            type: "long"
-      - name: "ce"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "rototype"
-            type: "object[]"
-          - name: "ection"
-            type: "bool"
-          - name: "Instance"
-            type: "float"
-          - name: "parator"
-            type: "ref void"
-          - name: "pInstance"
-            type: "void"
-          - name: "omparator"
-            type: "or.pComparator<r>"
-          - name: "ullOrEmpty"
-            type: "o.or"
-          - name: "arator"
-            type: "byte"
-          - name: "uptProxy"
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "lComparator"
-            type: "byte"
-          - name: "ception"
-            type: "long"
       - name: "nce"
         visibility: "private"
         abstract: false
@@ -3321,56 +1942,6 @@ classes:
         static: true
         virtual: false
         final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "ullOrEmpty"
-            type: "object[]"
-          - name: "arator"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "parator"
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "ception"
-            type: "o.or"
-          - name: "omparator"
-            type: "byte"
-          - name: "onException"
-            type: "long"
-          - name: "omparator"
-            type: "void"
-          - name: "esult"
-            type: "ners.der"
-          - name: "lComparator"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-      - name: "ion"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
-      - name: "n"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
         return_type: "ushort"
         number_of_generic_parameters: 0
         number_of_parameters: 4
@@ -3383,82 +1954,6 @@ classes:
             type: "bool"
           - name: "uptProxy"
             type: "short"
-      - name: "ion"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "arator"
-            type: "byte"
-          - name: "uptProxy"
-            type: "object[]"
-          - name: "parator"
-            type: "bool"
-          - name: "rator"
-            type: "float"
-          - name: "lComparator"
-            type: "ref void"
-          - name: "ception"
-            type: "void"
-          - name: "omparator"
-            type: "or.pComparator<r>"
-          - name: "onException"
-            type: "o.or"
-          - name: "omparator"
-            type: "byte"
-          - name: "esult"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "nfo"
-            type: "ners.der"
-          - name: "ception"
-            type: "byte"
-          - name: "config"
-            type: "long"
-      - name: "on"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "arator"
-            type: "byte"
-          - name: "uptProxy"
-            type: "object[]"
-          - name: "parator"
-            type: "bool"
-          - name: "rator"
-            type: "float"
-          - name: "lComparator"
-            type: "ref void"
-          - name: "ception"
-            type: "void"
-          - name: "omparator"
-            type: "or.pComparator<r>"
-          - name: "onException"
-            type: "o.or"
-          - name: "omparator"
-            type: "byte"
-          - name: "esult"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "nfo"
-            type: "ners.der"
-          - name: "ception"
-            type: "byte"
-          - name: "config"
-            type: "long"
       - name: "RegisterSpecification"
         visibility: "internal"
         abstract: false
@@ -3471,44 +1966,6 @@ classes:
         parameters:
           - name: "arator"
             type: "bool"
-      - name: "ble"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "uptProxy"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: "rator"
-            type: "bool"
-          - name: "lComparator"
-            type: "float"
-          - name: "ception"
-            type: "ref void"
-          - name: "omparator"
-            type: "void"
-          - name: "onException"
-            type: "or.pComparator<r>"
-          - name: "omparator"
-            type: "o.or"
-          - name: "esult"
-            type: "byte"
-          - name: "lComparator"
-            type: "long"
-          - name: "nfo"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "config"
-            type: "byte"
-          - name: "rator"
-            type: "long"
   - fullname: "erInterpreterCandidate"
     name: "erInterpreterCandidate"
     visibility: "private"
@@ -3517,22 +1974,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "pMethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
   - fullname: "Candidate"
     name: "Candidate"
     visibility: "private"
@@ -3541,7 +1985,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -3589,18 +2033,6 @@ classes:
             type: "bool"
           - name: "esult"
             type: "short"
-      - name: "Instance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "onException"
-            type: "char"
   - fullname: "rModel"
     name: "rModel"
     visibility: "private"
@@ -3609,7 +2041,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -3631,18 +2063,6 @@ classes:
             type: "bool"
           - name: "nfo"
             type: "short"
-      - name: "PrepareMethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
   - fullname: "tFilterProperty"
     name: "tFilterProperty"
     visibility: "private"
@@ -3651,54 +2071,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "totype"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "ool.ine.Pools"
-        number_of_generic_parameters: 0
-        number_of_parameters: 3
-        parameters:
-          - name: "nfo"
-            type: "object"
-          - name: "ception"
-            type: "object"
-          - name: "config"
-            type: "ingleton"
-      - name: "otype"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "ool.ine.Pools"
-        number_of_generic_parameters: 0
-        number_of_parameters: 3
-        parameters:
-          - name: "config"
-            type: "object"
-          - name: "rator"
-            type: "object"
-          - name: "rtProxy"
-            type: "ingleton"
-      - name: "hod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "onException"
-            type: "char"
   - fullname: "oducerStrategyExporter"
     name: "oducerStrategyExporter"
     visibility: "private"
@@ -3718,42 +2093,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "e"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "ool.ine.Pools"
-        number_of_generic_parameters: 0
-        number_of_parameters: 3
-        parameters:
-          - name: "onException"
-            type: "object"
-          - name: "uptProxy"
-            type: "object"
-          - name: "r"
-            type: "ingleton"
-      - name: "erPrototype"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "ool.ine.Pools"
-        number_of_generic_parameters: 0
-        number_of_parameters: 3
-        parameters:
-          - name: "stem.Reflection"
-            type: "object"
-          - name: "parator"
-            type: "object"
-          - name: "rtProxy"
-            type: "ingleton"
   - fullname: "erDef"
     name: "erDef"
     visibility: "private"
@@ -3773,22 +2115,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "eatorPrototype"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "ntry"
     name: "ntry"
     visibility: "internal"
@@ -3797,222 +2126,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 10
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "icode"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "es"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "ethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "eMethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "ble"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: "ethod"
-            type: "float"
-          - name: "hod"
-            type: "ref void"
-          - name: "nit"
-            type: "void"
-          - name: "RunMethod"
-            type: "or.pComparator<r>"
-          - name: "ble"
-            type: "o.or"
-          - name: "hod"
-            type: "byte"
-          - name: "nit"
-            type: "long"
-          - name: "e"
-            type: "void"
-          - name: "ethod"
-            type: "ners.der"
-          - name: "d"
-            type: "byte"
-          - name: "hod"
-            type: "long"
-      - name: "tExecutingAssembly"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "ble"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: "ethod"
-            type: "float"
-          - name: "hod"
-            type: "ref void"
-          - name: "nit"
-            type: "void"
-          - name: "RunMethod"
-            type: "or.pComparator<r>"
-          - name: "ble"
-            type: "o.or"
-          - name: "hod"
-            type: "byte"
-          - name: "nit"
-            type: "long"
-          - name: "e"
-            type: "void"
-          - name: "ethod"
-            type: "ners.der"
-          - name: "d"
-            type: "byte"
-          - name: "hod"
-            type: "long"
-      - name: "embly"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "ble"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: "ethod"
-            type: "float"
-          - name: "hod"
-            type: "ref void"
-          - name: "nit"
-            type: "void"
-          - name: "RunMethod"
-            type: "or.pComparator<r>"
-          - name: "ble"
-            type: "o.or"
-          - name: "hod"
-            type: "byte"
-          - name: "nit"
-            type: "long"
-          - name: "e"
-            type: "void"
-          - name: "ethod"
-            type: "ners.der"
-          - name: "d"
-            type: "byte"
-          - name: "hod"
-            type: "long"
-      - name: "Method"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "Method"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "llMethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "e"
-            type: "object[]"
-          - name: "ethod"
-            type: "bool"
-          - name: "hod"
-            type: "float"
-          - name: "nit"
-            type: "ref void"
-          - name: "RunMethod"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: "hod"
-            type: "o.or"
-          - name: "nit"
-            type: "byte"
-          - name: "e"
-            type: "long"
-          - name: "ethod"
-            type: "void"
-          - name: "d"
-            type: "ners.der"
-          - name: "hod"
-            type: "byte"
-          - name: "ble"
-            type: "long"
       - name: "llMethod"
         visibility: "internal"
         abstract: false
@@ -4033,22 +2150,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "selection"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "RunMethod"
-            type: "char"
   - fullname: "nterpreterCandidate"
     name: "nterpreterCandidate"
     visibility: "private"
@@ -4057,34 +2161,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "tInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "ethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "ate"
     name: "ate"
     visibility: "private"
@@ -4093,22 +2172,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "hod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
       - name: "hod"
         visibility: "internal"
         abstract: false
@@ -4126,22 +2193,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "evertMethod"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "d"
-            type: "char"
   - fullname: "peProducer"
     name: "peProducer"
     visibility: "private"
@@ -4150,22 +2204,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "loneInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "merResolverStructBuilder"
     name: "merResolverStructBuilder"
     visibility: "private"
@@ -4174,22 +2215,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "tInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
       - name: "tInfo"
         visibility: "internal"
         abstract: false
@@ -4210,22 +2239,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "PopInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "ramsPrototype"
     name: "ramsPrototype"
     visibility: "private"
@@ -4234,22 +2250,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
   - fullname: "ices.gyExporter"
     name: "gyExporter"
     namespace: "ices"
@@ -4259,7 +2262,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -4272,94 +2275,6 @@ classes:
         return_type: "merResolverStructBuilder"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "InvokeInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lComparator"
-            type: "char"
-      - name: "rtInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "fineComparator"
-            type: "bool"
-          - name: "e"
-            type: "float"
-          - name: "stem.Reflection"
-            type: "ref void"
-          - name: "mparator"
-            type: "void"
-          - name: "parator"
-            type: "or.pComparator<r>"
-          - name: "eflectComparator"
-            type: "o.or"
-          - name: "ateInstance"
-            type: "byte"
-          - name: "esult"
-            type: "long"
-          - name: "rtProxy"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "esult"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
-      - name: "llInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "fineComparator"
-            type: "bool"
-          - name: "e"
-            type: "float"
-          - name: "stem.Reflection"
-            type: "ref void"
-          - name: "mparator"
-            type: "void"
-          - name: "parator"
-            type: "or.pComparator<r>"
-          - name: "eflectComparator"
-            type: "o.or"
-          - name: "ateInstance"
-            type: "byte"
-          - name: "esult"
-            type: "long"
-          - name: "rtProxy"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "esult"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
   - fullname: ".Dictionaries.erResolverStructBuilder"
     name: "erResolverStructBuilder"
     namespace: ".Dictionaries"
@@ -4369,22 +2284,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ceOption.rviceFieldDic"
-    methods:
-      - name: "ruptInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "ners.der"
     name: "der"
     namespace: "ners"
@@ -4394,7 +2296,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "roducer.ceConfiguration"
     methods:
@@ -4416,18 +2318,6 @@ classes:
             type: "bool"
           - name: "arator"
             type: "short"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
   - fullname: "Map.PropertySetterModel"
     name: "PropertySetterModel"
     namespace: "Map"
@@ -4437,22 +2327,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "ceOption.rviceFieldDic"
     methods:
-      - name: "nce"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
       - name: "Exporter"
         visibility: "internal"
         abstract: false
@@ -4470,22 +2348,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
     methods:
-      - name: "etupInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
       - name: "stInfo"
         visibility: "internal"
         abstract: false
@@ -4509,7 +2375,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -4522,18 +2388,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "e"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "char"
   - fullname: "ventInterpreterCandidate"
     name: "ventInterpreterCandidate"
     visibility: "public"
@@ -4566,22 +2420,10 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
     methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rtProxy"
-            type: "char"
       - name: "rototype"
         visibility: "internal"
         abstract: false
@@ -4591,44 +2433,6 @@ classes:
         return_type: "ocationFilterProperty.izer"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "ateExporter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rtProxy"
-            type: "byte"
-          - name: "config"
-            type: "object[]"
-          - name: ""
-            type: "bool"
-          - name: "e"
-            type: "float"
-          - name: "ion`2"
-            type: "ref void"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "rator"
-            type: "or.pComparator<r>"
-          - name: "porter"
-            type: "o.or"
-          - name: "Prototype"
-            type: "byte"
-          - name: "rator"
-            type: "long"
-          - name: "chInterpreter"
-            type: "void"
-          - name: "h"
-            type: "ners.der"
-          - name: ""
-            type: "byte"
-          - name: ""
-            type: "long"
   - fullname: "erpreterCandidate.ourceFileFields"
     name: "ourceFileFields"
     namespace: "erpreterCandidate"
@@ -4638,22 +2442,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "byte"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rtProxy"
-            type: "erSerializer.efineProxy<r>"
   - fullname: "andLine.Producers.ds"
     name: "ds"
     namespace: "andLine.Producers"
@@ -4663,7 +2454,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -4683,20 +2474,6 @@ classes:
             type: "ocationFilterProperty.izer"
           - name: "e"
             type: "short"
-      - name: ""
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: "rator"
-            type: "ulong"
   - fullname: "Producer"
     name: "Producer"
     visibility: "private"
@@ -4705,25 +2482,12 @@ classes:
     sealed: true
     number_of_base_types: 4
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "\342\200\205\010"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
   - fullname: "ateWriter.rverAuth"
     name: "rverAuth"
     namespace: "ateWriter"
@@ -4733,50 +2497,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 12
+    number_of_methods: 8
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "xporter"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: ".<string,er.ption>"
-      - name: "nitExporter"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "er.ption"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: ""
-            type: "onInstance.rMap"
-          - name: "config"
-            type: "ingleton"
-      - name: "eateExporter"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "er.ption"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "config"
-            type: "onInstance.rMap"
-          - name: "rtProxy"
-            type: "ingleton"
       - name: "SetupExporter"
         visibility: "public"
         abstract: false
@@ -4847,18 +2571,6 @@ classes:
             type: "er.roxy"
           - name: "parator"
             type: "ushort"
-      - name: "orInfo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "char"
       - name: "ectMap"
         visibility: "internal"
         abstract: false
@@ -4906,25 +2618,12 @@ classes:
     sealed: true
     number_of_base_types: 4
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "moveExporter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "uteModelClass"
     name: "uteModelClass"
     visibility: "private"
@@ -5158,7 +2857,7 @@ classes:
         static: true
         virtual: false
         final: false
-        return_type: "r"
+        return_type: "onfiguration"
         number_of_generic_parameters: 0
         number_of_parameters: 1
         parameters:
@@ -5173,136 +2872,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "xporter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: "onException"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: ""
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "m"
-            type: "o.or"
-          - name: "parator"
-            type: "byte"
-          - name: "CheckComparator"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: "5"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
-      - name: "p"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: "onException"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: ""
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "m"
-            type: "o.or"
-          - name: "parator"
-            type: "byte"
-          - name: "CheckComparator"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: "5"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: "onException"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: ""
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "m"
-            type: "o.or"
-          - name: "parator"
-            type: "byte"
-          - name: "CheckComparator"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: "5"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
   - fullname: "ueType.ototypeProducer"
     name: "ototypeProducer"
     namespace: "ueType"
@@ -5312,7 +2884,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -5325,18 +2897,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "ool.anceConnector"
     name: "anceConnector"
     namespace: "ool"
@@ -5346,7 +2906,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -5359,18 +2919,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "gy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lComparator"
-            type: "char"
   - fullname: "uthenticationConsumerPool"
     name: "uthenticationConsumerPool"
     visibility: "internal"
@@ -5416,7 +2964,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 7
+    number_of_methods: 6
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -5486,18 +3034,6 @@ classes:
         parameters:
           - name: "r"
             type: "ScopeInitInfo.eterCandidate"
-      - name: "ingleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "ngleton"
         visibility: "internal"
         abstract: false
@@ -5524,7 +3060,7 @@ classes:
     sealed: true
     number_of_base_types: 6
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "or.get_Item3"
@@ -5532,95 +3068,6 @@ classes:
       - "or._Item4"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "dex_info"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "on"
-            type: "char"
-      - name: "ions"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "on"
-            type: "byte"
-          - name: "r"
-            type: "object[]"
-          - name: "vePrototype"
-            type: "bool"
-          - name: "rtProxy"
-            type: "float"
-          - name: "lComparator"
-            type: "ref void"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "lizerStrategy"
-            type: "or.pComparator<r>"
-          - name: "r"
-            type: "o.or"
-          - name: "ionStrategy"
-            type: "byte"
-          - name: "r"
-            type: "long"
-          - name: "arator"
-            type: "void"
-          - name: "r"
-            type: "ners.der"
-          - name: "uptProxy"
-            type: "byte"
-          - name: "parator"
-            type: "long"
-      - name: "go"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "on"
-            type: "byte"
-          - name: "r"
-            type: "object[]"
-          - name: "vePrototype"
-            type: "bool"
-          - name: "rtProxy"
-            type: "float"
-          - name: "lComparator"
-            type: "ref void"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "lizerStrategy"
-            type: "or.pComparator<r>"
-          - name: "r"
-            type: "o.or"
-          - name: "ionStrategy"
-            type: "byte"
-          - name: "r"
-            type: "long"
-          - name: "arator"
-            type: "void"
-          - name: "r"
-            type: "ners.der"
-          - name: "uptProxy"
-            type: "byte"
-          - name: "parator"
-            type: "long"
   - fullname: "cationPrototypeProducer"
     name: "cationPrototypeProducer"
     visibility: "private"
@@ -5640,7 +3087,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -5668,56 +3115,6 @@ classes:
         parameters:
           - name: "stem.Reflection"
             type: "or.pComparator<ScopeInitInfo.eterCandidate>"
-      - name: "on"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "lizerStrategy"
-            type: "byte"
-          - name: "r"
-            type: "object[]"
-          - name: "ionStrategy"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "arator"
-            type: "ref void"
-          - name: "r"
-            type: "void"
-          - name: "uptProxy"
-            type: "or.pComparator<r>"
-          - name: "parator"
-            type: "o.or"
-          - name: "h"
-            type: "byte"
-          - name: "h"
-            type: "long"
-          - name: "eflectComparator"
-            type: "void"
-          - name: "hantStrategy"
-            type: "ners.der"
-          - name: "onException"
-            type: "byte"
-          - name: "omparator"
-            type: "long"
-      - name: "Singleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lizerStrategy"
-            type: "char"
   - fullname: "gy"
     name: "gy"
     visibility: "private"
@@ -5726,7 +3123,7 @@ classes:
     sealed: true
     number_of_base_types: 6
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "or.get_Item3"
@@ -5734,95 +3131,6 @@ classes:
       - "or._Item4"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
-      - name: "go"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "ionStrategy"
-            type: "object[]"
-          - name: "r"
-            type: "bool"
-          - name: "arator"
-            type: "float"
-          - name: "r"
-            type: "ref void"
-          - name: "uptProxy"
-            type: "void"
-          - name: "parator"
-            type: "or.pComparator<r>"
-          - name: "h"
-            type: "o.or"
-          - name: "h"
-            type: "byte"
-          - name: "eflectComparator"
-            type: "long"
-          - name: "hantStrategy"
-            type: "void"
-          - name: "onException"
-            type: "ners.der"
-          - name: "omparator"
-            type: "byte"
-          - name: "uptProxy"
-            type: "long"
-      - name: "o"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "r"
-            type: "byte"
-          - name: "ionStrategy"
-            type: "object[]"
-          - name: "r"
-            type: "bool"
-          - name: "arator"
-            type: "float"
-          - name: "r"
-            type: "ref void"
-          - name: "uptProxy"
-            type: "void"
-          - name: "parator"
-            type: "or.pComparator<r>"
-          - name: "h"
-            type: "o.or"
-          - name: "h"
-            type: "byte"
-          - name: "eflectComparator"
-            type: "long"
-          - name: "hantStrategy"
-            type: "void"
-          - name: "onException"
-            type: "ners.der"
-          - name: "omparator"
-            type: "byte"
-          - name: "uptProxy"
-            type: "long"
   - fullname: "terModel"
     name: "terModel"
     visibility: "private"
@@ -5831,7 +3139,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -5847,18 +3155,6 @@ classes:
         parameters:
           - name: "r"
             type: "or.pComparator<ScopeInitInfo.eterCandidate>"
-      - name: "n_token"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
   - fullname: "egy"
     name: "egy"
     visibility: "private"
@@ -5878,7 +3174,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -5930,18 +3226,6 @@ classes:
         parameters:
           - name: "eflectComparator"
             type: "or.pComparator<string>"
-      - name: "tupSingleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "hantStrategy"
-            type: "char"
   - fullname: "ueType.ieldResolverStructBuilder"
     name: "ieldResolverStructBuilder"
     namespace: "ueType"
@@ -5951,22 +3235,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "roducer.ceConfiguration"
     methods:
-      - name: "eckSingleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "ton"
         visibility: "internal"
         abstract: false
@@ -5993,7 +3265,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 23
+    number_of_methods: 15
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -6152,18 +3424,6 @@ classes:
         parameters:
           - name: "rototype"
             type: "or.pComparator<string>"
-      - name: "iteSingleton"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rtProxy"
-            type: "int"
       - name: "nce"
         visibility: "public"
         abstract: false
@@ -6202,18 +3462,6 @@ classes:
         parameters:
           - name: ""
             type: "ices.Instance"
-      - name: "erConfiguration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "t_Y"
         visibility: "internal"
         abstract: false
@@ -6250,82 +3498,6 @@ classes:
             type: "bool"
           - name: "e"
             type: "short"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "alcAlgo"
-            type: "byte"
-          - name: "lgo"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "rator"
-            type: "ref void"
-          - name: "r"
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "rator"
-            type: "o.or"
-          - name: "rototype"
-            type: "byte"
-          - name: "arator"
-            type: "long"
-          - name: "SingleOrDefault"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "lComparator"
-            type: "byte"
-          - name: "omparator"
-            type: "long"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "alcAlgo"
-            type: "byte"
-          - name: "lgo"
-            type: "object[]"
-          - name: "e"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "rator"
-            type: "ref void"
-          - name: "r"
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "rator"
-            type: "o.or"
-          - name: "rototype"
-            type: "byte"
-          - name: "arator"
-            type: "long"
-          - name: "SingleOrDefault"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "lComparator"
-            type: "byte"
-          - name: "omparator"
-            type: "long"
       - name: "o"
         visibility: "internal"
         abstract: false
@@ -6352,158 +3524,6 @@ classes:
             type: "int"
           - name: "rator"
             type: "byte"
-      - name: "o"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "rator"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "rototype"
-            type: "or.pComparator<r>"
-          - name: "arator"
-            type: "o.or"
-          - name: "SingleOrDefault"
-            type: "byte"
-          - name: "rator"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "rator"
-            type: "byte"
-          - name: ""
-            type: "long"
-      - name: "Algo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "rator"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "rototype"
-            type: "or.pComparator<r>"
-          - name: "arator"
-            type: "o.or"
-          - name: "SingleOrDefault"
-            type: "byte"
-          - name: "rator"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "rator"
-            type: "byte"
-          - name: ""
-            type: "long"
-      - name: "ngthcomp"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "rator"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "rototype"
-            type: "or.pComparator<r>"
-          - name: "arator"
-            type: "o.or"
-          - name: "SingleOrDefault"
-            type: "byte"
-          - name: "rator"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "rator"
-            type: "byte"
-          - name: ""
-            type: "long"
-      - name: "rintAlgo"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "rator"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "rototype"
-            type: "or.pComparator<r>"
-          - name: "arator"
-            type: "o.or"
-          - name: "SingleOrDefault"
-            type: "byte"
-          - name: "rator"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "rator"
-            type: "byte"
-          - name: ""
-            type: "long"
   - fullname: "tegy"
     name: "tegy"
     visibility: "private"
@@ -6512,22 +3532,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "alStrategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: "erConsumerPool"
     name: "erConsumerPool"
     visibility: "private"
@@ -6536,7 +3543,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -6549,18 +3556,6 @@ classes:
         return_type: "er"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "eStrategy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
   - fullname: "bStrategy"
     name: "bStrategy"
     visibility: "private"
@@ -6569,22 +3564,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "guration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
   - fullname: "essageModelClass"
     name: "essageModelClass"
     visibility: "private"
@@ -6593,7 +3575,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -6615,44 +3597,6 @@ classes:
             type: "bool"
           - name: "eflectComparator"
             type: "short"
-      - name: "guration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "eflectComparator"
-            type: "bool"
-          - name: "arator"
-            type: "float"
-          - name: "ception"
-            type: "ref void"
-          - name: "lComparator"
-            type: "void"
-          - name: "parator"
-            type: "or.pComparator<r>"
-          - name: "e"
-            type: "o.or"
-          - name: "igInstance"
-            type: "byte"
-          - name: "e"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: ""
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: ""
-            type: "long"
       - name: "nfiguration"
         visibility: "internal"
         abstract: false
@@ -6669,18 +3613,6 @@ classes:
             type: "object"
           - name: "eflectComparator"
             type: "erSerializer.lgo"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
   - fullname: "ContainerSerializer"
     name: "ContainerSerializer"
     visibility: "private"
@@ -6689,22 +3621,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "eTest"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
   - fullname: "ParserFilterProperty"
     name: "ParserFilterProperty"
     visibility: "private"
@@ -6724,22 +3643,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "geConfiguration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
   - fullname: "?\022c.Model"
     name: "Model"
     namespace: "?\022c"
@@ -6749,22 +3655,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "ateTest"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "igInstance"
-            type: "char"
   - fullname: "ategy"
     name: "ategy"
     visibility: "private"
@@ -6773,7 +3666,7 @@ classes:
     sealed: true
     number_of_base_types: 4
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
@@ -6792,18 +3685,6 @@ classes:
         parameters:
           - name: "e"
             type: "string"
-      - name: "\342\200\205\016"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
   - fullname: "terEntry"
     name: "terEntry"
     visibility: "private"
@@ -6812,22 +3693,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "orInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "nstanceInstance"
     name: "nstanceInstance"
     visibility: "private"
@@ -6836,22 +3704,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "iguration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
   - fullname: "e"
     name: "e"
     visibility: "private"
@@ -6860,7 +3715,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -6873,18 +3728,6 @@ classes:
         return_type: "or.pe<string>"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "ProxyInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "char"
   - fullname: "istener"
     name: "istener"
     visibility: "private"
@@ -6904,7 +3747,7 @@ classes:
     sealed: true
     number_of_base_types: 4
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
@@ -6923,18 +3766,6 @@ classes:
         parameters:
           - name: "rototype"
             type: "string"
-      - name: "\010"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "dDic"
     name: "dDic"
     visibility: "private"
@@ -6954,7 +3785,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -6970,18 +3801,6 @@ classes:
         parameters:
           - name: "eflectComparator"
             type: "byte"
-      - name: "ntextInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
   - fullname: "llbackInstance"
     name: "llbackInstance"
     visibility: "private"
@@ -6990,7 +3809,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -7012,132 +3831,6 @@ classes:
             type: "bool"
           - name: "ception"
             type: "short"
-      - name: "guration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: "ullOrEmpty"
-            type: "object[]"
-          - name: "ception"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "arator"
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "ion`2"
-            type: "or.pComparator<r>"
-          - name: "lComparator"
-            type: "o.or"
-          - name: "re"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "arator"
-            type: "void"
-          - name: "arator"
-            type: "ners.der"
-          - name: "Pool"
-            type: "byte"
-          - name: "lComparator"
-            type: "long"
-      - name: "nfiguration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: "ullOrEmpty"
-            type: "object[]"
-          - name: "ception"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "arator"
-            type: "ref void"
-          - name: "rator"
-            type: "void"
-          - name: "ion`2"
-            type: "or.pComparator<r>"
-          - name: "lComparator"
-            type: "o.or"
-          - name: "re"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "arator"
-            type: "void"
-          - name: "arator"
-            type: "ners.der"
-          - name: "Pool"
-            type: "byte"
-          - name: "lComparator"
-            type: "long"
-      - name: "nitTest"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "char"
-      - name: "t"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ception"
-            type: "byte"
-          - name: "uptProxy"
-            type: "object[]"
-          - name: "arator"
-            type: "bool"
-          - name: "rator"
-            type: "float"
-          - name: "ion`2"
-            type: "ref void"
-          - name: "lComparator"
-            type: "void"
-          - name: "re"
-            type: "or.pComparator<r>"
-          - name: ""
-            type: "o.or"
-          - name: "arator"
-            type: "byte"
-          - name: "arator"
-            type: "long"
-          - name: "Pool"
-            type: "void"
-          - name: "lComparator"
-            type: "ners.der"
-          - name: "ion`2"
-            type: "byte"
-          - name: "xy"
-            type: "long"
   - fullname: "e.teInterpreterCandidate"
     name: "teInterpreterCandidate"
     namespace: "e"
@@ -7147,50 +3840,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "solveTest"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "void"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "uptProxy"
-            type: "ateWriter.StrategyExporterListener<r,r>"
-          - name: "arator"
-            type: "or.pComparator<r>"
-      - name: "st"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "uint"
-      - name: "tion"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "rator"
-            type: "r"
-          - name: "ion`2"
-            type: "r"
   - fullname: "roducer.AdvisorModelClass"
     name: "AdvisorModelClass"
     namespace: "roducer"
@@ -7200,36 +3852,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 0
     base_types:
       - "ateWriter.terProperty"
-    methods:
-      - name: "onfiguration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
-      - name: "PushValue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "r"
-            type: "erSerializer.Comparator"
-          - name: "rimStart"
-            type: "erSerializer.Comparator"
   - fullname: "ocationFilterProperty.izer"
     name: "izer"
     namespace: "ocationFilterProperty"
@@ -7239,7 +3864,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -7261,18 +3886,6 @@ classes:
             type: "bool"
           - name: "lComparator"
             type: "short"
-      - name: "guration"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
       - name: "leConfiguration"
         visibility: "internal"
         abstract: false
@@ -7287,82 +3900,6 @@ classes:
             type: "object"
           - name: ""
             type: "or.pComparator<string>"
-      - name: "Value"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "mparator"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "m"
-            type: "or.pComparator<r>"
-          - name: "go"
-            type: "o.or"
-          - name: "eflectComparator"
-            type: "byte"
-          - name: "parator"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "mparator"
-            type: "ners.der"
-          - name: "uptProxy"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
-      - name: "ue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "mparator"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "m"
-            type: "or.pComparator<r>"
-          - name: "go"
-            type: "o.or"
-          - name: "eflectComparator"
-            type: "byte"
-          - name: "parator"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "mparator"
-            type: "ners.der"
-          - name: "uptProxy"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
   - fullname: "andLine.Producers.tance"
     name: "tance"
     namespace: "andLine.Producers"
@@ -7372,7 +3909,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -7390,18 +3927,6 @@ classes:
             type: "string"
           - name: "eflectComparator"
             type: "short"
-      - name: "ver"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "e"
         visibility: "internal"
         abstract: false
@@ -7456,7 +3981,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -7469,18 +3994,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "pdateValue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
   - fullname: "tInstance"
     name: "tInstance"
     visibility: "internal"
@@ -7489,7 +4002,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 12
+    number_of_methods: 4
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -7559,94 +4072,6 @@ classes:
             type: "byte[]"
           - name: "wSingleton"
             type: "int"
-      - name: "d"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "AssetResolver"
-            type: "char"
-      - name: "inValue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "AssetResolver"
-            type: "byte"
-          - name: "Value"
-            type: "object[]"
-          - name: "MoveResolver"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "olver"
-            type: "ref void"
-          - name: "Value"
-            type: "void"
-          - name: "rototype"
-            type: "or.pComparator<r>"
-          - name: "SingleOrDefault"
-            type: "o.or"
-          - name: "ble"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "omparator"
-            type: "void"
-          - name: "esult"
-            type: "ners.der"
-          - name: "nfo"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
-      - name: "ue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "AssetResolver"
-            type: "byte"
-          - name: "Value"
-            type: "object[]"
-          - name: "MoveResolver"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "olver"
-            type: "ref void"
-          - name: "Value"
-            type: "void"
-          - name: "rototype"
-            type: "or.pComparator<r>"
-          - name: "SingleOrDefault"
-            type: "o.or"
-          - name: "ble"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "omparator"
-            type: "void"
-          - name: "esult"
-            type: "ners.der"
-          - name: "nfo"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
       - name: "alue"
         visibility: "internal"
         abstract: false
@@ -7659,196 +4084,6 @@ classes:
         parameters:
           - name: "AssetResolver"
             type: "bool"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "MoveResolver"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "olver"
-            type: "bool"
-          - name: "Value"
-            type: "float"
-          - name: "rototype"
-            type: "ref void"
-          - name: "SingleOrDefault"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: ""
-            type: "o.or"
-          - name: "omparator"
-            type: "byte"
-          - name: "esult"
-            type: "long"
-          - name: "nfo"
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: "re"
-            type: "byte"
-          - name: "onException"
-            type: "long"
-      - name: "sition"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "olver"
-            type: "object[]"
-          - name: "Value"
-            type: "bool"
-          - name: "rototype"
-            type: "float"
-          - name: "SingleOrDefault"
-            type: "ref void"
-          - name: "ble"
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "omparator"
-            type: "o.or"
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "re"
-            type: "ners.der"
-          - name: "onException"
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "long"
-      - name: "ConcatValue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "olver"
-            type: "object[]"
-          - name: "Value"
-            type: "bool"
-          - name: "rototype"
-            type: "float"
-          - name: "SingleOrDefault"
-            type: "ref void"
-          - name: "ble"
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "omparator"
-            type: "o.or"
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "re"
-            type: "ners.der"
-          - name: "onException"
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "long"
-      - name: "e"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "olver"
-            type: "object[]"
-          - name: "Value"
-            type: "bool"
-          - name: "rototype"
-            type: "float"
-          - name: "SingleOrDefault"
-            type: "ref void"
-          - name: "ble"
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "omparator"
-            type: "o.or"
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "re"
-            type: "ners.der"
-          - name: "onException"
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "long"
-      - name: "lushValue"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "olver"
-            type: "object[]"
-          - name: "Value"
-            type: "bool"
-          - name: "rototype"
-            type: "float"
-          - name: "SingleOrDefault"
-            type: "ref void"
-          - name: "ble"
-            type: "void"
-          - name: ""
-            type: "or.pComparator<r>"
-          - name: "omparator"
-            type: "o.or"
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "long"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "re"
-            type: "ners.der"
-          - name: "onException"
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "long"
   - fullname: "eponseInstance"
     name: "eponseInstance"
     visibility: "private"
@@ -7868,7 +4103,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 4
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -7884,18 +4119,6 @@ classes:
         parameters:
           - name: "olver"
             type: "string"
-      - name: "ad"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
       - name: ""
         visibility: "internal"
         abstract: false
@@ -7961,7 +4184,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
     methods:
@@ -7983,56 +4206,6 @@ classes:
             type: "bool"
           - name: "stem.Reflection"
             type: "short"
-      - name: "llectPolicy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
-      - name: "stantiatePolicy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: "re"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "SingleOrDefault"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "ection"
-            type: "o.or"
-          - name: "parator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "ble"
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "omparator"
-            type: "byte"
-          - name: "r"
-            type: "long"
   - fullname: "ocationFilterProperty.alizer"
     name: "alizer"
     namespace: "ocationFilterProperty"
@@ -8042,7 +4215,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8058,20 +4231,6 @@ classes:
         parameters:
           - name: "esult"
             type: "erSerializer.semblyCopyrightAttribute"
-      - name: "eResolver"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "stem.Reflection"
-            type: "r"
-          - name: "re"
-            type: "int"
   - fullname: "ateWriter.ags"
     name: "ags"
     namespace: "ateWriter"
@@ -8081,22 +4240,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "cy"
         visibility: "internal"
         abstract: false
@@ -8115,82 +4262,6 @@ classes:
             type: "bool"
           - name: "uptProxy"
             type: "short"
-      - name: "olicy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "r"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "sableResolver"
-            type: "float"
-          - name: "adResolver"
-            type: "ref void"
-          - name: "r"
-            type: "void"
-          - name: "rator"
-            type: "or.pComparator<r>"
-          - name: "solver"
-            type: "o.or"
-          - name: "troyResolver"
-            type: "byte"
-          - name: "ble"
-            type: "long"
-          - name: "5"
-            type: "void"
-          - name: "eProxy"
-            type: "ners.der"
-          - name: "licy"
-            type: "byte"
-          - name: "LoginPolicy"
-            type: "long"
-      - name: "Policy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "r"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "sableResolver"
-            type: "float"
-          - name: "adResolver"
-            type: "ref void"
-          - name: "r"
-            type: "void"
-          - name: "rator"
-            type: "or.pComparator<r>"
-          - name: "solver"
-            type: "o.or"
-          - name: "troyResolver"
-            type: "byte"
-          - name: "ble"
-            type: "long"
-          - name: "5"
-            type: "void"
-          - name: "eProxy"
-            type: "ners.der"
-          - name: "licy"
-            type: "byte"
-          - name: "LoginPolicy"
-            type: "long"
       - name: "y"
         visibility: "internal"
         abstract: false
@@ -8212,7 +4283,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 7
+    number_of_methods: 6
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8290,18 +4361,6 @@ classes:
             type: "bool"
           - name: "sableResolver"
             type: "short"
-      - name: "lectResolver"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
       - name: "NewResolver"
         visibility: "internal"
         abstract: false
@@ -8324,7 +4383,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 6
+    number_of_methods: 4
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8421,56 +4480,6 @@ classes:
         return_type: "or.pe<erSerializer.Prototype<dLine.Definitions.sitorResolverDef,.Dictionaries.icy<andLine.Producers.VsExportSharingPolicy>>>"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "GetResolver"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "m"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "5"
-            type: "object[]"
-          - name: "eProxy"
-            type: "bool"
-          - name: "licy"
-            type: "float"
-          - name: "LoginPolicy"
-            type: "ref void"
-          - name: "wPolicy"
-            type: "void"
-          - name: "neResolver"
-            type: "or.pComparator<r>"
-          - name: "er"
-            type: "o.or"
-          - name: "cludeparam3"
-            type: "byte"
-          - name: "esult"
-            type: "long"
-          - name: "SearchComparator"
-            type: "void"
-          - name: "eHandle"
-            type: "ners.der"
-          - name: "pec5"
-            type: "byte"
-          - name: "en6"
-            type: "long"
   - fullname: "tionConsumer"
     name: "tionConsumer"
     visibility: "internal"
@@ -8479,22 +4488,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "lver"
-        visibility: "private"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "erSerializer.AssetComparator<r>"
   - fullname: "olverStructBuilder"
     name: "olverStructBuilder"
     visibility: "private"
@@ -8503,7 +4499,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8521,18 +4517,6 @@ classes:
             type: "ool.lectionTemplateWriter"
           - name: "eflectComparator"
             type: "int"
-      - name: "m_RegInstance"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "ateStrategyExporter"
     name: "ateStrategyExporter"
     visibility: "private"
@@ -8541,7 +4525,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8570,18 +4554,6 @@ classes:
         return_type: "string[]"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "iteResolver"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
   - fullname: "ssionComposerID"
     name: "ssionComposerID"
     visibility: "private"
@@ -8590,22 +4562,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "y"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "ExporterExporterListener"
     name: "ExporterExporterListener"
     visibility: "private"
@@ -8614,22 +4573,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "er"
     name: "er"
     visibility: "private"
@@ -8638,7 +4584,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8656,18 +4602,6 @@ classes:
             type: ".Dictionaries.icy<object>"
           - name: "r"
             type: "ushort"
-      - name: "\342\200\213"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
   - fullname: "mplateService"
     name: "mplateService"
     visibility: "private"
@@ -8676,7 +4610,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8689,18 +4623,6 @@ classes:
         return_type: "string[]"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "licy"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "config"
-            type: "char"
   - fullname: "uestContainerSerializer"
     name: "uestContainerSerializer"
     visibility: "private"
@@ -8709,22 +4631,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "Empty"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "roducer.alizer"
     name: "alizer"
     namespace: "roducer"
@@ -8734,22 +4643,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "r"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "float"
   - fullname: "FieldDic"
     name: "FieldDic"
     visibility: "private"
@@ -8839,7 +4735,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8852,18 +4748,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "char"
   - fullname: "ices.istenerExporter"
     name: "istenerExporter"
     namespace: "ices"
@@ -8873,7 +4757,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8886,18 +4770,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "char"
   - fullname: "ool.lectionTemplateWriter"
     name: "lectionTemplateWriter"
     namespace: "ool"
@@ -8919,7 +4791,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 6
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -8941,44 +4813,6 @@ classes:
             type: "bool"
           - name: "ibute"
             type: "short"
-      - name: "ntent"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "sorExporter"
-            type: "object[]"
-          - name: "ibute"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "alcAlgo"
-            type: "ref void"
-          - name: "lgo"
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "ifyConsumer"
-            type: "o.or"
-          - name: "arator"
-            type: "byte"
-          - name: "chInterpreter"
-            type: "long"
-          - name: "ResolveConsumer"
-            type: "void"
-          - name: "parator"
-            type: "ners.der"
-          - name: "At"
-            type: "byte"
-          - name: "config"
-            type: "long"
       - name: "gorithm"
         visibility: "internal"
         abstract: false
@@ -8993,94 +4827,6 @@ classes:
             type: "string"
           - name: "sorExporter"
             type: "short"
-      - name: "ecryptor"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "sorExporter"
-            type: "object[]"
-          - name: "ibute"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "alcAlgo"
-            type: "ref void"
-          - name: "lgo"
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "ifyConsumer"
-            type: "o.or"
-          - name: "arator"
-            type: "byte"
-          - name: "chInterpreter"
-            type: "long"
-          - name: "ResolveConsumer"
-            type: "void"
-          - name: "parator"
-            type: "ners.der"
-          - name: "At"
-            type: "byte"
-          - name: "config"
-            type: "long"
-      - name: "untAttribute"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
-      - name: "eAttribute"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "sorExporter"
-            type: "object[]"
-          - name: "ibute"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "alcAlgo"
-            type: "ref void"
-          - name: "lgo"
-            type: "void"
-          - name: "lComparator"
-            type: "or.pComparator<r>"
-          - name: "ifyConsumer"
-            type: "o.or"
-          - name: "arator"
-            type: "byte"
-          - name: "chInterpreter"
-            type: "long"
-          - name: "ResolveConsumer"
-            type: "void"
-          - name: "parator"
-            type: "ners.der"
-          - name: "At"
-            type: "byte"
-          - name: "config"
-            type: "long"
   - fullname: "ool.omposerID"
     name: "omposerID"
     namespace: "ool"
@@ -9090,22 +4836,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "unter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
       - name: "ttribute"
         visibility: "internal"
         abstract: false
@@ -9126,44 +4860,6 @@ classes:
             type: "string"
           - name: "fo"
             type: "byte"
-      - name: "teAttribute"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "go"
-            type: "bool"
-          - name: "rator"
-            type: "float"
-          - name: "fo"
-            type: "ref void"
-          - name: "e"
-            type: "void"
-          - name: "r"
-            type: "or.pComparator<r>"
-          - name: "e"
-            type: "o.or"
-          - name: "uptProxy"
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "long"
-          - name: "onException"
-            type: "void"
-          - name: ""
-            type: "ners.der"
-          - name: "r"
-            type: "byte"
-          - name: "vePrototype"
-            type: "long"
   - fullname: "ibuteExporter"
     name: "ibuteExporter"
     visibility: "private"
@@ -9183,7 +4879,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -9205,18 +4901,6 @@ classes:
             type: "bool"
           - name: "e"
             type: "short"
-      - name: "estAttribute"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
   - fullname: "erResolverStructBuilder"
     name: "erResolverStructBuilder"
     visibility: "private"
@@ -9225,7 +4909,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -9247,18 +4931,6 @@ classes:
         return_type: "ool.omposerID"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "eConsumer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: "ool.mporterExporter"
     name: "mporterExporter"
     namespace: "ool"
@@ -9268,62 +4940,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "tribute"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "uint"
-      - name: "Attribute"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "uint"
-      - name: "iteConsumer"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "void"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "onException"
-            type: "ateWriter.StrategyExporterListener<r,r>"
-          - name: ""
-            type: "or.pComparator<r>"
-      - name: "wConsumer"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "ateWriter.StrategyExporterListener<r,r>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "r"
-            type: "r"
-          - name: "vePrototype"
-            type: "r"
   - fullname: "istInterpreterCandidate"
     name: "istInterpreterCandidate"
     visibility: "private"
@@ -9343,22 +4962,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "se"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lComparator"
-            type: "r"
   - fullname: "ap"
     name: "ap"
     visibility: "private"
@@ -9424,7 +5030,7 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 6
+    number_of_methods: 5
     base_types:
       - "erSerializer.ContainerSerializer"
       - "erSerializer.tor"
@@ -9519,18 +5125,6 @@ classes:
             type: "bool"
           - name: "fineComparator"
             type: "sbyte"
-      - name: "ludeComposer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "leteComposer"
         visibility: "internal"
         abstract: false
@@ -9571,7 +5165,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -9605,56 +5199,6 @@ classes:
             type: "bool"
           - name: "h"
             type: "short"
-      - name: "oser"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "ble"
-            type: "byte"
-          - name: "5"
-            type: "object[]"
-          - name: "h"
-            type: "bool"
-          - name: "fo"
-            type: "float"
-          - name: "nfo"
-            type: "ref void"
-          - name: "5"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: "ception"
-            type: "o.or"
-          - name: ""
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "long"
-          - name: "rator"
-            type: "void"
-          - name: "r"
-            type: "ners.der"
-          - name: "parator"
-            type: "byte"
-          - name: "omparator"
-            type: "long"
-      - name: "ory"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ble"
-            type: "char"
   - fullname: "ool.ss"
     name: "ss"
     namespace: "ool"
@@ -9676,7 +5220,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
     methods:
@@ -9694,18 +5238,6 @@ classes:
             type: "bool"
           - name: "5"
             type: "bool"
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: ""
-            type: "char"
       - name: "y"
         visibility: "internal"
         abstract: false
@@ -9718,44 +5250,6 @@ classes:
         parameters:
           - name: ""
             type: "or.pComparator<ocationFilterProperty.izer>"
-      - name: "r"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: ""
-            type: "byte"
-          - name: "SingleOrDefault"
-            type: "object[]"
-          - name: "rator"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "parator"
-            type: "ref void"
-          - name: "omparator"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: "fineComparator"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "parator"
-            type: "long"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "onException"
-            type: "ners.der"
-          - name: "ection"
-            type: "byte"
-          - name: "r"
-            type: "long"
   - fullname: "Map.er"
     name: "er"
     namespace: "Map"
@@ -9765,76 +5259,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "keFactory"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<string>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 28
-        parameters:
-          - name: ""
-            type: "erSerializer.estComparator"
-          - name: "SingleOrDefault"
-            type: "bool"
-          - name: "rator"
-            type: "int"
-          - name: "r"
-            type: "Map.PropertySetterModel"
-          - name: "parator"
-            type: "ScopeInitInfo.eterCandidate"
-          - name: "omparator"
-            type: "long"
-          - name: "ble"
-            type: "erSerializer.or<ScopeInitInfo.eterCandidate,Map.PropertySetterModel>"
-          - name: "fineComparator"
-            type: "int"
-          - name: "r"
-            type: "long"
-          - name: "parator"
-            type: "bool"
-          - name: "stem.Reflection"
-            type: "ScopeInitInfo.eterCandidate"
-          - name: "onException"
-            type: "Map.PropertySetterModel"
-          - name: "ection"
-            type: "ingleton"
-          - name: "r"
-            type: "void"
-          - name: "rtProxy"
-            type: "bool"
-          - name: "stem.Reflection"
-            type: "ool.ss<r>"
-          - name: "CheckComparator"
-            type: "or.pComparator<andLine.Producers.VsExportSharingPolicy>"
-          - name: "ble"
-            type: "r"
-          - name: "rototype"
-            type: "long"
-          - name: "5"
-            type: "ushort"
-          - name: ""
-            type: "bool"
-          - name: "fineComparator"
-            type: "int"
-          - name: "ble"
-            type: "olverStructBuilder<r>"
-          - name: "CheckComparator"
-            type: "ushort"
-          - name: "config"
-            type: "mplateService<r>"
-          - name: "chInterpreter"
-            type: "double"
-          - name: "h"
-            type: "ool.emplateWriter<er.ame,or.pComparator<dLine.Definitions.sitorResolverDef>>"
-          - name: "lComparator"
-            type: "int"
   - fullname: "nInstance"
     name: "nInstance"
     visibility: "private"
@@ -9843,22 +5270,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "ry"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "CloneComposer"
         visibility: "internal"
         abstract: false
@@ -9868,44 +5283,6 @@ classes:
         return_type: "dLine.Definitions.xporter"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "deFactory"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "ble"
-            type: "object[]"
-          - name: "fineComparator"
-            type: "bool"
-          - name: "r"
-            type: "float"
-          - name: "parator"
-            type: "ref void"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "onException"
-            type: "or.pComparator<r>"
-          - name: "ection"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
-          - name: "stem.Reflection"
-            type: "void"
-          - name: "CheckComparator"
-            type: "ners.der"
-          - name: "ble"
-            type: "byte"
-          - name: "rototype"
-            type: "long"
       - name: "teFactory"
         visibility: "internal"
         abstract: false
@@ -9932,7 +5309,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -9945,18 +5322,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "rruptFactory"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "char"
   - fullname: "e.Builder"
     name: "Builder"
     namespace: "e"
@@ -9990,22 +5355,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ceOption.rviceFieldDic"
-    methods:
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
   - fullname: "chant.ScriptExecutionResult"
     name: "ScriptExecutionResult"
     namespace: "chant"
@@ -10015,22 +5367,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ScopeInitInfo.eterCandidate"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "erSerializer.efineProxy<r>"
   - fullname: "ueType.nResult"
     name: "nResult"
     namespace: "ueType"
@@ -10052,136 +5391,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 7
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "reComposer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "char"
-      - name: "rderFactory"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "h"
-            type: "byte"
-          - name: "lComparator"
-            type: "object[]"
-          - name: "CheckComparator"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "re"
-            type: "ref void"
-          - name: "erFactory"
-            type: "void"
-          - name: "ulateConsumer"
-            type: "or.pComparator<r>"
-          - name: "RestartComposer"
-            type: "o.or"
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "uptProxy"
-            type: "void"
-          - name: "sEnumerable"
-            type: "ners.der"
-          - name: "le"
-            type: "byte"
-          - name: "omposer"
-            type: "long"
-      - name: "y"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "h"
-            type: "byte"
-          - name: "lComparator"
-            type: "object[]"
-          - name: "CheckComparator"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "re"
-            type: "ref void"
-          - name: "erFactory"
-            type: "void"
-          - name: "ulateConsumer"
-            type: "or.pComparator<r>"
-          - name: "RestartComposer"
-            type: "o.or"
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "uptProxy"
-            type: "void"
-          - name: "sEnumerable"
-            type: "ners.der"
-          - name: "le"
-            type: "byte"
-          - name: "omposer"
-            type: "long"
-      - name: "ry"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "h"
-            type: "byte"
-          - name: "lComparator"
-            type: "object[]"
-          - name: "CheckComparator"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "re"
-            type: "ref void"
-          - name: "erFactory"
-            type: "void"
-          - name: "ulateConsumer"
-            type: "or.pComparator<r>"
-          - name: "RestartComposer"
-            type: "o.or"
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "uptProxy"
-            type: "void"
-          - name: "sEnumerable"
-            type: "ners.der"
-          - name: "le"
-            type: "byte"
-          - name: "omposer"
-            type: "long"
       - name: ""
         visibility: "internal"
         abstract: false
@@ -10203,44 +5416,6 @@ classes:
         return_type: "or.pe<erSerializer.Prototype<dLine.Definitions.sitorResolverDef,.Dictionaries.icy<andLine.Producers.VsExportSharingPolicy>>>"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "ry"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "h"
-            type: "byte"
-          - name: "lComparator"
-            type: "object[]"
-          - name: "CheckComparator"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "re"
-            type: "ref void"
-          - name: "erFactory"
-            type: "void"
-          - name: "ulateConsumer"
-            type: "or.pComparator<r>"
-          - name: "RestartComposer"
-            type: "o.or"
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "uptProxy"
-            type: "void"
-          - name: "sEnumerable"
-            type: "ners.der"
-          - name: "le"
-            type: "byte"
-          - name: "omposer"
-            type: "long"
   - fullname: "ter"
     name: "ter"
     visibility: "private"
@@ -10249,22 +5424,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "eatorExporter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lComparator"
-            type: "char"
   - fullname: "ool.ter"
     name: "ter"
     namespace: "ool"
@@ -10298,7 +5460,7 @@ classes:
     sealed: true
     number_of_base_types: 6
     number_of_generic_parameters: 0
-    number_of_methods: 6
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
       - "or.get_Item3"
@@ -10307,18 +5469,6 @@ classes:
       - "erSerializer.tor"
       - "o."
     methods:
-      - name: "etFactory"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "xOfitem"
         visibility: "internal"
         abstract: false
@@ -10361,82 +5511,6 @@ classes:
             type: "bool"
           - name: "esult"
             type: "short"
-      - name: "m"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: "ngleton"
-            type: "object[]"
-          - name: "esult"
-            type: "bool"
-          - name: "nfo"
-            type: "float"
-          - name: "bleComposer"
-            type: "ref void"
-          - name: "uptProxy"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "ception"
-            type: "o.or"
-          - name: "ion`2"
-            type: "byte"
-          - name: "rSingleton"
-            type: "long"
-          - name: "rSingleton"
-            type: "void"
-          - name: "erSingleton"
-            type: "ners.der"
-          - name: "e"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
-      - name: "ewSystem"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: "ngleton"
-            type: "object[]"
-          - name: "esult"
-            type: "bool"
-          - name: "nfo"
-            type: "float"
-          - name: "bleComposer"
-            type: "ref void"
-          - name: "uptProxy"
-            type: "void"
-          - name: "esult"
-            type: "or.pComparator<r>"
-          - name: "ception"
-            type: "o.or"
-          - name: "ion`2"
-            type: "byte"
-          - name: "rSingleton"
-            type: "long"
-          - name: "rSingleton"
-            type: "void"
-          - name: "erSingleton"
-            type: "ners.der"
-          - name: "e"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
   - fullname: "r"
     name: "r"
     visibility: "private"
@@ -10456,7 +5530,7 @@ classes:
     sealed: true
     number_of_base_types: 6
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "or.get_Item3"
@@ -10464,95 +5538,6 @@ classes:
       - "or._Item4"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "m"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "esult"
-            type: "char"
-      - name: "m"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "bleComposer"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "esult"
-            type: "ref void"
-          - name: "ception"
-            type: "void"
-          - name: "ion`2"
-            type: "or.pComparator<r>"
-          - name: "rSingleton"
-            type: "o.or"
-          - name: "rSingleton"
-            type: "byte"
-          - name: "erSingleton"
-            type: "long"
-          - name: "e"
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: ""
-            type: "byte"
-          - name: "parator"
-            type: "long"
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "esult"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "bleComposer"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "esult"
-            type: "ref void"
-          - name: "ception"
-            type: "void"
-          - name: "ion`2"
-            type: "or.pComparator<r>"
-          - name: "rSingleton"
-            type: "o.or"
-          - name: "rSingleton"
-            type: "byte"
-          - name: "erSingleton"
-            type: "long"
-          - name: "e"
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: ""
-            type: "byte"
-          - name: "parator"
-            type: "long"
   - fullname: "ter"
     name: "ter"
     visibility: "private"
@@ -10561,22 +5546,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
   - fullname: "Pool"
     name: "Pool"
     visibility: "private"
@@ -10585,7 +5557,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -10601,18 +5573,6 @@ classes:
         parameters:
           - name: "esult"
             type: "or.pComparator<string>"
-      - name: "udeSystem"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ception"
-            type: "char"
       - name: "vertComposer"
         visibility: "internal"
         abstract: false
@@ -10670,7 +5630,7 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "ool.tory"
@@ -10678,18 +5638,6 @@ classes:
       - "CommandLine.Listeners"
       - "erpreterCandidate.ectionResolver"
     methods:
-      - name: "mplate"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rSingleton"
-            type: "char"
       - name: "CurrentThread"
         visibility: "internal"
         abstract: false
@@ -10720,26 +5668,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "ool.tory"
       - "bool"
       - "CommandLine.Listeners"
       - "erpreterCandidate.ectionResolver"
-    methods:
-      - name: "el"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "erSingleton"
-            type: "char"
   - fullname: "torContainerModel"
     name: "torContainerModel"
     visibility: "internal"
@@ -10748,7 +5683,7 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "ool.tory"
@@ -10756,18 +5691,6 @@ classes:
       - "CommandLine.Listeners"
       - "erpreterCandidate.ectionResolver"
     methods:
-      - name: "ystem"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
       - name: "SearchTemplate"
         visibility: "internal"
         abstract: false
@@ -10830,7 +5753,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -10848,56 +5771,6 @@ classes:
             type: "ool.lectionTemplateWriter"
           - name: "stem.Reflection"
             type: "int"
-      - name: "rySingleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "rtProxy"
-            type: "object[]"
-          - name: "tor"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: "eflectComparator"
-            type: "ref void"
-          - name: "vePrototype"
-            type: "void"
-          - name: "ser"
-            type: "or.pComparator<r>"
-          - name: "config"
-            type: "o.or"
-          - name: "arator"
-            type: "byte"
-          - name: "CheckComparator"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "esolveSystem"
-            type: "ners.der"
-          - name: ""
-            type: "byte"
-          - name: "Template"
-            type: "long"
-      - name: "isableSystem"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
   - fullname: "sageSingleton"
     name: "sageSingleton"
     visibility: "internal"
@@ -10906,7 +5779,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -10919,18 +5792,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "on"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "ImporterSingleton"
     name: "ImporterSingleton"
     visibility: "internal"
@@ -10939,7 +5800,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -10952,18 +5813,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "sterTemplate"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
   - fullname: "ssuerStrategyExporter"
     name: "ssuerStrategyExporter"
     visibility: "internal"
@@ -10972,7 +5821,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -10990,18 +5839,6 @@ classes:
             type: "bool"
           - name: "SingleOrDefault"
             type: "int"
-      - name: "pe"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "tor"
-            type: "char"
       - name: "or"
         visibility: "internal"
         abstract: false
@@ -11022,22 +5859,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "CollectRecord"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "rrorInterpreterCandidate"
     name: "rrorInterpreterCandidate"
     visibility: "private"
@@ -11117,22 +5941,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 2
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "Record"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stem.Reflection"
-            type: "char"
       - name: "ord"
         visibility: "internal"
         abstract: false
@@ -11191,22 +6003,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
-    methods:
-      - name: "teSingleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "uptProxy"
-            type: "char"
   - fullname: "ners.cationContainerSerializer"
     name: "cationContainerSerializer"
     namespace: "ners"
@@ -11216,7 +6015,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -11229,18 +6028,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "\342\200\201\342\200\202\342\200\205\006"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "hTemplate"
-            type: "char"
   - fullname: "er"
     name: "er"
     visibility: "private"
@@ -11287,7 +6074,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 11
+    number_of_methods: 4
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -11359,246 +6146,6 @@ classes:
             type: "bool"
           - name: "lComparator"
             type: "short"
-      - name: "e"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "config"
-            type: "char"
-      - name: "ord"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "m"
-            type: "float"
-          - name: "ption"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "mparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "RateComparator"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "fo"
-            type: "long"
-      - name: "cord"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "m"
-            type: "float"
-          - name: "ption"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "mparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "RateComparator"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "fo"
-            type: "long"
-      - name: "Record"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "m"
-            type: "float"
-          - name: "ption"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "mparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "RateComparator"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "fo"
-            type: "long"
-      - name: "rd"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "m"
-            type: "float"
-          - name: "ption"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "mparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "RateComparator"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "fo"
-            type: "long"
-      - name: "d"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "m"
-            type: "float"
-          - name: "ption"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "mparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "RateComparator"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "fo"
-            type: "long"
-      - name: "ord"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "config"
-            type: "byte"
-          - name: ""
-            type: "object[]"
-          - name: "lComparator"
-            type: "bool"
-          - name: "m"
-            type: "float"
-          - name: "ption"
-            type: "ref void"
-          - name: "arator"
-            type: "void"
-          - name: "mparator"
-            type: "or.pComparator<r>"
-          - name: "esult"
-            type: "o.or"
-          - name: "r"
-            type: "byte"
-          - name: "RateComparator"
-            type: "long"
-          - name: "rototype"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rtProxy"
-            type: "byte"
-          - name: "fo"
-            type: "long"
   - fullname: "verDef"
     name: "verDef"
     visibility: "private"
@@ -11702,24 +6249,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "dgeSingleton"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "r"
-            type: "r"
-          - name: "Pool"
-            type: "r"
   - fullname: "ainerSerializer"
     name: "ainerSerializer"
     visibility: "public"
@@ -11728,22 +6260,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ateWriter.terProperty"
-    methods:
-      - name: "gleton"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "onException"
-            type: "char"
   - fullname: "ners.reterCandidate"
     name: "reterCandidate"
     namespace: "ners"
@@ -11753,22 +6272,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: ""
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "andLine.Producers.VsExportSharingPolicy"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rtProxy"
-            type: "r"
   - fullname: "okenInterpreterCandidate"
     name: "okenInterpreterCandidate"
     visibility: "private"
@@ -11777,23 +6283,10 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.zer"
       - "utePrototype.rverSingleton"
-    methods:
-      - name: "d"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "r"
-            type: "char"
   - fullname: "ate"
     name: "ate"
     visibility: "private"
@@ -11802,23 +6295,10 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.zer"
       - "utePrototype.rverSingleton"
-    methods:
-      - name: "dService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "lComparator"
-            type: "char"
   - fullname: "mplateService"
     name: "mplateService"
     visibility: "private"
@@ -11827,23 +6307,10 @@ classes:
     sealed: true
     number_of_base_types: 2
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.zer"
       - "utePrototype.rverSingleton"
-    methods:
-      - name: "pService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "ool.tainerSerializer"
     name: "tainerSerializer"
     namespace: "ool"
@@ -11853,22 +6320,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
-    methods:
-      - name: "outService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "ool.zer"
     name: "zer"
     namespace: "ool"
@@ -11878,22 +6332,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
-    methods:
-      - name: "anageService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "ototypeAuth"
     name: "ototypeAuth"
     visibility: "internal"
@@ -11902,7 +6343,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -11924,132 +6365,6 @@ classes:
             type: "bool"
           - name: "stem.Reflection"
             type: "short"
-      - name: "terruptField"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
-      - name: "untService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: "rtProxy"
-            type: "object[]"
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "SearchComparator"
-            type: "ref void"
-          - name: "ption"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: "stomizeService"
-            type: "o.or"
-          - name: "eField"
-            type: "byte"
-          - name: "wField"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rototype"
-            type: "byte"
-          - name: "d"
-            type: "long"
-      - name: "InvokeService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: "rtProxy"
-            type: "object[]"
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "SearchComparator"
-            type: "ref void"
-          - name: "ption"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: "stomizeService"
-            type: "o.or"
-          - name: "eField"
-            type: "byte"
-          - name: "wField"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rototype"
-            type: "byte"
-          - name: "d"
-            type: "long"
-      - name: "rvice"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "e"
-            type: "byte"
-          - name: "rtProxy"
-            type: "object[]"
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: "uptProxy"
-            type: "float"
-          - name: "SearchComparator"
-            type: "ref void"
-          - name: "ption"
-            type: "void"
-          - name: "ble"
-            type: "or.pComparator<r>"
-          - name: "stomizeService"
-            type: "o.or"
-          - name: "eField"
-            type: "byte"
-          - name: "wField"
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "ception"
-            type: "ners.der"
-          - name: "rototype"
-            type: "byte"
-          - name: "d"
-            type: "long"
   - fullname: "GetterSetterMap"
     name: "GetterSetterMap"
     visibility: "private"
@@ -12107,7 +6422,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -12120,18 +6435,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "ateService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "stomizeService"
-            type: "char"
   - fullname: "ScopeInitInfo.date"
     name: "date"
     namespace: "ScopeInitInfo"
@@ -12153,7 +6456,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 4
+    number_of_methods: 2
     base_types:
       - "erSerializer.roperty"
     methods:
@@ -12175,56 +6478,6 @@ classes:
             type: "bool"
           - name: "stem.Reflection"
             type: "short"
-      - name: "FindFilter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
-      - name: "hangeService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "onException"
-            type: "object[]"
-          - name: "stem.Reflection"
-            type: "bool"
-          - name: ""
-            type: "float"
-          - name: ""
-            type: "ref void"
-          - name: "5"
-            type: "void"
-          - name: "r"
-            type: "or.pComparator<r>"
-          - name: "omparator"
-            type: "o.or"
-          - name: "parator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "lComparator"
-            type: "void"
-          - name: "stem.Reflection"
-            type: "ners.der"
-          - name: "eflectComparator"
-            type: "byte"
-          - name: "stem.Reflection"
-            type: "long"
       - name: "riteService"
         visibility: "internal"
         abstract: false
@@ -12270,7 +6523,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 6
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -12300,94 +6553,6 @@ classes:
             type: "er.roxy"
           - name: "5"
             type: "ushort"
-      - name: "r"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: ""
-            type: "bool"
-          - name: "lComparator"
-            type: "float"
-          - name: "stem.Reflection"
-            type: "ref void"
-          - name: "eflectComparator"
-            type: "void"
-          - name: "stem.Reflection"
-            type: "or.pComparator<r>"
-          - name: "ice"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: "r"
-            type: "long"
-          - name: "r"
-            type: "void"
-          - name: "rimStart"
-            type: "ners.der"
-          - name: "ble"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
-      - name: "r"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
-      - name: "atchService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "parator"
-            type: "object[]"
-          - name: ""
-            type: "bool"
-          - name: "lComparator"
-            type: "float"
-          - name: "stem.Reflection"
-            type: "ref void"
-          - name: "eflectComparator"
-            type: "void"
-          - name: "stem.Reflection"
-            type: "or.pComparator<r>"
-          - name: "ice"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: "r"
-            type: "long"
-          - name: "r"
-            type: "void"
-          - name: "rimStart"
-            type: "ners.der"
-          - name: "ble"
-            type: "byte"
-          - name: "rtProxy"
-            type: "long"
       - name: "CancelService"
         visibility: "internal"
         abstract: false
@@ -12414,7 +6579,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -12432,18 +6597,6 @@ classes:
             type: "erSerializer.estComparator"
           - name: "stem.Reflection"
             type: "uint"
-      - name: "ilter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "eflectComparator"
-            type: "char"
   - fullname: "y"
     name: "y"
     visibility: "private"
@@ -12452,7 +6605,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 21
+    number_of_methods: 14
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -12642,170 +6795,6 @@ classes:
             type: "or.pComparator<ool.erPrototype>"
           - name: "nfo"
             type: "ScopeInitInfo.eterCandidate"
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "on"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "tatus"
-            type: "long"
-      - name: "ter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rator"
-            type: "char"
-      - name: "StartService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "on"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "tatus"
-            type: "long"
-      - name: "itService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "on"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "tatus"
-            type: "long"
-      - name: "isterService"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "on"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "tatus"
-            type: "long"
       - name: "AssetService"
         visibility: "internal"
         abstract: false
@@ -12815,82 +6804,6 @@ classes:
         return_type: "or.pe<erSerializer.Prototype<dLine.Definitions.sitorResolverDef,.Dictionaries.icy<andLine.Producers.VsExportSharingPolicy>>>"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "rvice"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "on"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "tatus"
-            type: "long"
-      - name: "atus"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "rator"
-            type: "byte"
-          - name: "nfo"
-            type: "object[]"
-          - name: "uptProxy"
-            type: "bool"
-          - name: "parator"
-            type: "float"
-          - name: "onException"
-            type: "ref void"
-          - name: "onException"
-            type: "void"
-          - name: "eflectComparator"
-            type: "or.pComparator<r>"
-          - name: "on"
-            type: "o.or"
-          - name: "lComparator"
-            type: "byte"
-          - name: ""
-            type: "long"
-          - name: "parator"
-            type: "void"
-          - name: "rator"
-            type: "ners.der"
-          - name: "stem.Reflection"
-            type: "byte"
-          - name: "tatus"
-            type: "long"
   - fullname: "erConfiguration"
     name: "erConfiguration"
     visibility: "private"
@@ -12922,7 +6835,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 4
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -12982,18 +6895,6 @@ classes:
             type: "string"
           - name: "parator"
             type: "int"
-      - name: "ListSetter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "char"
   - fullname: ".Dictionaries.ingletonInstance"
     name: "ingletonInstance"
     namespace: ".Dictionaries"
@@ -13003,7 +6904,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 3
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -13037,30 +6938,6 @@ classes:
             type: "erSerializer.Comparator"
           - name: "ser"
             type: "long"
-      - name: "riteSetter"
-        visibility: "public"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "erSerializer.mparator<r,r,r>"
-      - name: "ontainer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
       - name: "r"
         visibility: "internal"
         abstract: false
@@ -13087,26 +6964,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "void"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "iner"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
   - fullname: "PrinterConfiguration"
     name: "PrinterConfiguration"
     visibility: "private"
@@ -13138,26 +7002,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "void"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "\342\200\205\016"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "arator"
-            type: "char"
   - fullname: "alContainerSerializer"
     name: "alContainerSerializer"
     visibility: "private"
@@ -13166,26 +7017,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "void"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "\002"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "char"
   - fullname: "alizer"
     name: "alizer"
     visibility: "private"
@@ -13194,24 +7032,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "areSetter"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "or.pComparator<or.er<int,r>>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 2
-        parameters:
-          - name: "parator"
-            type: "or.pComparator<r>"
-          - name: "nit"
-            type: "int"
   - fullname: "etterResolver"
     name: "etterResolver"
     visibility: "private"
@@ -13220,7 +7043,7 @@ classes:
     sealed: true
     number_of_base_types: 4
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
@@ -13236,18 +7059,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "\342\200\205\016"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "Resolver"
-            type: "char"
   - fullname: "nterpreterCandidate"
     name: "nterpreterCandidate"
     visibility: "private"
@@ -13256,26 +7067,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "void"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "\342\200\205\010"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "ionResolver"
-            type: "char"
   - fullname: "trategyExporter"
     name: "trategyExporter"
     visibility: "private"
@@ -13284,26 +7082,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "void"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "\342\200\205\016"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "eProducer"
     name: "eProducer"
     visibility: "private"
@@ -13312,22 +7097,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "er"
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "h"
-            type: "short"
   - fullname: "tionConfigurationConsumer"
     name: "tionConfigurationConsumer"
     visibility: "private"
@@ -13336,26 +7108,13 @@ classes:
     sealed: true
     number_of_base_types: 5
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
       - "void"
       - "erSerializer.tor"
       - "o."
-    methods:
-      - name: "\342\200\205\016"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "Resolver"
-            type: "char"
   - fullname: "nsumer"
     name: "nsumer"
     visibility: "private"
@@ -13364,7 +7123,7 @@ classes:
     sealed: true
     number_of_base_types: 4
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
       - "o.or"
@@ -13383,18 +7142,6 @@ classes:
         parameters:
           - name: "nfo"
             type: "string"
-      - name: "\342\200\205\003"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "erpreterCandidate.ectionResolver"
     name: "ectionResolver"
     namespace: "erpreterCandidate"
@@ -13428,7 +7175,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -13441,18 +7188,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "e"
-            type: "char"
   - fullname: "e.PrototypeAuth"
     name: "PrototypeAuth"
     namespace: "e"
@@ -13462,7 +7197,7 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
@@ -13475,18 +7210,6 @@ classes:
         return_type: "void"
         number_of_generic_parameters: 0
         number_of_parameters: 0
-      - name: "suerResolver"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "parator"
-            type: "char"
   - fullname: "dLine.Definitions.HelperResolver"
     name: "HelperResolver"
     namespace: "dLine.Definitions"
@@ -13496,22 +7219,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ScopeInitInfo.eterCandidate"
-    methods:
-      - name: "sitContainer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "erpreterCandidate.Resolver"
     name: "Resolver"
     namespace: "erpreterCandidate"
@@ -13545,22 +7255,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "ceOption.rviceFieldDic"
-    methods:
-      - name: "tParameter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "config"
-            type: "char"
   - fullname: "ocationFilterProperty.ntry"
     name: "ntry"
     namespace: "ocationFilterProperty"
@@ -13570,34 +7267,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 2
+    number_of_methods: 0
     base_types:
       - "object"
-    methods:
-      - name: ""
-        visibility: "internal"
-        abstract: false
-        static: false
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "erSerializer.efineProxy<r>"
-      - name: "rameter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "ool.base"
     name: "base"
     namespace: "ool"
@@ -13607,22 +7279,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "andLine.Producers.VsExportSharingPolicy"
-    methods:
-      - name: "ameter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "nfo"
-            type: "char"
   - fullname: "ool.er"
     name: "er"
     namespace: "ool"
@@ -13643,60 +7302,10 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 3
+    number_of_methods: 1
     base_types:
       - "erSerializer.ContainerSerializer"
     methods:
-      - name: "GetContainer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "omparator"
-            type: "char"
-      - name: "AddParameter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "omparator"
-            type: "byte"
-          - name: "r"
-            type: "object[]"
-          - name: "rototype"
-            type: "bool"
-          - name: "ePool"
-            type: "float"
-          - name: "var12"
-            type: "ref void"
-          - name: "rototype"
-            type: "void"
-          - name: "tainer"
-            type: "or.pComparator<r>"
-          - name: "ble"
-            type: "o.or"
-          - name: "config"
-            type: "byte"
-          - name: "tainer"
-            type: "long"
-          - name: ""
-            type: "void"
-          - name: "omparator"
-            type: "ners.der"
-          - name: "P_12"
-            type: "byte"
-          - name: "P_13"
-            type: "long"
       - name: "arameter"
         visibility: "internal"
         abstract: false
@@ -13736,22 +7345,9 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.roperty"
-    methods:
-      - name: "tParameter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "rototype"
-            type: "char"
   - fullname: "e.olver"
     name: "olver"
     namespace: "e"
@@ -13761,7 +7357,7 @@ classes:
     sealed: false
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 5
+    number_of_methods: 3
     base_types:
       - "erSerializer.roperty"
     methods:
@@ -13792,56 +7388,6 @@ classes:
             type: "bool"
           - name: "P_3"
             type: "short"
-      - name: "ntainer"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "P_0"
-            type: "char"
-      - name: "ameter"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "or.pComparator<ueType.ieldResolverStructBuilder>"
-        number_of_generic_parameters: 0
-        number_of_parameters: 14
-        parameters:
-          - name: "P_0"
-            type: "byte"
-          - name: "P_1"
-            type: "object[]"
-          - name: "P_2"
-            type: "bool"
-          - name: "P_3"
-            type: "float"
-          - name: "P_4"
-            type: "ref void"
-          - name: "P_5"
-            type: "void"
-          - name: "P_6"
-            type: "or.pComparator<r>"
-          - name: "P_7"
-            type: "o.or"
-          - name: "P_8"
-            type: "byte"
-          - name: "P_9"
-            type: "long"
-          - name: "P_10"
-            type: "void"
-          - name: "P_11"
-            type: "ners.der"
-          - name: "P_12"
-            type: "byte"
-          - name: "P_13"
-            type: "long"
       - name: "Parameter"
         visibility: "internal"
         abstract: false
@@ -13864,19 +7410,6 @@ classes:
     sealed: true
     number_of_base_types: 1
     number_of_generic_parameters: 0
-    number_of_methods: 1
+    number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-    methods:
-      - name: "e49abd49f6889ae7d89496b20f"
-        visibility: "internal"
-        abstract: false
-        static: true
-        virtual: false
-        final: false
-        return_type: "r"
-        number_of_generic_parameters: 0
-        number_of_parameters: 1
-        parameters:
-          - name: "P_0"
-            type: "char"

--- a/yara-x/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
+++ b/yara-x/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
@@ -12085,7 +12085,7 @@ classes:
           - name: "stomizeService"
             type: "dLine.Definitions.solverDef<erSerializer.estComparator,object[]>"
           - name: "eField"
-            type: "erSerializer.Prototype<ototypeAuth,erSerializer.estComparator>[0...667,19...20,1...18,19...127,2...30,14...41,7...13,2...11,21...22,18...35,1068...2127,3...20,19...127,0...10,19...39,1...18,19...1086,2...4,,,]"
+            type: "erSerializer.Prototype<ototypeAuth,erSerializer.estComparator>[0...667,-55...-54,-64...-47,-55...53,1...29,7...34,-61...-55,1...10,-54...-53,9...26,534...1593,-63...-46,-55...53,0...10,-55...-35,-64...-47,-55...1012,1...3,,,]"
           - name: "wField"
             type: "byte"
           - name: "lComparator"

--- a/yara-x/src/modules/dotnet/tests/testdata/984750efd1cb94e5ca7b366863af2092af954dad65df534bff603b9afcb49cd4.out
+++ b/yara-x/src/modules/dotnet/tests/testdata/984750efd1cb94e5ca7b366863af2092af954dad65df534bff603b9afcb49cd4.out
@@ -844,7 +844,7 @@ classes:
         static: true
         virtual: false
         final: false
-        return_type: "System.Threading.Tasks.Task<TResult>"
+        return_type: "System.Threading.Tasks.Task<T>"
         number_of_generic_parameters: 1
         number_of_parameters: 4
         generic_parameters:
@@ -926,7 +926,7 @@ classes:
         static: true
         virtual: false
         final: false
-        return_type: "System.Threading.Tasks.Task<TResult>"
+        return_type: "System.Threading.Tasks.Task<T>"
         number_of_generic_parameters: 1
         number_of_parameters: 3
         generic_parameters:


### PR DESCRIPTION
Fix issues in `dotnet` module, specifically:

* Parsing of array dimensions was incorrect because low boundaries were parsed as unsigned variable-length integers, and they are *signed*.

* Generic arguments in classes and method were not properly handled. 