### PR TITLE
build: cargo: Set default release profile to use LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,12 +111,6 @@ yara-x-proto = { path = "proto", version = "0.3.0" }
 yara-x-proto-yaml = { path = "proto-yaml", version = "0.3.0" }
 zip = "1.1.2"
 
-# Special profile that builds a release binary with link-time optimization. 
-# Compiling with this profile takes a while, but the resulting binary is
-# smaller and better optimized. For building with this profile use:
-#
-# cargo build --profile release-lto
-[profile.release-lto]
-inherits = "release"
+[profile.release]
 lto = true
 codegen-units = 1


### PR DESCRIPTION
Linux distros use this target for their end-user packages, as such this needs to be the default for those users to take advantage of the performance benefits.