### PR TITLE
chore: inherit `repository` field from workspace in `parser/Cargo.toml`

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -10,6 +10,7 @@ readme.workspace = true
 license.workspace = true
 homepage.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 [features]
 # Enables debug logs.


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.