### PR TITLE
fix: Fix handling invalid(?) unicode in filenames.

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub use fix::*;
 pub use fmt::*;
 pub use scan::*;
 
+use std::borrow::Cow;
 use std::fs;
 use std::io::stdout;
 use std::path::PathBuf;
@@ -211,10 +212,10 @@ impl Component for CompileState {
     }
 }
 
-fn truncate_with_ellipsis(s: String, max_length: usize) -> String {
+fn truncate_with_ellipsis(s: Cow<str>, max_length: usize) -> Cow<str> {
     if s.len() <= max_length {
         s
     } else {
-        format!("{}...", &s[..max_length - 3])
+        format!("{}...", &s[..max_length - 3]).into()
     }
 }

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::min;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -529,16 +530,20 @@ impl ScanState {
 // superconsole will not print any string that contains Unicode characters that
 // are spaces but are not the ASCII space character, so we replace them all.
 // See https://github.com/VirusTotal/yara-x/pull/163 for discussion.
-fn replace_whitespace(s: String) -> String {
-    let mut new: String = String::new();
-    for c in s.chars() {
-        if c.is_whitespace() {
-            new.push(' ');
-        } else {
-            new.push(c);
+fn replace_whitespace(path: &PathBuf) -> Cow<str> {
+    let mut s = path.to_string_lossy();
+    if s.chars().any(|c| c != ' ' && c.is_whitespace()) {
+        let mut r = String::with_capacity(s.len());
+        for c in s.chars() {
+            if c.is_whitespace() {
+                r.push(' ')
+            } else {
+                r.push(c)
+            }
         }
+        s = Cow::Owned(r);
     }
-    new
+    s
 }
 
 impl Component for ScanState {
@@ -581,7 +586,7 @@ impl Component for ScanState {
             for (file, start_time) in
                 self.files_in_progress.lock().unwrap().iter()
             {
-                let path = replace_whitespace(file.display().to_string());
+                let path = replace_whitespace(file);
                 // The length of the elapsed is 7 characters.
                 let spaces = " "
                     .repeat(dimensions.width.saturating_sub(path.len() + 7));

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -530,7 +530,7 @@ impl ScanState {
 // superconsole will not print any string that contains Unicode characters that
 // are spaces but are not the ASCII space character, so we replace them all.
 // See https://github.com/VirusTotal/yara-x/pull/163 for discussion.
-fn replace_whitespace(path: &PathBuf) -> Cow<str> {
+fn replace_whitespace(path: &Path) -> Cow<str> {
     let mut s = path.to_string_lossy();
     if s.chars().any(|c| c != ' ' && c.is_whitespace()) {
         let mut r = String::with_capacity(s.len());

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -526,6 +526,21 @@ impl ScanState {
     }
 }
 
+// superconsole will not print any string that contains Unicode characters that
+// are spaces but are not the ASCII space character, so we replace them all.
+// See https://github.com/VirusTotal/yara-x/pull/163 for discussion.
+fn replace_whitespace(s: String) -> String {
+    let mut new: String = String::new();
+    for c in s.chars() {
+        if c.is_whitespace() {
+            new.push(' ');
+        } else {
+            new.push(c);
+        }
+    }
+    new
+}
+
 impl Component for ScanState {
     fn draw_unchecked(
         &self,
@@ -566,7 +581,7 @@ impl Component for ScanState {
             for (file, start_time) in
                 self.files_in_progress.lock().unwrap().iter()
             {
-                let path = format!("{:?}", file.display().to_string());
+                let path = replace_whitespace(file.display().to_string());
                 // The length of the elapsed is 7 characters.
                 let spaces = " "
                     .repeat(dimensions.width.saturating_sub(path.len() + 7));

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -566,7 +566,7 @@ impl Component for ScanState {
             for (file, start_time) in
                 self.files_in_progress.lock().unwrap().iter()
             {
-                let path = file.display().to_string();
+                let path = format!("{:?}", file.display().to_string());
                 // The length of the elapsed is 7 characters.
                 let spaces = " "
                     .repeat(dimensions.width.saturating_sub(path.len() + 7));


### PR DESCRIPTION
When running yr scan against some random files I have laying around I noticed a crash. I think it is because there is invalid (at least I think it is, I'm so bad at understanding unicode) unicode in the filename of one of the files contained in 84523ddad722e205e2d52eedfb682026928b63f919a7bf1ce6f1ad4180d0f507 (available on VT).

This changes it so the string is using the debug formatter which handles the invalid utf-8 better? This seems to work fine on my machine.