### PR TITLE
feat: return error when the entrypoint keyword is used

### DIFF
--- a/yara-x/src/compiler/emit.rs
+++ b/yara-x/src/compiler/emit.rs
@@ -348,12 +348,6 @@ fn emit_expr(
             instr.global_get(ctx.wasm_symbols.filesize);
         }
 
-        Expr::Entrypoint { .. } => {
-            // TODO
-            // todo!()
-            instr.i64_const(0);
-        }
-
         Expr::Ident { symbol } => {
             match symbol.kind() {
                 SymbolKind::Rule(rule_id) => {

--- a/yara-x/src/compiler/errors.rs
+++ b/yara-x/src/compiler/errors.rs
@@ -219,10 +219,10 @@ pub enum CompileErrorInfo {
         note: Option<String>,
     },
 
-    #[error("`entrypoint` is deprecated`")]
-    #[label("the `entrypoint` keyword is deprecated", span)]
+    #[error("`entrypoint` is unsupported`")]
+    #[label("the `entrypoint` keyword is not supported anymore", span)]
     #[note(note)]
-    DeprecatedEntrypoint {
+    EntrypointUnsupported {
         detailed_report: String,
         span: Span,
         note: Option<String>,

--- a/yara-x/src/compiler/errors.rs
+++ b/yara-x/src/compiler/errors.rs
@@ -218,4 +218,13 @@ pub enum CompileErrorInfo {
         span: Span,
         note: Option<String>,
     },
+
+    #[error("`entrypoint` is deprecated`")]
+    #[label("the `entrypoint` keyword is deprecated", span)]
+    #[note(note)]
+    DeprecatedEntrypoint {
+        detailed_report: String,
+        span: Span,
+        note: Option<String>,
+    },
 }

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -208,7 +208,13 @@ pub(in crate::compiler) fn expr_from_ast(
     expr: &ast::Expr,
 ) -> Result<Expr, CompileError> {
     match expr {
-        ast::Expr::Entrypoint { .. } => Ok(Expr::Entrypoint),
+        ast::Expr::Entrypoint { span } => {
+            Err(CompileError::from(CompileErrorInfo::deprecated_entrypoint(
+                ctx.report_builder,
+                *span,
+                Some("use `pe.entry_point`, `elf.entry_point`".to_string()),
+            )))
+        }
         ast::Expr::Filesize { .. } => Ok(Expr::Filesize),
 
         ast::Expr::True { .. } => {

--- a/yara-x/src/compiler/ir/ast2ir.rs
+++ b/yara-x/src/compiler/ir/ast2ir.rs
@@ -209,10 +209,10 @@ pub(in crate::compiler) fn expr_from_ast(
 ) -> Result<Expr, CompileError> {
     match expr {
         ast::Expr::Entrypoint { span } => {
-            Err(CompileError::from(CompileErrorInfo::deprecated_entrypoint(
+            Err(CompileError::from(CompileErrorInfo::entrypoint_unsupported(
                 ctx.report_builder,
                 *span,
-                Some("use `pe.entry_point`, `elf.entry_point`".to_string()),
+                Some("use `pe.entry_point`, `elf.entry_point` or `macho.entry_point`".to_string()),
             )))
         }
         ast::Expr::Filesize { .. } => Ok(Expr::Filesize),

--- a/yara-x/src/compiler/ir/mod.rs
+++ b/yara-x/src/compiler/ir/mod.rs
@@ -281,8 +281,8 @@ pub(in crate::compiler) enum Expr {
         type_value: TypeValue,
     },
 
+    /// `filesize` expression.
     Filesize,
-    Entrypoint,
 
     /// Boolean `not` expression.
     Not {
@@ -690,7 +690,6 @@ impl Expr {
             }
 
             Expr::Filesize
-            | Expr::Entrypoint
             | Expr::PatternCount { .. }
             | Expr::PatternCountVar { .. }
             | Expr::PatternOffset { .. }
@@ -761,7 +760,6 @@ impl Expr {
             }
 
             Expr::Filesize
-            | Expr::Entrypoint
             | Expr::PatternCount { .. }
             | Expr::PatternCountVar { .. }
             | Expr::PatternOffset { .. }

--- a/yara-x/src/compiler/tests/errors.rs
+++ b/yara-x/src/compiler/tests/errors.rs
@@ -913,6 +913,26 @@ rule test {
 "#,
         ),
         ////////////////////////////////////////////////////////////
+        (
+            line!(),
+            r#"
+rule test {
+  condition:
+    entrypoint == 0x1000
+}
+"#,
+            r#"error: `entrypoint` is unsupported`
+   ╭─[line:4:5]
+   │
+ 4 │     entrypoint == 0x1000
+   │     ─────┬────  
+   │          ╰────── the `entrypoint` keyword is not supported anymore
+   │ 
+   │ Note: use `pe.entry_point`, `elf.entry_point` or `macho.entry_point`
+───╯
+"#,
+        ),
+        ////////////////////////////////////////////////////////////
         #[cfg(feature = "test_proto2-module")]
         (
             line!(),


### PR DESCRIPTION
This keyword was deprecated in YARA since long ago.