### PR TITLE
feat: Implement tag printing.

### DIFF
--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -81,6 +81,12 @@ pub fn scan() -> Command {
                 .help("Disable printing console log messages")
         )
         .arg(
+            arg!(-t --"tag" <TAG>)
+                .help("Print only rules tagged as TAG")
+                .required(false)
+                .value_parser(value_parser!(String))
+        )
+        .arg(
             arg!(-n --"negate")
                 .help("Print non-satisfied rules only")
         )
@@ -359,6 +365,7 @@ fn print_rules_as_json(
     output: &Sender<Message>,
 ) {
     let print_namespace = args.get_flag("print-namespace");
+    let only_tag = args.get_one::<String>("tag");
     let print_tags = args.get_flag("print-tags");
     let print_meta = args.get_flag("print-meta");
     let print_strings = args.get_flag("print-strings");
@@ -374,6 +381,14 @@ fn print_rules_as_json(
     // `the `by_ref` method cannot be invoked on a trait object`
     #[allow(clippy::while_let_on_iterator)]
     while let Some(matching_rule) = rules.next() {
+        if only_tag.is_some()
+            && !matching_rule
+                .tags()
+                .any(|t| t.identifier() == only_tag.unwrap())
+        {
+            return;
+        }
+
         let mut json_rule = if print_namespace {
             serde_json::json!({
                 "namespace": matching_rule.namespace(),
@@ -458,6 +473,7 @@ fn print_rules_as_text(
     output: &Sender<Message>,
 ) {
     let print_namespace = args.get_flag("print-namespace");
+    let only_tag = args.get_one::<String>("tag");
     let print_tags = args.get_flag("print-tags");
     let print_meta = args.get_flag("print-meta");
     let print_strings = args.get_flag("print-strings");
@@ -468,6 +484,14 @@ fn print_rules_as_text(
     // `the `by_ref` method cannot be invoked on a trait object`
     #[allow(clippy::while_let_on_iterator)]
     while let Some(matching_rule) = rules.next() {
+        if only_tag.is_some()
+            && !matching_rule
+                .tags()
+                .any(|t| t.identifier() == only_tag.unwrap())
+        {
+            return;
+        }
+
         let mut line = if print_namespace {
             format!(
                 "{}:{}",

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -507,7 +507,7 @@ fn print_rules_as_text(
         if print_tags && !tags.is_empty() {
             line.push_str(" [");
             for (pos, tag) in tags.with_position() {
-                line.push_str(&format!("{}", tag.identifier()));
+                line.push_str(tag.identifier());
                 if !matches!(pos, itertools::Position::Last) {
                     line.push(',');
                 }

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -973,7 +973,7 @@ impl<'a> Compiler<'a> {
                 self.report_builder.current_source_id(),
                 rule.identifier.span(),
             ),
-            tags: tags,
+            tags,
             patterns: vec![],
             is_global: rule.flags.contains(RuleFlag::Global),
             is_private: rule.flags.contains(RuleFlag::Private),

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -913,6 +913,13 @@ impl<'a> Compiler<'a> {
             self.check_for_duplicate_tags(tags.as_slice())?;
         }
 
+        let tags: Vec<IdentId> = rule
+            .tags
+            .iter()
+            .flatten()
+            .map(|t| self.ident_pool.get_or_intern(t.name))
+            .collect();
+
         // Take snapshot of the current compiler state. In case of error
         // compiling the current rule this snapshot allows restoring the
         // compiler to the state it had before starting compiling the rule.
@@ -966,6 +973,7 @@ impl<'a> Compiler<'a> {
                 self.report_builder.current_source_id(),
                 rule.identifier.span(),
             ),
+            tags: tags,
             patterns: vec![],
             is_global: rule.flags.contains(RuleFlag::Global),
             is_private: rule.flags.contains(RuleFlag::Private),

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -471,6 +471,8 @@ pub(crate) struct RuleInfo {
     pub(crate) namespace_ident_id: IdentId,
     /// The ID of the rule identifier in the identifiers pool.
     pub(crate) ident_id: IdentId,
+    /// Tags associated to the rule.
+    pub(crate) tags: Vec<IdentId>,
     /// Reference to the rule identifier in the source code. This field is
     /// ignored while serializing and deserializing compiles rules, as it
     /// is used only during the compilation phase, but not during the scan

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -964,6 +964,15 @@ impl<'a, 'r> Rule<'a, 'r> {
         }
     }
 
+    /// Returns the tags associated to this rule.
+    pub fn tags(&self) -> Tags<'a, 'r> {
+        Tags {
+            ctx: self.ctx,
+            iterator: self.rule_info.tags.iter(),
+            len: self.rule_info.tags.len(),
+        }
+    }
+
     /// Returns the patterns defined by this rule.
     pub fn patterns(&self) -> Patterns<'a, 'r> {
         Patterns {
@@ -1088,6 +1097,50 @@ impl<'a, 'r> ExactSizeIterator for Metadata<'a, 'r> {
     #[inline]
     fn len(&self) -> usize {
         self.len
+    }
+}
+
+/// An iterator that returns the tags defined by a rule.
+pub struct Tags<'a, 'r> {
+    ctx: &'a ScanContext<'r>,
+    iterator: Iter<'a, IdentId>,
+    len: usize,
+}
+
+impl<'a, 'r> Tags<'a, 'r> {
+    /// Returns `true` if the rule doesn't have any tags.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.iterator.len() == 0
+    }
+}
+
+impl<'a, 'r> Iterator for Tags<'a, 'r> {
+    type Item = Tag<'a, 'r>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let ident_id = self.iterator.next()?;
+        Some(Tag { ctx: self.ctx, ident_id: *ident_id })
+    }
+}
+
+impl<'a, 'r> ExactSizeIterator for Tags<'a, 'r> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+/// Represents a tag defined by a rule.
+pub struct Tag<'a, 'r> {
+    ctx: &'a ScanContext<'r>,
+    ident_id: IdentId,
+}
+
+impl<'a, 'r> Tag<'a, 'r> {
+    /// Returns the tag's identifier.
+    pub fn identifier(&self) -> &'r str {
+        self.ctx.compiled_rules.ident_pool().get(self.ident_id).unwrap()
     }
 }
 


### PR DESCRIPTION
This commit adds a -g argument to the scan command which will print the tags of matching rules.

One thing I realized (and this is also true for metadata) is that if there is no tags we are still including them in the JSON (just as an empty list). When we print in text mode we have checks if the tags are empty and skipping them if so.

I'm open to changing the JSON output so that we do not include a "meta" and "tags" key if they are empty.