### PR TITLE
fix: out of memory issue due to accumulation of items in `ScanContext`

### DIFF
--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -89,10 +89,9 @@ pub(crate) struct ScanContext<'r> {
     /// as an individual pattern, but the match of one of the pieces doesn't
     /// imply that the whole pattern matches. This partial matches are stored
     /// here until they can be confirmed or discarded. There's no guarantee
-    /// that matches stored in `VecDeque<UnconfirmedMatch>` are sorted by
-    /// matching offset.
-    pub unconfirmed_matches:
-        FxHashMap<SubPatternId, VecDeque<UnconfirmedMatch>>,
+    /// that matches stored in `Vec<UnconfirmedMatch>` are sorted by matching
+    /// offset.
+    pub unconfirmed_matches: FxHashMap<SubPatternId, Vec<UnconfirmedMatch>>,
     /// Set that contains the PatternId for those patterns that have reached
     /// the maximum number of matches indicated by `max_matches_per_pattern`.
     pub limit_reached: FxHashSet<PatternId>,
@@ -685,7 +684,7 @@ impl ScanContext<'_> {
                 self.unconfirmed_matches
                     .entry(sub_pattern_id)
                     .or_default()
-                    .push_back(UnconfirmedMatch {
+                    .push(UnconfirmedMatch {
                         range: match_.range,
                         chain_length: 0,
                     })
@@ -716,7 +715,7 @@ impl ScanContext<'_> {
                         self.unconfirmed_matches
                             .entry(sub_pattern_id)
                             .or_default()
-                            .push_back(UnconfirmedMatch {
+                            .push(UnconfirmedMatch {
                                 range: match_.range,
                                 chain_length: 0,
                             });

--- a/lib/src/scanner/matches.rs
+++ b/lib/src/scanner/matches.rs
@@ -234,7 +234,7 @@ impl PatternMatches {
     }
 
     pub fn clear(&mut self) {
-        if self.capacity > self.max_matches_per_pattern * 10 {
+        if self.capacity > 10000 {
             self.matches.clear();
             self.capacity = 0;
         } else {

--- a/lib/src/scanner/matches.rs
+++ b/lib/src/scanner/matches.rs
@@ -144,6 +144,11 @@ impl MatchList {
     }
 
     #[inline]
+    pub fn shrink_to(&mut self, min_capacity: usize) {
+        self.matches.shrink_to(min_capacity)
+    }
+
+    #[inline]
     pub fn iter(&self) -> Iter<'_, Match> {
         self.matches.iter()
     }

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -691,9 +691,7 @@ impl<'r> Scanner<'r> {
         ctx.limit_reached.clear();
 
         // Clear the unconfirmed matches.
-        for (_, matches) in ctx.unconfirmed_matches.iter_mut() {
-            matches.clear()
-        }
+        ctx.unconfirmed_matches.clear();
 
         // If some pattern or rule matched, clear the matches. Notice that a
         // rule may match without any pattern being matched, because there
@@ -703,17 +701,7 @@ impl<'r> Scanner<'r> {
             || !ctx.non_private_matching_rules.is_empty()
             || !ctx.private_matching_rules.is_empty()
         {
-            // The hash map that tracks the pattern matches is not completely
-            // cleared with pattern_matches.clear() because that would cause
-            // that all the vectors are deallocated. Instead, each of the
-            // vectors are cleared individually, which removes the items
-            // while maintaining the vector capacity. This way the vector may
-            // be reused in later scans without memory allocations.
-            for (_, matches) in ctx.pattern_matches.iter_mut() {
-                matches.clear()
-            }
-
-            // Clear the lists of matching rules.
+            ctx.pattern_matches.clear();
             ctx.non_private_matching_rules.clear();
             ctx.private_matching_rules.clear();
 

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -702,7 +702,7 @@ impl<'r> Scanner<'r> {
         // would be too high.
         for (_, matches) in ctx.unconfirmed_matches.iter_mut() {
             matches.clear();
-            matches.shrink_to(512);
+            matches.shrink_to(32);
         }
 
         // If some pattern or rule matched, clear the matches. Notice that a
@@ -715,7 +715,7 @@ impl<'r> Scanner<'r> {
         {
             for (_, matches) in ctx.pattern_matches.iter_mut() {
                 matches.clear();
-                matches.shrink_to(512);
+                matches.shrink_to(32);
             }
 
             ctx.non_private_matching_rules.clear();

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -36,6 +36,7 @@ use crate::wasm::{ENGINE, MATCHING_RULES_BITMAP_BASE};
 use crate::{modules, wasm, Variable};
 
 pub(crate) use crate::scanner::context::*;
+use crate::scanner::matches::PatternMatches;
 
 mod context;
 mod matches;
@@ -101,7 +102,6 @@ pub struct Scanner<'r> {
 }
 
 impl<'r> Scanner<'r> {
-    const DEFAULT_MAX_MATCHES_PER_PATTERN: usize = 1_000_000;
     const DEFAULT_SCAN_TIMEOUT: u64 = 315_360_000;
 
     /// Creates a new scanner.
@@ -135,11 +135,10 @@ impl<'r> Scanner<'r> {
                 main_memory: None,
                 module_outputs: FxHashMap::default(),
                 user_provided_module_outputs: FxHashMap::default(),
-                pattern_matches: FxHashMap::default(),
+                pattern_matches: PatternMatches::new(),
                 unconfirmed_matches: FxHashMap::default(),
                 deadline: 0,
                 limit_reached: FxHashSet::default(),
-                max_matches_per_pattern: Self::DEFAULT_MAX_MATCHES_PER_PATTERN,
                 regexp_cache: RefCell::new(FxHashMap::default()),
                 #[cfg(feature = "rules-profiling")]
                 time_spent_in_pattern: FxHashMap::default(),
@@ -272,7 +271,7 @@ impl<'r> Scanner<'r> {
     /// When some pattern reaches the maximum number of patterns it won't
     /// produce more matches.
     pub fn max_matches_per_pattern(&mut self, n: usize) -> &mut Self {
-        self.wasm_store.data_mut().max_matches_per_pattern = n;
+        self.wasm_store.data_mut().pattern_matches.max_matches_per_pattern(n);
         self
     }
 
@@ -691,19 +690,7 @@ impl<'r> Scanner<'r> {
         ctx.limit_reached.clear();
 
         // Clear the unconfirmed matches.
-        //
-        // We could use `unconfirmed_matches.clear()` for clearing the whole
-        // hash map, but that would cause that all the vectors are deallocated.
-        // Instead, each vector is cleared individually, which removes the items
-        // while maintaining the vector capacity. This way the vector may be
-        // reused in later scans without memory allocations. However, need keep
-        // the size of those vector under control by calling `shrink_to`, if
-        // this map have too many large vectors the overall memory consumption
-        // would be too high.
-        for (_, matches) in ctx.unconfirmed_matches.iter_mut() {
-            matches.clear();
-            matches.shrink_to(32);
-        }
+        ctx.unconfirmed_matches.clear();
 
         // If some pattern or rule matched, clear the matches. Notice that a
         // rule may match without any pattern being matched, because there
@@ -713,11 +700,7 @@ impl<'r> Scanner<'r> {
             || !ctx.non_private_matching_rules.is_empty()
             || !ctx.private_matching_rules.is_empty()
         {
-            for (_, matches) in ctx.pattern_matches.iter_mut() {
-                matches.clear();
-                matches.shrink_to(32);
-            }
-
+            ctx.pattern_matches.clear();
             ctx.non_private_matching_rules.clear();
             ctx.private_matching_rules.clear();
 
@@ -1007,8 +990,8 @@ impl<'a, 'r> Pattern<'a, 'r> {
             iterator: self
                 .ctx
                 .pattern_matches
-                .get(&self.pattern_id)
-                .map(|match_list| match_list.iter()),
+                .get(self.pattern_id)
+                .map(|matches| matches.iter()),
         }
     }
 }

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -691,7 +691,13 @@ impl<'r> Scanner<'r> {
         ctx.limit_reached.clear();
 
         // Clear the unconfirmed matches.
-        ctx.unconfirmed_matches.clear();
+        if ctx.unconfirmed_matches.len() < 100 {
+            for (_, matches) in ctx.unconfirmed_matches.iter_mut() {
+                matches.clear()
+            }
+        } else {
+            ctx.unconfirmed_matches.clear();
+        }
 
         // If some pattern or rule matched, clear the matches. Notice that a
         // rule may match without any pattern being matched, because there
@@ -701,7 +707,14 @@ impl<'r> Scanner<'r> {
             || !ctx.non_private_matching_rules.is_empty()
             || !ctx.private_matching_rules.is_empty()
         {
-            ctx.pattern_matches.clear();
+            if ctx.pattern_matches.len() < 100 {
+                for (_, matches) in ctx.pattern_matches.iter_mut() {
+                    matches.clear()
+                }
+            } else {
+                ctx.pattern_matches.clear();
+            }
+
             ctx.non_private_matching_rules.clear();
             ctx.private_matching_rules.clear();
 

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -791,7 +791,7 @@ pub(crate) fn is_pat_match_at(
     if offset < 0 {
         return false;
     }
-    if let Some(matches) = caller.data().pattern_matches.get(&pattern_id) {
+    if let Some(matches) = caller.data().pattern_matches.get(pattern_id) {
         matches.search(offset.try_into().unwrap()).is_ok()
     } else {
         false
@@ -810,7 +810,7 @@ pub(crate) fn is_pat_match_in(
     lower_bound: i64,
     upper_bound: i64,
 ) -> bool {
-    if let Some(matches) = caller.data().pattern_matches.get(&pattern_id) {
+    if let Some(matches) = caller.data().pattern_matches.get(pattern_id) {
         matches
             .matches_in_range(lower_bound as isize..=upper_bound as isize)
             .is_positive()
@@ -825,7 +825,7 @@ pub(crate) fn pat_matches(
     caller: &mut Caller<'_, ScanContext>,
     pattern_id: PatternId,
 ) -> i64 {
-    if let Some(matches) = caller.data().pattern_matches.get(&pattern_id) {
+    if let Some(matches) = caller.data().pattern_matches.get(pattern_id) {
         matches.len().try_into().unwrap()
     } else {
         0
@@ -844,7 +844,7 @@ pub(crate) fn pat_matches_in(
     lower_bound: i64,
     upper_bound: i64,
 ) -> i64 {
-    if let Some(matches) = caller.data().pattern_matches.get(&pattern_id) {
+    if let Some(matches) = caller.data().pattern_matches.get(pattern_id) {
         matches.matches_in_range(lower_bound as isize..=upper_bound as isize)
     } else {
         0
@@ -862,7 +862,7 @@ pub(crate) fn pat_length(
     pattern_id: PatternId,
     index: i64,
 ) -> Option<i64> {
-    if let Some(matches) = caller.data().pattern_matches.get(&pattern_id) {
+    if let Some(matches) = caller.data().pattern_matches.get(pattern_id) {
         let index: usize = index.try_into().ok()?;
         // Index is 1-based, convert it to 0-based before calling `matches.get`
         let m = matches.get(index.checked_sub(1)?)?;
@@ -883,7 +883,7 @@ pub(crate) fn pat_offset(
     pattern_id: PatternId,
     index: i64,
 ) -> Option<i64> {
-    if let Some(matches) = caller.data().pattern_matches.get(&pattern_id) {
+    if let Some(matches) = caller.data().pattern_matches.get(pattern_id) {
         let index: usize = index.try_into().ok()?;
         // Index is 1-based, convert it to 0-based before calling `matches.get`
         let m = matches.get(index.checked_sub(1)?)?;


### PR DESCRIPTION
`ScanContext` contains hash maps that tracks the matches found for each pattern. The values in these maps are vectors that can become very large. For performance reasons, instead of completely deallocating those vectors after each scan, we were clearing the vector but retaining its capacity, so that they can be reused in later scans. The problem with that is that these vectors are not freed while the scanner is in use, and this can have a large impact on the process' memory footprint, causing OOM issues.

This PR adds a `PatternMatches` type that encapsulates all the logic for tracking pattern matches, including a more sophisticated approach that tries to reuse the vectors as much as possible, but frees them when they grow too much.