### PR TITLE
fix: add support for FAT Mach-O files in yr dump auto module selection

### DIFF
--- a/yara-x-cli/src/commands/dump.rs
+++ b/yara-x-cli/src/commands/dump.rs
@@ -127,7 +127,9 @@ pub fn exec_dump(args: &ArgMatches) -> anyhow::Result<()> {
         if !module_output.lnk.is_lnk() {
             module_output.lnk = MessageField::none()
         }
-        if !module_output.macho.has_magic() {
+        if !module_output.macho.has_magic()
+            && !module_output.macho.has_fat_magic()
+        {
             module_output.macho = MessageField::none()
         }
         if !module_output.pe.is_pe() {


### PR DESCRIPTION
Automatic module selection for `yr dump` command did not take into consideration, that FAT Mach-O files do not have `magic` field in top level and instead of it they have `fat_magic`. This PR fixes it and automatic module selection produces output for valid FAT Mach-O files without having to manually specify which module should it use.