### PR TITLE
chore: Fix deprecated node16 warnings in actions workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,7 +27,7 @@ jobs:
       run: cargo llvm-cov --workspace --lib --lcov --output-path lcov.info
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: lcov.info
         fail_ci_if_error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
Similar problem to #66, except node16 is now deprecated.

Only action using node16 now is the `aig787/cargo-udeps-action` check:

I've created a PR to fix for the udeps action: https://github.com/aig787/cargo-udeps-action/pull/5