### PR TITLE
chore: rename macho module functions from x_present to has_x.

### DIFF
--- a/lib/src/modules/macho/mod.rs
+++ b/lib/src/modules/macho/mod.rs
@@ -185,8 +185,8 @@ fn ep_for_arch_subtype(
 /// Returns true if the Mach-O parsed entitlements contain `entitlement`
 ///
 /// `entitlement` is case-insensitive.
-#[module_export(name = "entitlement_present")]
-fn entitlements_present(
+#[module_export]
+fn has_entitlement(
     ctx: &ScanContext,
     entitlement: RuntimeString,
 ) -> Option<bool> {
@@ -213,11 +213,8 @@ fn entitlements_present(
 /// Returns true if the Mach-O parsed dylibs contain `dylib_name`
 ///
 /// `dylib_name` is case-insensitive.
-#[module_export(name = "dylib_present")]
-fn dylibs_present(
-    ctx: &ScanContext,
-    dylib_name: RuntimeString,
-) -> Option<bool> {
+#[module_export]
+fn has_dylib(ctx: &ScanContext, dylib_name: RuntimeString) -> Option<bool> {
     let macho = ctx.module_output::<Macho>()?;
     let expected_name = dylib_name.as_bstr(ctx);
 
@@ -245,8 +242,8 @@ fn dylibs_present(
 /// Returns true if the Mach-O parsed rpaths contain `rpath`
 ///
 /// `rpath` is case-insensitive.
-#[module_export(name = "rpath_present")]
-fn rpaths_present(ctx: &ScanContext, rpath: RuntimeString) -> Option<bool> {
+#[module_export]
+fn has_rpath(ctx: &ScanContext, rpath: RuntimeString) -> Option<bool> {
     let macho = ctx.module_output::<Macho>()?;
     let expected_rpath = rpath.as_bstr(ctx);
 

--- a/lib/src/modules/macho/parser.rs
+++ b/lib/src/modules/macho/parser.rs
@@ -124,7 +124,7 @@ impl<'a> MachO<'a> {
                 FAT_MAGIC | FAT_CIGAM | FAT_MAGIC_64 | FAT_CIGAM_64
             )
         })
-        .parse(data)?;
+            .parse(data)?;
 
         // The magic number indicates the endianness.
         let endianness = match magic {
@@ -203,7 +203,7 @@ impl<'a> MachO<'a> {
         let (remainder, magic) = verify(be_u32, |magic| {
             matches!(*magic, MH_MAGIC | MH_CIGAM | MH_MAGIC_64 | MH_CIGAM_64)
         })
-        .parse(data)?;
+            .parse(data)?;
 
         let endianness = match magic {
             MH_MAGIC | MH_MAGIC_64 => Endianness::Big,
@@ -228,14 +228,14 @@ impl<'a> MachO<'a> {
                 cond(!is_32_bits, u32(endianness)), // reserved, only in 64-bits
             )),
             |(
-                cputype,
-                cpusubtype,
-                filetype,
-                ncmds,
-                sizeofcmds,
-                flags,
-                reserved,
-            )| {
+                 cputype,
+                 cpusubtype,
+                 filetype,
+                 ncmds,
+                 sizeofcmds,
+                 flags,
+                 reserved,
+             )| {
                 MachOHeader {
                     magic,
                     cputype,
@@ -395,19 +395,19 @@ impl<'a> MachOFile<'a> {
                 cond(!self.is_32_bits, u32(self.endianness)), // reserved3
             )),
             |(
-                sectname,
-                segname,
-                addr,
-                size,
-                offset,
-                align,
-                reloff,
-                nreloc,
-                flags,
-                reserved1,
-                reserved2,
-                reserved3,
-            )| {
+                 sectname,
+                 segname,
+                 addr,
+                 size,
+                 offset,
+                 align,
+                 reloff,
+                 nreloc,
+                 flags,
+                 reserved1,
+                 reserved2,
+                 reserved3,
+             )| {
                 Section {
                     sectname,
                     segname,
@@ -686,23 +686,23 @@ impl<'a> MachOFile<'a> {
                 u32(self.endianness), //  nlocrel
             )),
             |(
-                ilocalsym,
-                nlocalsym,
-                iextdefsym,
-                nextdefsym,
-                tocoff,
-                ntoc,
-                modtaboff,
-                nmodtab,
-                extrefsymoff,
-                nextrefsyms,
-                indirectsymoff,
-                nindirectsyms,
-                extreloff,
-                nextrel,
-                locreloff,
-                nlocrel,
-            )| {
+                 ilocalsym,
+                 nlocalsym,
+                 iextdefsym,
+                 nextdefsym,
+                 tocoff,
+                 ntoc,
+                 modtaboff,
+                 nmodtab,
+                 extrefsymoff,
+                 nextrefsyms,
+                 indirectsymoff,
+                 nindirectsyms,
+                 extreloff,
+                 nextrel,
+                 locreloff,
+                 nlocrel,
+             )| {
                 Dysymtab {
                     ilocalsym,
                     nlocalsym,
@@ -884,17 +884,17 @@ impl<'a> MachOFile<'a> {
                 u32(self.endianness), //  export_size
             )),
             |(
-                rebase_off,
-                rebase_size,
-                bind_off,
-                bind_size,
-                weak_bind_off,
-                weak_bind_size,
-                lazy_bind_off,
-                lazy_bind_size,
-                export_off,
-                export_size,
-            )| {
+                 rebase_off,
+                 rebase_size,
+                 bind_off,
+                 bind_size,
+                 weak_bind_off,
+                 weak_bind_size,
+                 lazy_bind_off,
+                 lazy_bind_size,
+                 export_off,
+                 export_size,
+             )| {
                 DyldInfo {
                     rebase_off,
                     rebase_size,
@@ -958,7 +958,7 @@ impl<'a> MachOFile<'a> {
     ) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], BuildVersionCommand> + '_
     {
         move |input: &'a [u8]| {
-            let (mut remainder, (platform, minos, sdk, ntools)) =
+            let (remainder, (platform, minos, sdk, ntools)) =
                 tuple((
                     u32(self.endianness), // platform,
                     u32(self.endianness), // minos,
@@ -966,18 +966,16 @@ impl<'a> MachOFile<'a> {
                     u32(self.endianness), // ntools,
                 ))(input)?;
 
-            let mut tools = Vec::<BuildToolObject>::new();
-
-            for _ in 0..ntools {
-                let (data, (tool, version)) = tuple((
-                    u32(self.endianness), // tool,
-                    u32(self.endianness), // version,
-                ))(remainder)?;
-
-                remainder = data;
-
-                tools.push(BuildToolObject { tool, version })
-            }
+            let (_, tools) = count(
+                map(
+                    tuple((
+                        u32(self.endianness), // tool,
+                        u32(self.endianness), // version,
+                    )),
+                    |(tool, version)| BuildToolObject { tool, version },
+                ),
+                ntools as usize,
+            )(remainder)?;
 
             Ok((
                 &[],
@@ -1680,7 +1678,8 @@ impl From<&MinVersion> for protos::macho::MinVersion {
         result.set_device(
             protobuf::EnumOrUnknown::<protos::macho::DEVICE_TYPE>::from_i32(
                 mv.device as i32,
-            ).unwrap(),
+            )
+                .unwrap(),
         );
         result.set_version(convert_to_version_string(mv.version));
         result.set_sdk(convert_to_version_string(mv.sdk));

--- a/lib/src/modules/macho/tests/mod.rs
+++ b/lib/src/modules/macho/tests/mod.rs
@@ -231,7 +231,7 @@ fn test_macho_module() {
         import "macho"
         rule test {
             condition:
-                macho.dylib_present("totally not present dylib")
+                macho.has_dylib("totally not present dylib")
         }
         "#
     );
@@ -241,7 +241,7 @@ fn test_macho_module() {
         import "macho"
         rule macho_test {
             condition:
-                macho.dylib_present("/usr/lib/libSystem.B.dylib")
+                macho.has_dylib("/usr/lib/libSystem.B.dylib")
         }
         "#,
         &tiny_universal_macho_data
@@ -252,7 +252,7 @@ fn test_macho_module() {
         import "macho"
         rule test {
             condition:
-                macho.rpath_present("totally not present rpath")
+                macho.has_rpath("totally not present rpath")
         }
         "#
     );
@@ -262,7 +262,7 @@ fn test_macho_module() {
         import "macho"
         rule macho_test {
             condition:
-                macho.rpath_present("@loader_path/../Frameworks")
+                macho.has_rpath("@loader_path/../Frameworks")
         }
         "#,
         &tiny_universal_macho_data
@@ -273,7 +273,7 @@ fn test_macho_module() {
         import "macho"
         rule macho_test {
             condition:
-                macho.rpath_present("@loader_path/../Frameworks")
+                macho.has_rpath("@loader_path/../Frameworks")
         }
         "#,
         &x86_macho_data
@@ -284,7 +284,7 @@ fn test_macho_module() {
         import "macho"
         rule macho_test {
             condition:
-                macho.entitlement_present("com.apple.security.network.client")
+                macho.has_entitlement("com.apple.security.network.client")
         }
         "#,
         &chess_macho_data
@@ -295,7 +295,7 @@ fn test_macho_module() {
         import "macho"
         rule macho_test {
             condition:
-                macho.entitlement_present("COM.ApplE.security.NetWoRK.client")
+                macho.has_entitlement("COM.ApplE.security.NetWoRK.client")
         }
         "#,
         &chess_macho_data
@@ -306,7 +306,7 @@ fn test_macho_module() {
         import "macho"
         rule macho_test {
             condition:
-                macho.entitlement_present("made-up-entitlement")
+                macho.has_entitlement("made-up-entitlement")
         }
         "#,
         &chess_macho_data


### PR DESCRIPTION
Also implemented `build_version_command` in a more idiomatic way.