### PR TITLE
feat: adds --test flag in yr fmt

### DIFF
--- a/yara-x-cli/src/commands/fmt.rs
+++ b/yara-x-cli/src/commands/fmt.rs
@@ -33,6 +33,8 @@ pub fn exec_fmt(args: &ArgMatches) -> anyhow::Result<()> {
     let formatter = Formatter::new();
 
     if let Some(files) = files {
+        let mut changed_files = Vec::new();
+
         for file in files {
             let input = fs::read(file.as_path())?;
 
@@ -44,7 +46,7 @@ pub fn exec_fmt(args: &ArgMatches) -> anyhow::Result<()> {
             let output = formatted.into_inner();
 
             if *test.unwrap() && input != output {
-                process::exit(3)
+                changed_files.push(file.display().to_string());
             }
 
             if *write.unwrap() {
@@ -52,6 +54,11 @@ pub fn exec_fmt(args: &ArgMatches) -> anyhow::Result<()> {
             } else {
                 print!("{}", String::from_utf8(output)?);
             };
+        }
+
+        if changed_files.len() >= 1 {
+            eprintln!("File(s) to format: {}", changed_files.join(", "));
+            process::exit(2)
         }
     } else {
         formatter.format(stdin(), stdout())?;


### PR DESCRIPTION
Adds -t/--test flag in yr fmt which returns an error code if formatting made changes on the file.

This feature exists in a few other language formatting tools ([jsonnet](https://github.com/google/go-jsonnet/blob/master/cmd/jsonnetfmt/cmd.go#L47-L48), [terraform](https://developer.hashicorp.com/terraform/cli/commands/fmt#check), [gofmt](https://github.com/golang/go/blob/master/src/cmd/gofmt/gofmt.go#L33)) which is useful as part of stylistic CI/CD checks