### PR TITLE
docs: fix minor typo

### DIFF
--- a/site/content/docs/intro/yara_vs_yara-x.md
+++ b/site/content/docs/intro/yara_vs_yara-x.md
@@ -118,7 +118,7 @@ But maintaining those parser in-sync with the official one is hard, and very
 often they lag behind.
 
 YARA-X, in contrast, has a more modular design, where the parser is decoupled
-from the rule compilation logic, allowing the re-use of the parser of other
+from the rule compilation logic, allowing the re-use of the parser for other
 purposes.
 
 ## The bad things


### PR DESCRIPTION
This is a fix for a minor typo in the doc

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>