### PR TITLE
feat: Implement multiline string literals in metadata.

### DIFF
--- a/lib/src/compiler/tests/testdata/errors/69.out
+++ b/lib/src/compiler/tests/testdata/errors/69.out
@@ -2,5 +2,5 @@ error: syntax error
  --> line:1:23
   |
 1 | rule test { meta: a = condition: true }
-  |                       ^ expected `false`, `true`, number, or string literal
+  |                       ^ expected `false`, `true`, multiline string literal, number, or string literal
   |

--- a/lib/src/compiler/tests/testdata/errors/69.out
+++ b/lib/src/compiler/tests/testdata/errors/69.out
@@ -2,5 +2,5 @@ error: syntax error
  --> line:1:23
   |
 1 | rule test { meta: a = condition: true }
-  |                       ^ expected `false`, `true`, multiline string literal, number, or string literal
+  |                       ^ expected `false`, `true`, number, or string literal
   |

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -126,8 +126,8 @@ impl<'src> Display for MetaValue<'src> {
             Self::Bool(v) => write!(f, "{}", v),
             Self::Integer(v) => write!(f, "{}", v),
             Self::Float(v) => write!(f, "{:.1}", v),
-            Self::String(v) => write!(f, "{}", v),
-            Self::Bytes(v) => write!(f, "{}", v),
+            Self::String(v) => write!(f, "\"{}\"", v),
+            Self::Bytes(v) => write!(f, "\"{}\"", v),
         }
     }
 }

--- a/parser/src/parser/cst2ast.rs
+++ b/parser/src/parser/cst2ast.rs
@@ -1889,7 +1889,8 @@ fn string_lit_from_cst<'src>(
     let literal = string_lit.as_str();
 
     // The span doesn't include the quotes.
-    let string_span = ctx.span(&string_lit).subspan(num_quotes, literal.len() - num_quotes);
+    let string_span =
+        ctx.span(&string_lit).subspan(num_quotes, literal.len() - num_quotes);
 
     // From now on ignore the quotes.
     let literal = &literal[num_quotes..literal.len() - num_quotes];

--- a/parser/src/parser/errors.rs
+++ b/parser/src/parser/errors.rs
@@ -336,7 +336,7 @@ impl ErrorInfo {
             Rule::rule_decl => "rule declaration",
             Rule::source_file => "YARA rules",
             Rule::string_lit => "string literal",
-            Rule::multiline_string_lit => "multiline string literal",
+            Rule::multiline_string_lit => "string literal",
             Rule::regexp => "regular expression",
             Rule::pattern_mods => "pattern modifiers",
 

--- a/parser/src/parser/errors.rs
+++ b/parser/src/parser/errors.rs
@@ -336,6 +336,7 @@ impl ErrorInfo {
             Rule::rule_decl => "rule declaration",
             Rule::source_file => "YARA rules",
             Rule::string_lit => "string literal",
+            Rule::multiline_string_lit => "multiline string literal",
             Rule::regexp => "regular expression",
             Rule::pattern_mods => "pattern modifiers",
 

--- a/parser/src/parser/grammar.pest
+++ b/parser/src/parser/grammar.pest
@@ -244,6 +244,25 @@ pattern_length = @{
   "!" ~ ident_chars*
 }
 
+// Multiline string literal. i.e:
+//
+// """
+// I'm a multiline string literal!
+//
+// Hooray!
+// """
+multiline_string_lit = @{
+  DOUBLE_QUOTES{3} ~ (
+    // The escape sequence \\ has precedence, if not, \\" would be interpreted
+    // as a backslash \, followed by the escape sequence \"
+    "\\\\" |
+    // Allow \" inside the double quotes.
+    "\\\"" |
+    // Allow any characters except triple quotes.
+    !DOUBLE_QUOTES{3} ~ ANY
+  )* ~ DOUBLE_QUOTES{3}
+}
+
 // String literal (i.e: "", "foo", "bar").
 string_lit = @{
   DOUBLE_QUOTES ~ (
@@ -306,6 +325,7 @@ meta_def = {
     k_FALSE               |
     float_lit             |
     integer_lit           |
+    multiline_string_lit  |
     string_lit
   )
 }

--- a/parser/src/parser/tests/testdata/meta.yaml
+++ b/parser/src/parser/tests/testdata/meta.yaml
@@ -9,6 +9,15 @@
         some_bool = true
         some_bool = false
         some_string = "foo"
+        some_multiline_string = """
+        I'm a multiline string literal!
+
+        \"test\"
+
+        I also handle escapes, \x41\x42\x43!
+
+        ... and emojis 🤖!
+        """
       condition:
         true
     }
@@ -20,7 +29,16 @@
        │  ├─ some_float = 2.0
        │  ├─ some_bool = true
        │  ├─ some_bool = false
-       │  └─ some_string = foo
+       │  ├─ some_string = "foo"
+       │  └─ some_multiline_string = "
+       I'm a multiline string literal!
+
+       "test"
+
+       I also handle escapes, ABC!
+
+       ... and emojis 🤖!
+       "
        └─ condition
           └─ true
 


### PR DESCRIPTION
This commit implements multiline string literals in metadata section.

```
rule a {
  meta:
    a = """
I'm a multiline string literal!

Hooray!

\"test\"

I also handle escapes, \x41\x42\x43!

... and emojis 🤖!
"""
  condition:
    true
}
```

While I'm here, also quote the metadata string values when printing the ast.