### PR TITLE
ci: check that tag numbers are in sync with crate version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,14 +40,6 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4
 
-    - name: Install dependencies
-      id: vcpkg
-      uses: johnwason/vcpkg-action@v6
-      with:
-        pkgs: openssl
-        triplet: ${{ matrix.vcpkg_openssl_triplet }}
-        token: ${{ github.token }}
-
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:
@@ -61,6 +53,14 @@ jobs:
         if [ "${{ github.ref_name }}" != "v$version" ]; then
           exit 1
         fi
+
+    - name: Install dependencies
+      id: vcpkg
+      uses: johnwason/vcpkg-action@v6
+      with:
+        pkgs: openssl
+        triplet: ${{ matrix.vcpkg_openssl_triplet }}
+        token: ${{ github.token }}
 
     - name: Build
       run: cargo build --bin yr --profile release-lto --target ${{ matrix.target }} ${{ matrix.args }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,15 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
 
+    - name: Check version number
+      shell: bash
+      run: |
+        set -ex
+        version=`cargo pkgid --manifest-path lib/Cargo.toml | cut -d "@" -f2`
+        if [ "${{ github.ref_name }}" != "v${{ version }}" ]; then
+          exit 1
+        fi
+
     - name: Build
       run: cargo build --bin yr --profile release-lto --target ${{ matrix.target }} ${{ matrix.args }}
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
       run: |
         set -ex
         version=`cargo pkgid --manifest-path lib/Cargo.toml | cut -d "@" -f2`
-        if [ "${{ github.ref_name }}" != "v${{ version }}" ]; then
+        if [ "${{ github.ref_name }}" != "v$version" ]; then
           exit 1
         fi
 


### PR DESCRIPTION
When adding a tag `vX.Y.Z`, the release workflow makes sure that the crate version is `X.Y.Z`. The prevents creating tags that doesn't correspond to the version declared in Cargo.toml.