### PR TITLE
fix: Verification of MS countersignatures now takes into account signer info digest and verifies it against digest of content info (timestamp info)

### DIFF
--- a/lib/src/modules/pe/tests/testdata/130f9b2e65bfceae8d9e7cbe205471fc8ee34c3d9996f77baa3c3ab47a3b3068.out
+++ b/lib/src/modules/pe/tests/testdata/130f9b2e65bfceae8d9e7cbe205471fc8ee34c3d9996f77baa3c3ab47a3b3068.out
@@ -689,7 +689,7 @@ signatures:
         not_before: 1513987200 # 2017-12-23 00:00:00 UTC
         not_after: 1868918399 # 2029-03-22 23:59:59 UTC
     countersignatures:
-      - verified: true
+      - verified: false
         sign_time: 1634237249 # 2021-10-14 18:47:29 UTC
         digest: "a6d56d546fb347a798239820467f4871bdd4c2f331548f4fdf5ab961a46c5c45"
         digest_alg: "sha256"


### PR DESCRIPTION
The signature of the signed attributes was verified, the digest of countersigned signature was verified but what was missing is the verification that the signed attributes are actually signing the embedded timestamp information. This would allow anyone to take a valid countersignature, replace content info of the signed data with their own timestamp info, recalculate hash against the countersigned signature and it would be verified as OK.