### PR TITLE
feat: implement API for treating slow patterns as error instead of warnings

### DIFF
--- a/capi/include/yara_x.h
+++ b/capi/include/yara_x.h
@@ -33,6 +33,10 @@
 // constructs that YARA-X doesn't accept by default.
 #define YRX_RELAXED_RE_SYNTAX 2
 
+// Flag passed to [`yrx_compiler_create`] for treating slow patterns as
+// errors instead of warnings.
+#define YRX_ERROR_ON_SLOW_PATTERN 4
+
 // Metadata value types.
 typedef enum YRX_METADATA_VALUE_TYPE {
   I64,

--- a/capi/src/compiler.rs
+++ b/capi/src/compiler.rs
@@ -27,6 +27,10 @@ pub const YRX_COLORIZE_ERRORS: u32 = 1;
 /// constructs that YARA-X doesn't accept by default.
 pub const YRX_RELAXED_RE_SYNTAX: u32 = 2;
 
+/// Flag passed to [`yrx_compiler_create`] for treating slow patterns as
+/// errors instead of warnings.
+pub const YRX_ERROR_ON_SLOW_PATTERN: u32 = 4;
+
 fn _yrx_compiler_create<'a>(flags: u32) -> yara_x::Compiler<'a> {
     let mut compiler = yara_x::Compiler::new();
     if flags & YRX_RELAXED_RE_SYNTAX != 0 {
@@ -34,6 +38,9 @@ fn _yrx_compiler_create<'a>(flags: u32) -> yara_x::Compiler<'a> {
     }
     if flags & YRX_COLORIZE_ERRORS != 0 {
         compiler.colorize_errors(true);
+    }
+    if flags & YRX_ERROR_ON_SLOW_PATTERN != 0 {
+        compiler.error_on_slow_pattern(true);
     }
     compiler
 }

--- a/go/compiler.go
+++ b/go/compiler.go
@@ -71,10 +71,20 @@ func RelaxedReSyntax(yes bool) CompileOption {
 	}
 }
 
+// ErrorOnSlowPattern is an option for [NewCompiler] and [Compile] that
+// tells the compiler to treat slow patterns as errors instead of warnings.
+func ErrorOnSlowPattern(yes bool) CompileOption {
+		return func(c *Compiler) error {
+  		c.errorOnSlowPattern = yes
+  		return nil
+  	}
+}
+
 // Compiler represent a YARA compiler.
 type Compiler struct {
 	cCompiler       *C.YRX_COMPILER
 	relaxedReSyntax bool
+	errorOnSlowPattern bool
 	ignoredModules  map[string]bool
 	vars map[string]interface{}
 }
@@ -95,6 +105,10 @@ func NewCompiler(opts... CompileOption) (*Compiler, error) {
 	flags := C.uint32_t(0)
 	if c.relaxedReSyntax {
 		flags |= C.YRX_RELAXED_RE_SYNTAX
+	}
+
+	if c.errorOnSlowPattern {
+		flags |= C.YRX_ERROR_ON_SLOW_PATTERN
 	}
 
 	C.yrx_compiler_create(flags, &c.cCompiler)

--- a/go/compiler_test.go
+++ b/go/compiler_test.go
@@ -39,6 +39,14 @@ func TestRelaxedReSyntax(t *testing.T) {
 	assert.Len(t, matchingRules, 1)
 }
 
+
+func TestErrorOnSlowPattern(t *testing.T) {
+	_, err := Compile(`
+		rule test { strings: $a = /a.*b/ condition: $a }`,
+		ErrorOnSlowPattern(true))
+	assert.Error(t, err)
+}
+
 func TestSerialization(t *testing.T) {
 	r, err := Compile("rule test { condition: true }")
 	assert.NoError(t, err)

--- a/lib/src/compiler/errors.rs
+++ b/lib/src/compiler/errors.rs
@@ -194,7 +194,7 @@ pub enum CompileError {
         note: Option<String>,
     },
 
-    #[warning("slow pattern")]
+    #[error("slow pattern")]
     #[label("this pattern may slow down the scan", span)]
     SlowPattern { detailed_report: String, span: Span },
 }

--- a/lib/src/compiler/errors.rs
+++ b/lib/src/compiler/errors.rs
@@ -193,4 +193,8 @@ pub enum CompileError {
         span: Span,
         note: Option<String>,
     },
+
+    #[warning("slow pattern")]
+    #[label("this pattern may slow down the scan", span)]
+    SlowPattern { detailed_report: String, span: Span },
 }

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -314,7 +314,7 @@ impl<'a> Compiler<'a> {
             wasm_symbols,
             wasm_exports,
             relaxed_re_syntax: false,
-            error_on_slow_pattern: true,
+            error_on_slow_pattern: false,
             next_pattern_id: PatternId(0),
             current_pattern_id: PatternId(0),
             current_namespace: default_namespace,
@@ -596,6 +596,8 @@ impl<'a> Compiler<'a> {
     }
 
     /// When enabled, slow patterns produce an error instead of a warning.
+    ///
+    /// This is disabled by default.
     pub fn error_on_slow_pattern(&mut self, yes: bool) -> &mut Self {
         self.error_on_slow_pattern = yes;
         self

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -23,6 +23,12 @@ def test_relaxed_re_syntax():
   assert len(matching_rules) == 1
 
 
+def test_error_on_slow_pattern():
+	compiler = yara_x.Compiler(error_on_slow_pattern=True)
+	with pytest.raises(yara_x.CompileError):
+		compiler.add_source(r'rule test {strings: $a = /a.*b/ condition: $a}')
+
+
 def test_int_globals():
   compiler = yara_x.Compiler()
   compiler.define_global('some_int', 1)


### PR DESCRIPTION
Slow patterns are those that have atoms with less than 2 bytes. Such patterns can slow down scanning and the compiler raises a warning when it finds one of those patterns. The new APIs allow telling the compiler to raise an error instead of a warning.