### PR TITLE
feat: Add support for rule metadata to be output in scan mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4898,6 +4898,7 @@ dependencies = [
  "encoding_rs",
  "env_logger",
  "globwalk",
+ "itertools 0.13.0",
  "log",
  "pprof",
  "protobuf",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,6 +41,7 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["cargo", "derive"] }
 clap_complete = { workspace = true }
 globwalk = { workspace = true }
+itertools = { workspace = true }
 enable-ansi-support = { workspace = true }
 env_logger = { workspace = true, optional = true, features = ["auto-color"] }
 log = { workspace = true, optional = true }

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -443,7 +443,7 @@ fn print_rules_as_text(
     // `the `by_ref` method cannot be invoked on a trait object`
     #[allow(clippy::while_let_on_iterator)]
     while let Some(matching_rule) = rules.next() {
-        let name = if print_namespace {
+        let mut line = if print_namespace {
             format!(
                 "{}:{}",
                 matching_rule.namespace().paint(Cyan).bold(),
@@ -453,7 +453,7 @@ fn print_rules_as_text(
             format!("{}", matching_rule.identifier().paint(Cyan).bold())
         };
 
-        let meta = if print_meta {
+        if print_meta {
             let mut meta_str: String = String::from("");
             for (m, v) in matching_rule.metadata() {
                 // [a="b",c =1,d=true]
@@ -475,12 +475,14 @@ fn print_rules_as_text(
                     ),
                 };
             }
-            format!("[{}]", &meta_str.as_str()[0..meta_str.len() - 1])
-        } else {
-            format!("")
-        };
+            line = format!(
+                "{} [{}]",
+                line,
+                &meta_str.as_str()[0..meta_str.len() - 1]
+            );
+        }
 
-        let line = format!("{} {} {}", name, meta, file_path.display());
+        line = format!("{} {}", line, file_path.display());
         output.send(Message::Info(line)).unwrap();
 
         if print_strings || print_strings_limit.is_some() {

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -354,6 +354,7 @@ fn print_rules_as_json(
     output: &Sender<Message>,
 ) {
     let print_namespace = args.get_flag("print-namespace");
+    let print_meta = args.get_flag("print-meta");
     let print_strings = args.get_flag("print-strings");
     let print_strings_limit = args.get_one::<usize>("print-strings-limit");
 
@@ -378,14 +379,9 @@ fn print_rules_as_json(
             })
         };
 
-        /*
-        output
-            .send(Message::Info(format!(
-                "{}",
-                matching_rule.metadata().into_json()
-            )))
-            .unwrap();
-        */
+        if print_meta {
+            json_rule["meta"] = matching_rule.metadata().into_json();
+        }
 
         if print_strings || print_strings_limit.is_some() {
             let limit = print_strings_limit.unwrap_or(&STRINGS_LIMIT);

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -419,19 +419,14 @@ fn print_rules_as_json(
 
                     if let Some(k) = m.xor_key() {
                         let mut p = String::with_capacity(s.len());
-                        for b in
-                            &match_data[..min(match_data.len(), *limit)]
-                        {
+                        for b in &match_data[..min(match_data.len(), *limit)] {
                             for c in (b ^ k).escape_ascii() {
-                                p.push_str(
-                                    format!("{}", c as char).as_str(),
-                                );
+                                p.push_str(format!("{}", c as char).as_str());
                             }
                         }
                         match_json["xor_key"] = serde_json::json!(k);
                         match_json["plaintext"] = serde_json::json!(p);
                     }
-
                     match_vec.push(match_json);
                 }
                 json_rule["strings"] = serde_json::json!(match_vec);

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -417,22 +417,19 @@ fn print_rules_as_json(
                         "data": s.as_str()
                     });
 
-                    match m.xor_key() {
-                        Some(k) => {
-                            let mut p = String::with_capacity(s.len());
-                            for b in
-                                &match_data[..min(match_data.len(), *limit)]
-                            {
-                                for c in (b ^ k).escape_ascii() {
-                                    p.push_str(
-                                        format!("{}", c as char).as_str(),
-                                    );
-                                }
+                    if let Some(k) = m.xor_key() {
+                        let mut p = String::with_capacity(s.len());
+                        for b in
+                            &match_data[..min(match_data.len(), *limit)]
+                        {
+                            for c in (b ^ k).escape_ascii() {
+                                p.push_str(
+                                    format!("{}", c as char).as_str(),
+                                );
                             }
-                            match_json["xor_key"] = serde_json::json!(k);
-                            match_json["plaintext"] = serde_json::json!(p);
                         }
-                        _ => {}
+                        match_json["xor_key"] = serde_json::json!(k);
+                        match_json["plaintext"] = serde_json::json!(p);
                     }
 
                     match_vec.push(match_json);
@@ -536,10 +533,10 @@ fn print_rules_as_text(
                                     );
                                 }
                             }
-                            msg.push_str(format!("): ").as_str());
+                            msg.push_str("): ");
                         }
                         _ => {
-                            msg.push_str(format!(": ").as_str());
+                            msg.push_str(": ");
                         }
                     }
 


### PR DESCRIPTION
This adds support for the `-m` flag to the scan command, which will print rule metadata.

I'm following the output of the original YARA implementation when outputting things as to try and not break any scripts that may expect the output in a certain format. I'm open to suggestions on ways to make this easier to read if you think we should just break existing scripts and come up with a new format here.