### PR TITLE
chore: Fix deprecated node12 warnings in actions workflows

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.71.0
       with:
         components: clippy
@@ -17,7 +17,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.71.0
       with:
         components: rustfmt
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Install nightly toolchain
       uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -13,7 +13,7 @@ jobs:
       CARGO_TERM_COLOR: always
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -44,7 +44,7 @@ jobs:
       matrix:
         target: [x64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -68,7 +68,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      
+
       - name: Run cargo test
         run: cargo test --all-targets ${{ matrix.args }}
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,12 +89,9 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-
+      
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-targets ${{ matrix.args }}
+        run: cargo test --all-targets ${{ matrix.args }}
         env:
           RUSTFLAGS: -Awarnings # Allow all warnings
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup cache
         uses: actions/cache@v3


### PR DESCRIPTION
I've cleaned up all of the following messages in the GitHub Actions workflows output:

> The following actions uses node12 which is deprecated and will be forced to run on node16: `<specific action>`. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

[`actions-rs/cargo`](https://github.com/actions-rs/cargo) has been archived and is no longer maintained, plus we can run `cargo test` instead of relying on a GitHub Action to do so for us. 

The only one I could not clean up manually is the following:

> The following actions uses node12 which is deprecated and will be forced to run on node16: `aig787/cargo-udeps-action@v1`. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

I've opened an issue here and documented it occurring, there's a PR on the repo already submitted to fix it: https://github.com/aig787/cargo-udeps-action/issues/4

Before PR: 
<img width="1361" alt="image" src="https://github.com/VirusTotal/yara-x/assets/6127011/e13296ef-fed0-4484-a0b1-48e2b90a4b9a">

After PR:
<img width="1350" alt="image2" src="https://github.com/VirusTotal/yara-x/assets/6127011/9917d39e-876f-49ff-a8f8-c50b4cf8187c">
