### PR TITLE
ci: mark nightly as experimental in matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,8 +9,10 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
+        experimental: [false]
         build:
         - msrv
         - stable
@@ -40,6 +42,7 @@ jobs:
           # Disable rust-lld with -Zlinker-features=-lld
           # See: https://github.com/dtolnay/linkme/commit/d13709bfd2c1278b4c8b6c846e2017b623923c0c
           rust_flags: "-Awarnings -Zlinker-features=-lld"
+          experimental: true
 
         - build: macos
           os: macos-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: true
       matrix:
         experimental: [false]
         build:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        experimental: [false]
         build:
         - msrv
         - stable
@@ -28,12 +27,14 @@ jobs:
           rust: 1.74.0
           args: "--features=magic-module"
           rust_flags: "-Awarnings"
+          experimental: false
 
         - build: stable
           os: ubuntu-latest
           rust: stable
           args: "--features=magic-module"
           rust_flags: "-Awarnings"
+          experimental: false
 
         - build: nightly
           os: ubuntu-latest
@@ -50,12 +51,14 @@ jobs:
           rust: stable
           args: ""
           rust_flags: "-Awarnings"
+          experimental: false
 
         - build: win-msvc
           os: windows-latest
           rust: stable
           args: ""
           rust_flags: "-Awarnings"
+          experimental: false
         
         # Tests for the `stable-x86_64-pc-windows-gnu` toolchain disabled
         # due to https://github.com/VirusTotal/yara-x/issues/29
@@ -64,12 +67,14 @@ jobs:
         #   os: windows-latest
         #   rust: stable-x86_64-gnu
         #   args: ""
+        #   experimental: false
 
         - build: no-default-features
           os: ubuntu-latest
           rust: stable
           args: "--package yara-x --no-default-features --features=test_proto2-module,test_proto3-module,string-module,time-module,hash-module,macho-module,magic-module,math-module,lnk-module,elf-module,pe-module,dotnet-module,console-module"
           rust_flags: "-Awarnings"
+          experimental: false
 
     steps:
     - name: Checkout sources


### PR DESCRIPTION
Originally brought up in #93, I have modified the tests workflow to fail-fast on non-experimental builds. As Rust's nightly channel is experimental, I have marked it as such.

Docs for following changes here: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures