### PR TITLE
feat: mach-o load command parsing features + fix bug

### DIFF
--- a/yara-x/src/modules/macho/mod.rs
+++ b/yara-x/src/modules/macho/mod.rs
@@ -1111,7 +1111,7 @@ fn parse_rpath_command(
         swap_rpath_command(&mut rp);
     }
 
-    let (input, path) = take(cmdsize - offset)(input)?;
+    let (input, path) = take(rp.cmdsize - rp.offset)(input)?;
 
     rp.path = path.into();
 

--- a/yara-x/src/modules/macho/mod.rs
+++ b/yara-x/src/modules/macho/mod.rs
@@ -2836,7 +2836,7 @@ fn ep_for_arch_subtype(
 }
 
 /// The function for checking if any dylib name present in the main Mach-O or embedded Mach-O files
-/// contain a dylib wit
+/// contain a dylib with the desired name
 ///
 /// # Arguments
 ///
@@ -2866,6 +2866,43 @@ fn dylibs_present(
         for dylib in file.dylibs.iter() {
             if dylib.name.as_ref().is_some_and(|name| {
                 expected_name.eq_ignore_ascii_case(name.as_bytes())
+            }) {
+                return Some(true);
+            }
+        }
+    }
+
+    Some(false)
+}
+
+/// The function for checking if any rpath present in the main Mach-O or embedded Mach-O files
+/// contain an rpath with the desired path
+///
+/// # Arguments
+///
+/// * `ctx`: A mutable reference to the scanning context.
+/// * `rpath`: The name of the dylib to check if present
+///
+/// # Returns
+///
+/// An `Option<bool>` containing if the path is found
+#[module_export(name = "rpath_present")]
+fn rpaths_present(ctx: &ScanContext, rpath: RuntimeString) -> Option<bool> {
+    let macho = ctx.module_output::<Macho>()?;
+    let expected_rpath = rpath.as_bstr(ctx);
+
+    for rp in macho.rpaths.iter() {
+        if rp.path.as_ref().is_some_and(|path| {
+            expected_rpath.eq_ignore_ascii_case(path.as_bytes())
+        }) {
+            return Some(true);
+        }
+    }
+
+    for file in macho.file.iter() {
+        for rp in file.rpaths.iter() {
+            if rp.path.as_ref().is_some_and(|path| {
+                expected_rpath.eq_ignore_ascii_case(path.as_bytes())
             }) {
                 return Some(true);
             }

--- a/yara-x/src/modules/macho/mod.rs
+++ b/yara-x/src/modules/macho/mod.rs
@@ -1696,7 +1696,6 @@ fn handle_dylib_command(
     // 24 bytes for all integer fields and offset in Dylib/DylibCommand
     // fat pointer of vec makes for inaccurate count
     if size < 24 {
-        dbg!("here, oopsie");
         return Err(MachoError::FileSectionTooSmall(
             "DylibCommand".to_string(),
         ));

--- a/yara-x/src/modules/macho/tests/mod.rs
+++ b/yara-x/src/modules/macho/tests/mod.rs
@@ -415,8 +415,12 @@ fn test_swap_entry_point_command() {
 
 #[test]
 fn test_macho_module() {
-    let macho_data = create_binary_from_zipped_ihex(
+    let tiny_universal_macho_data = create_binary_from_zipped_ihex(
         "src/modules/macho/tests/testdata/tiny_universal.in.zip",
+    );
+
+    let x86_macho_data = create_binary_from_zipped_ihex(
+        "src/modules/macho/tests/testdata/macho_x86_file.in.zip",
     );
 
     rule_true!(
@@ -469,7 +473,7 @@ fn test_macho_module() {
             macho.file_index_for_arch(0x00000007) == 0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -480,7 +484,7 @@ fn test_macho_module() {
             macho.file_index_for_arch(0x01000007) == 1
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_false!(
@@ -491,7 +495,7 @@ fn test_macho_module() {
             macho.file_index_for_arch(0x00000008) == 0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -513,7 +517,7 @@ fn test_macho_module() {
             macho.file_index_for_arch(0x00000007, 0x00000003) == 0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -524,7 +528,7 @@ fn test_macho_module() {
             macho.file_index_for_arch(16777223, 2147483651) == 1
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_false!(
@@ -535,7 +539,7 @@ fn test_macho_module() {
             macho.file_index_for_arch(0x00000008, 0x00000004) == 0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -546,7 +550,7 @@ fn test_macho_module() {
             not defined macho.file_index_for_arch(0x00000008, 0x00000004)
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -568,7 +572,7 @@ fn test_macho_module() {
             macho.entry_point_for_arch(0x00000007) == 0x00001EE0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -579,7 +583,7 @@ fn test_macho_module() {
             macho.entry_point_for_arch(0x01000007) == 0x00004EE0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -590,7 +594,7 @@ fn test_macho_module() {
             macho.entry_point_for_arch(0x00000007, 0x00000003) == 0x00001EE0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -601,7 +605,7 @@ fn test_macho_module() {
             macho.entry_point_for_arch(16777223, 2147483651) == 0x00004EE0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_false!(
@@ -612,7 +616,7 @@ fn test_macho_module() {
             macho.entry_point_for_arch(0x00000008, 0x00000003) == 0x00001EE0
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
     );
 
     rule_true!(
@@ -644,6 +648,38 @@ fn test_macho_module() {
                 macho.dylib_present("/usr/lib/libSystem.B.dylib")
         }
         "#,
-        &macho_data
+        &tiny_universal_macho_data
+    );
+
+    rule_false!(
+        r#"
+        import "macho"
+        rule test {
+            condition:
+                macho.rpath_present("totally not present rpath")
+        }
+        "#
+    );
+
+    rule_false!(
+        r#"
+        import "macho"
+        rule macho_test {
+            condition:
+                macho.rpath_present("@loader_path/../Frameworks")
+        }
+        "#,
+        &tiny_universal_macho_data
+    );
+
+    rule_true!(
+        r#"
+        import "macho"
+        rule macho_test {
+            condition:
+                macho.rpath_present("@loader_path/../Frameworks")
+        }
+        "#,
+        &x86_macho_data
     );
 }

--- a/yara-x/src/modules/macho/tests/mod.rs
+++ b/yara-x/src/modules/macho/tests/mod.rs
@@ -625,4 +625,25 @@ fn test_macho_module() {
         "#,
         &[]
     );
+
+    rule_false!(
+        r#"
+        import "macho"
+        rule test {
+            condition:
+                macho.dylib_present("totally not present dylib")
+        }
+        "#
+    );
+
+    rule_true!(
+        r#"
+        import "macho"
+        rule macho_test {
+            condition:
+                macho.dylib_present("/usr/lib/libSystem.B.dylib")
+        }
+        "#,
+        &macho_data
+    );
 }

--- a/yara-x/src/modules/macho/tests/testdata/tiny_universal.out
+++ b/yara-x/src/modules/macho/tests/testdata/tiny_universal.out
@@ -149,6 +149,7 @@ file:
         timestamp: 2 # 1970-01-01 00:00:02 UTC
         compatibility_version: "1.0.0"
         current_version: "1213.0.0"
+    dynamic_linker: "/usr/lib/dyld"
     entry_point: 3808
     stack_size: 0
   - magic: 0xfeedfacf
@@ -308,5 +309,6 @@ file:
         timestamp: 2 # 1970-01-01 00:00:02 UTC
         compatibility_version: "1.0.0"
         current_version: "1213.0.0"
+    dynamic_linker: "/usr/lib/dyld"
     entry_point: 3808
     stack_size: 0

--- a/yara-x/src/modules/macho/tests/testdata/tiny_universal.out
+++ b/yara-x/src/modules/macho/tests/testdata/tiny_universal.out
@@ -153,6 +153,25 @@ file:
     entry_point: 3808
     stack_size: 0
     source_version: "0.0.0.0.0"
+    dysymtab:
+        cmd: 11
+        cmdsize: 80
+        ilocalsym: 0
+        nlocalsym: 0
+        iextdefsym: 0
+        nextdefsym: 3
+        tocoff: 3
+        ntoc: 3
+        modtaboff: 0
+        nmodtab: 0
+        extrefsymoff: 0
+        nextrefsyms: 0
+        indirectsymoff: 0
+        nindirectsyms: 0
+        extreloff: 8416
+        nextrel: 6
+        locreloff: 0
+        nlocrel: 0
   - magic: 0xfeedfacf
     cputype: 16777223
     cpusubtype: 2147483651
@@ -314,3 +333,22 @@ file:
     entry_point: 3808
     stack_size: 0
     source_version: "0.0.0.0.0"
+    dysymtab:
+        cmd: 11
+        cmdsize: 80
+        ilocalsym: 0
+        nlocalsym: 0
+        iextdefsym: 0
+        nextdefsym: 3
+        tocoff: 3
+        ntoc: 3
+        modtaboff: 0
+        nmodtab: 0
+        extrefsymoff: 0
+        nextrefsyms: 0
+        indirectsymoff: 0
+        nindirectsyms: 0
+        extreloff: 8448
+        nextrel: 6
+        locreloff: 0
+        nlocrel: 0

--- a/yara-x/src/modules/macho/tests/testdata/tiny_universal.out
+++ b/yara-x/src/modules/macho/tests/testdata/tiny_universal.out
@@ -152,6 +152,7 @@ file:
     dynamic_linker: "/usr/lib/dyld"
     entry_point: 3808
     stack_size: 0
+    source_version: "0.0.0.0.0"
   - magic: 0xfeedfacf
     cputype: 16777223
     cpusubtype: 2147483651
@@ -312,3 +313,4 @@ file:
     dynamic_linker: "/usr/lib/dyld"
     entry_point: 3808
     stack_size: 0
+    source_version: "0.0.0.0.0"

--- a/yara-x/src/modules/modules.rs
+++ b/yara-x/src/modules/modules.rs
@@ -1,25 +1,25 @@
 // File generated automatically by build.rs. Do not edit.
-#[cfg(feature = "string-module")]
-mod string;
+#[cfg(feature = "test_proto2-module")]
+mod test_proto2;
 #[cfg(feature = "macho-module")]
 mod macho;
-#[cfg(feature = "pe-module")]
-mod pe;
-#[cfg(feature = "elf-module")]
-mod elf;
-#[cfg(feature = "text-module")]
-mod text;
-#[cfg(feature = "dotnet-module")]
-mod dotnet;
 #[cfg(feature = "lnk-module")]
 mod lnk;
 #[cfg(feature = "hash-module")]
 mod hash;
-#[cfg(feature = "math-module")]
-mod math;
-#[cfg(feature = "test_proto2-module")]
-mod test_proto2;
+#[cfg(feature = "text-module")]
+mod text;
 #[cfg(feature = "time-module")]
 mod time;
+#[cfg(feature = "dotnet-module")]
+mod dotnet;
 #[cfg(feature = "test_proto3-module")]
 mod test_proto3;
+#[cfg(feature = "pe-module")]
+mod pe;
+#[cfg(feature = "string-module")]
+mod string;
+#[cfg(feature = "elf-module")]
+mod elf;
+#[cfg(feature = "math-module")]
+mod math;

--- a/yara-x/src/modules/protos/macho.proto
+++ b/yara-x/src/modules/protos/macho.proto
@@ -23,6 +23,29 @@ message RPath {
   optional string path = 3;
 }
 
+message Dysymtab {
+  optional uint32 cmd = 1;
+  optional uint32 cmdsize = 2;
+  optional uint32 ilocalsym = 3;
+  optional uint32 nlocalsym = 4;
+  optional uint32 iextdefsym = 5;
+  optional uint32 nextdefsym = 6;
+  optional uint32 iundefsym = 7;
+  optional uint32 nundefsym = 8;
+  optional uint32 tocoff = 9;
+  optional uint32 ntoc = 10;
+  optional uint32 modtaboff = 11;
+  optional uint32 nmodtab = 12;
+  optional uint32 extrefsymoff = 13;
+  optional uint32 nextrefsyms = 14;
+  optional uint32 indirectsymoff = 15;
+  optional uint32 nindirectsyms = 16;
+  optional uint32 extreloff = 17;
+  optional uint32 nextrel = 18;
+  optional uint32 locreloff = 19;
+  optional uint32 nlocrel = 20;
+}
+
 message Section {
   optional string segname = 1;
   optional string sectname = 2;
@@ -79,6 +102,7 @@ message File {
   optional uint64 entry_point = 14;
   optional uint64 stack_size = 15;
   optional string source_version = 16;
+  optional Dysymtab dysymtab = 17;
 }
 
 message Macho {
@@ -99,15 +123,16 @@ message Macho {
   optional uint64 entry_point = 14;
   optional uint64 stack_size = 15;
   optional string source_version = 16;
+  optional Dysymtab dysymtab = 17;
 
 
   // Add fields for Mach-O fat binary header
-  optional uint32 fat_magic = 17 [(yaml.field).fmt = "x"];
-  optional uint32 nfat_arch = 18;
-  repeated FatArch fat_arch = 19;
+  optional uint32 fat_magic = 18 [(yaml.field).fmt = "x"];
+  optional uint32 nfat_arch = 19;
+  repeated FatArch fat_arch = 20;
 
   // Nested Mach-O files
-  repeated File file = 20;
+  repeated File file = 21;
 }
 
 enum HEADER {

--- a/yara-x/src/modules/protos/macho.proto
+++ b/yara-x/src/modules/protos/macho.proto
@@ -75,8 +75,9 @@ message File {
   repeated Segment segments = 10;
   repeated Dylib dylibs = 11;
   repeated RPath rpaths = 12;
-  optional uint64 entry_point = 13;
-  optional uint64 stack_size = 14;
+  optional string dynamic_linker = 13;
+  optional uint64 entry_point = 14;
+  optional uint64 stack_size = 15;
 }
 
 message Macho {
@@ -93,16 +94,17 @@ message Macho {
   repeated Segment segments = 10;
   repeated Dylib dylibs = 11;
   repeated RPath rpaths = 12;
-  optional uint64 entry_point = 13;
-  optional uint64 stack_size = 14;
+  optional string dynamic_linker = 13;
+  optional uint64 entry_point = 14;
+  optional uint64 stack_size = 15;
 
   // Add fields for Mach-O fat binary header
-  optional uint32 fat_magic = 15 [(yaml.field).fmt = "x"];
-  optional uint32 nfat_arch = 16;
-  repeated FatArch fat_arch = 17;
+  optional uint32 fat_magic = 16 [(yaml.field).fmt = "x"];
+  optional uint32 nfat_arch = 17;
+  repeated FatArch fat_arch = 18;
 
   // Nested Mach-O files
-  repeated File file = 18;
+  repeated File file = 19;
 }
 
 enum HEADER {

--- a/yara-x/src/modules/protos/macho.proto
+++ b/yara-x/src/modules/protos/macho.proto
@@ -78,6 +78,7 @@ message File {
   optional string dynamic_linker = 13;
   optional uint64 entry_point = 14;
   optional uint64 stack_size = 15;
+  optional string source_version = 16;
 }
 
 message Macho {
@@ -97,14 +98,16 @@ message Macho {
   optional string dynamic_linker = 13;
   optional uint64 entry_point = 14;
   optional uint64 stack_size = 15;
+  optional string source_version = 16;
+
 
   // Add fields for Mach-O fat binary header
-  optional uint32 fat_magic = 16 [(yaml.field).fmt = "x"];
-  optional uint32 nfat_arch = 17;
-  repeated FatArch fat_arch = 18;
+  optional uint32 fat_magic = 17 [(yaml.field).fmt = "x"];
+  optional uint32 nfat_arch = 18;
+  repeated FatArch fat_arch = 19;
 
   // Nested Mach-O files
-  repeated File file = 19;
+  repeated File file = 20;
 }
 
 enum HEADER {

--- a/yara-x/src/wasm/builder.rs
+++ b/yara-x/src/wasm/builder.rs
@@ -470,38 +470,38 @@ mod tests {
         assert_eq!(
             text,
             r#"(module
-  (func (;151;) (type 1) (result i32)
+  (func (;152;) (type 1) (result i32)
     i32.const 0
     global.set 2
     i32.const 0
     global.set 3
-    call 152
     call 153
+    call 154
     global.get 3
   )
-  (func (;152;) (type 0)
-    block ;; label = @1
-      call 154
-    end
+  (func (;153;) (type 0)
     block ;; label = @1
       call 155
     end
-  )
-  (func (;153;) (type 0)
     block ;; label = @1
       call 156
     end
   )
   (func (;154;) (type 0)
-    i32.const 4
+    block ;; label = @1
+      call 157
+    end
   )
   (func (;155;) (type 0)
-    i32.const 5
+    i32.const 4
   )
   (func (;156;) (type 0)
+    i32.const 5
+  )
+  (func (;157;) (type 0)
     i32.const 6
   )
-  (export "main" (func 151))
+  (export "main" (func 152))
 )"#
         );
     }

--- a/yara-x/src/wasm/builder.rs
+++ b/yara-x/src/wasm/builder.rs
@@ -470,38 +470,38 @@ mod tests {
         assert_eq!(
             text,
             r#"(module
-  (func (;150;) (type 1) (result i32)
+  (func (;151;) (type 1) (result i32)
     i32.const 0
     global.set 2
     i32.const 0
     global.set 3
-    call 151
     call 152
+    call 153
     global.get 3
   )
-  (func (;151;) (type 0)
-    block ;; label = @1
-      call 153
-    end
+  (func (;152;) (type 0)
     block ;; label = @1
       call 154
     end
-  )
-  (func (;152;) (type 0)
     block ;; label = @1
       call 155
     end
   )
   (func (;153;) (type 0)
-    i32.const 4
+    block ;; label = @1
+      call 156
+    end
   )
   (func (;154;) (type 0)
-    i32.const 5
+    i32.const 4
   )
   (func (;155;) (type 0)
+    i32.const 5
+  )
+  (func (;156;) (type 0)
     i32.const 6
   )
-  (export "main" (func 150))
+  (export "main" (func 151))
 )"#
         );
     }


### PR DESCRIPTION
- implemented LC_ID_DYLINKER, LC_LOAD_DYLINKER, and LC_DYLD_ENVIRONMENT load commands
- fixed bug in parsing for RPath and Dylibs where swap needed to occur before taking offset
- implemented search functions for rpath and dylibs with `macho.rpath_present` and `macho.dylib_present`
