### PR TITLE
feat: add feature for compiling .proto files with `protoc`

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@1.76.0
       with:
         components: clippy
-    - run: cargo clippy --tests --no-deps --all-features -- --deny clippy::all
+    - run: cargo clippy --tests --no-deps -- --deny clippy::all
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,6 +76,13 @@ jobs:
           rust_flags: "-Awarnings"
           experimental: false
 
+        - build: protoc
+          os: ubuntu-latest
+          rust: stable
+          args: "--package yara-x --features=protoc,magic-module"
+          rust_flags: "-Awarnings"
+          experimental: false
+
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
@@ -94,6 +101,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libmagic-dev
+
+    - name: Install protoc
+      if: matrix.build == 'protoc'
+      run: |
+        sudo apt-get install -y protobuf-compiler
+        cargo install protobuf-codegen
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
         - win-msvc
         # - win-gnu
         - no-default-features
+        - protoc
         include:
         - build: msrv
           os: ubuntu-latest

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -41,6 +41,14 @@ exact-atoms = []
 # the fast regexp matching mechanism for testing purposes.
 fast-regexp = []
 
+# Whether to use protoc for parsing and compiling .proto files. By default,
+# .proto files are parsed and compiled by the pure-Rust compiler implemented
+# by the `rust-protobuf` crate. With this feature you can change this behavior
+# and use protoc, the official Protocol Buffer compiler. You'll need to have
+# protoc installed in your system, together with the protoc-gen-rust plugin.
+# Follow the instructions in: https://lib.rs/crates/protobuf-codegen3
+protoc = []
+
 # Enables debug logs.
 logging = ["dep:log"]
 

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -143,11 +143,15 @@ fn main() {
     let mut proto_compiler = Codegen::new();
     let mut proto_parser = Parser::new();
 
-    proto_compiler
-        .pure()
-        .cargo_out_dir("protos")
-        .include("src/modules/protos");
+    if cfg!(feature = "protoc") {
+        proto_compiler.protoc();
+        proto_parser.protoc();
+    } else {
+        proto_compiler.pure();
+        proto_parser.pure();
+    }
 
+    proto_compiler.cargo_out_dir("protos").include("src/modules/protos");
     proto_parser.include("src/modules/protos");
 
     // All `.proto` files in src/modules/protos must be compiled

--- a/lib/src/modules/macho/parser.rs
+++ b/lib/src/modules/macho/parser.rs
@@ -1835,7 +1835,7 @@ impl From<&MinVersion> for protos::macho::MinVersion {
         let mut result = protos::macho::MinVersion::new();
 
         result.set_device(
-            protobuf::EnumOrUnknown::<protos::macho::DEVICE_TYPE>::from_i32(
+            protobuf::EnumOrUnknown::<protos::macho::DeviceType>::from_i32(
                 mv.device as i32,
             )
             .unwrap(),

--- a/lib/src/modules/pe/mod.rs
+++ b/lib/src/modules/pe/mod.rs
@@ -44,14 +44,14 @@ fn main(input: &[u8]) -> PE {
 #[module_export]
 fn is_32bit(ctx: &ScanContext) -> Option<bool> {
     let magic = ctx.module_output::<PE>()?.opthdr_magic?;
-    Some(magic.value() == OptHdrMagic::IMAGE_NT_OPTIONAL_HDR32_MAGIC as i32)
+    Some(magic.value() == OptionalMagic::IMAGE_NT_OPTIONAL_HDR32_MAGIC as i32)
 }
 
 /// Returns true if the file is a 64-bit PE.
 #[module_export]
 fn is_64bit(ctx: &ScanContext) -> Option<bool> {
     let magic = ctx.module_output::<PE>()?.opthdr_magic?;
-    Some(magic.value() == OptHdrMagic::IMAGE_NT_OPTIONAL_HDR64_MAGIC as i32)
+    Some(magic.value() == OptionalMagic::IMAGE_NT_OPTIONAL_HDR64_MAGIC as i32)
 }
 
 /// Returns true if the file is dynamic link library (DLL)

--- a/lib/src/modules/pe/parser.rs
+++ b/lib/src/modules/pe/parser.rs
@@ -2213,7 +2213,7 @@ impl From<PE<'_>> for protos::pe::PE {
         result.set_number_of_symbols(pe.pe_hdr.number_of_symbols);
         result.set_size_of_optional_header(pe.pe_hdr.size_of_optional_header.into());
 
-        result.opthdr_magic = Some(EnumOrUnknown::<protos::pe::OptHdrMagic>::from_i32(pe
+        result.opthdr_magic = Some(EnumOrUnknown::<protos::pe::OptionalMagic>::from_i32(pe
             .optional_hdr
             .magic.into()));
 

--- a/lib/src/modules/protos/macho.proto
+++ b/lib/src/modules/protos/macho.proto
@@ -113,7 +113,7 @@ message Segment {
   optional uint32 maxprot = 8 [(yaml.field).fmt = "x"];
   optional uint32 initprot = 9 [(yaml.field).fmt = "x"];
   optional uint32 nsects = 10;
-  optional uint32 flags = 11 [(yaml.field).fmt = "flags:SEGMENT_FLAG"];
+  optional uint32 flags = 11 [(yaml.field).fmt = "flags:SegmentFlag"];
   repeated Section sections = 12;
 }
 
@@ -133,7 +133,7 @@ message File {
   optional uint32 filetype = 4;
   optional uint32 ncmds = 5;
   optional uint32 sizeofcmds = 6;
-  optional uint32 flags = 7 [(yaml.field).fmt = "flags:FILE_FLAG"];
+  optional uint32 flags = 7 [(yaml.field).fmt = "flags:FileFlag"];
   optional uint32 reserved = 8;
   optional uint64 number_of_segments = 9;
   optional bytes dynamic_linker = 10;

--- a/lib/src/modules/protos/macho.proto
+++ b/lib/src/modules/protos/macho.proto
@@ -12,7 +12,7 @@ option (yara.module_options) = {
 };
 
 message MinVersion {
-  optional DEVICE_TYPE device = 1;
+  optional DeviceType device = 1;
   optional string version = 2;
   optional string sdk = 3;
 }
@@ -194,7 +194,7 @@ message Macho {
   repeated File file = 30;
 }
 
-enum HEADER {
+enum Header {
   option (yara.enum_options).inline = true;
   MH_MAGIC = 0 [(yara.enum_value).i64 = 0xfeedface];
   MH_CIGAM = 1 [(yara.enum_value).i64 = 0xcefaedfe];
@@ -202,7 +202,7 @@ enum HEADER {
   MH_CIGAM_64 = 3 [(yara.enum_value).i64 = 0xcffaedfe];
 }
 
-enum FAT_HEADER {
+enum FatHeader {
   option (yara.enum_options).inline = true;
   FAT_MAGIC = 0 [(yara.enum_value).i64 = 0xcafebabe];
   FAT_CIGAM = 1 [(yara.enum_value).i64 = 0xbebafeca];
@@ -210,13 +210,13 @@ enum FAT_HEADER {
   FAT_CIGAM_64 = 3 [(yara.enum_value).i64 = 0xbfbafeca];
 }
 
-enum MASK_64BIT {
+enum Mask64Bit {
   option (yara.enum_options).inline = true;
   CPU_ARCH_ABI64 = 0x01000000;
   CPU_SUBTYPE_LIB64 = 0 [(yara.enum_value).i64 = 0x80000000];
 }
 
-enum CPU_TYPE {
+enum CpuType {
   option (yara.enum_options).inline = true;
   CPU_TYPE_MC680X0 = 0x00000006;
   CPU_TYPE_X86 = 0x00000007;
@@ -231,12 +231,12 @@ enum CPU_TYPE {
   CPU_TYPE_POWERPC64 = 0x01000012;
 }
 
-enum CPU_I386_TYPE {
+enum CpuI386Type {
   option (yara.enum_options).inline = true;
   CPU_TYPE_I386 = 0x00000007;
 }
 
-enum CPU_INTEL_SUBTYPE {
+enum CpuIntelSubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_INTEL_MODEL_ALL = 0x00000000;
   CPU_SUBTYPE_386 = 0x00000003;
@@ -251,17 +251,17 @@ enum CPU_INTEL_SUBTYPE {
   CPU_SUBTYPE_XEON_MP = 0x0000001c;
 }
 
-enum CPU_I386_SUBTYPE {
+enum CpuI386SubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_I386_ALL = 0x00000003;
 }
 
-enum CPU_X86_SUBTYPE {
+enum CpuX86SubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_X86_64_ALL = 0x00000003;
 }
 
-enum CPU_INTEL_PENTIUM_SUBTYPE {
+enum CpuIntelPentiumSubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_PENT = 0x00000005;
   CPU_SUBTYPE_PENTPRO = 0x00000016;
@@ -275,7 +275,7 @@ enum CPU_INTEL_PENTIUM_SUBTYPE {
   CPU_SUBTYPE_PENTIUM_4_M = 0x0000001a;
 }
 
-enum CPU_ARM_SUBTYPE {
+enum CpuArmSubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_ARM_ALL = 0x00000000;
   CPU_SUBTYPE_ARM_V4T = 0x00000005;
@@ -291,18 +291,18 @@ enum CPU_ARM_SUBTYPE {
   CPU_SUBTYPE_ARM_V7EM = 0x00000010;
 }
 
-enum CPU_ARM_64_SUBTYPE {
+enum CpuArm64SubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_ARM_V5TEJ = 0x00000007;
   CPU_SUBTYPE_ARM64_ALL = 0x00000000;
 }
 
-enum CPU_SPARC_SUBTYPE {
+enum CpuSparcSubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_SPARC_ALL = 0x00000000;
 }
 
-enum CPU_POWERPC_SUBTYPE {
+enum CpuPowerPCSubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_POWERPC_ALL = 0x00000000;
   CPU_SUBTYPE_POWERPC_601 = 0x00000001;
@@ -319,13 +319,13 @@ enum CPU_POWERPC_SUBTYPE {
   CPU_SUBTYPE_POWERPC_970 = 0x00000064;
 }
 
-enum CPU_MC_SUBTYPE {
+enum CpuMcSubType {
   option (yara.enum_options).inline = true;
   CPU_SUBTYPE_MC980000_ALL = 0x00000000;
   CPU_SUBTYPE_MC98601 = 0x00000001;
 }
 
-enum FILE_TYPE {
+enum FileType {
   option (yara.enum_options).inline = true;
   MH_OBJECT = 0x00000001;
   MH_EXECUTE = 0x00000002;
@@ -340,7 +340,7 @@ enum FILE_TYPE {
   MH_KEXT_BUNDLE = 0x0000000b;
 }
 
-enum FILE_FLAG {
+enum FileFlag {
   option (yara.enum_options).inline = true;
   MH_NOUNDEFS = 0x00000001;
   MH_INCRLINK = 0x00000002;
@@ -370,7 +370,7 @@ enum FILE_FLAG {
   MH_APP_EXTENSION_SAFE = 0x02000000;
 }
 
-enum SEGMENT_FLAG {
+enum SegmentFlag {
   option (yara.enum_options).inline = true;
   SG_HIGHVM = 0x00000001;
   SG_FVMLIB = 0x00000002;
@@ -378,13 +378,13 @@ enum SEGMENT_FLAG {
   SG_PROTECTED_VERSION_1 = 0x00000008;
 }
 
-enum SECTION_FLAG_MASK {
+enum SectionFlagMask {
   option (yara.enum_options).inline = true;
   SECTION_TYPE = 0x000000ff;
   SECTION_ATTRIBUTES = 0 [(yara.enum_value).i64 = 0xffffff00];
 }
 
-enum SECTION_TYPE {
+enum SectionType {
   option (yara.enum_options).inline = true;
   S_REGULAR = 0x00000000;
   S_ZEROFILL = 0x00000001;
@@ -410,7 +410,7 @@ enum SECTION_TYPE {
   S_THREAD_LOCAL_INIT_FUNCTION_POINTERS = 0x00000015;
 }
 
-enum SECTION_ATTRIBUTES {
+enum SectionAttributes {
   option (yara.enum_options).inline = true;
   S_ATTR_PURE_INSTRUCTIONS = 0 [(yara.enum_value).i64 = 0x80000000];
   S_ATTR_NO_TOC = 0x40000000;
@@ -424,7 +424,7 @@ enum SECTION_ATTRIBUTES {
   S_ATTR_LOC_RELOC = 0x00000100;
 }
 
-enum DEVICE_TYPE {
+enum DeviceType {
   option (yara.enum_options).inline = true;
   MACOSX = 0x00000024;
   IPHONEOS = 0x00000025;

--- a/lib/src/modules/protos/pe.proto
+++ b/lib/src/modules/protos/pe.proto
@@ -20,7 +20,7 @@ message PE {
   optional Version subsystem_version = 5;
   optional Version image_version = 6;
   optional Version linker_version = 7;
-  optional OptHdrMagic opthdr_magic = 8;
+  optional OptionalMagic opthdr_magic = 8;
   optional uint32 characteristics = 9 [(yaml.field).fmt = "flags:Characteristics"];
   optional uint32 dll_characteristics = 10 [(yaml.field).fmt = "flags:DllCharacteristics"];
   optional uint32 timestamp = 11 [(yaml.field).fmt = "t"];
@@ -122,7 +122,7 @@ message Import {
 }
 
 message Export {
-  optional string name= 1;
+  optional string name = 1;
   required uint32 ordinal = 2;
   required uint32 rva = 3;
   optional uint32 offset = 4;
@@ -263,45 +263,45 @@ message Overlay {
 
 enum Machine {
   option (yara.enum_options).inline = true;
-  MACHINE_UNKNOWN   = 0x0000;
-  MACHINE_AM33      = 0x01d3;
-  MACHINE_AMD64     = 0x8664;
-  MACHINE_ARM       = 0x01c0;
-  MACHINE_ARMNT     = 0x01c4;
-  MACHINE_ARM64     = 0xaa64;
-  MACHINE_EBC       = 0x0ebc;
-  MACHINE_I386      = 0x014c;
-  MACHINE_IA64      = 0x0200;
-  MACHINE_M32R      = 0x9041;
-  MACHINE_MIPS16    = 0x0266;
-  MACHINE_MIPSFPU   = 0x0366;
+  MACHINE_UNKNOWN = 0x0000;
+  MACHINE_AM33 = 0x01d3;
+  MACHINE_AMD64 = 0x8664;
+  MACHINE_ARM = 0x01c0;
+  MACHINE_ARMNT = 0x01c4;
+  MACHINE_ARM64 = 0xaa64;
+  MACHINE_EBC = 0x0ebc;
+  MACHINE_I386 = 0x014c;
+  MACHINE_IA64 = 0x0200;
+  MACHINE_M32R = 0x9041;
+  MACHINE_MIPS16 = 0x0266;
+  MACHINE_MIPSFPU = 0x0366;
   MACHINE_MIPSFPU16 = 0x0466;
-  MACHINE_POWERPC   = 0x01f0;
+  MACHINE_POWERPC = 0x01f0;
   MACHINE_POWERPCFP = 0x01f1;
-  MACHINE_R4000     = 0x0166;
-  MACHINE_SH3       = 0x01a2;
-  MACHINE_SH3DSP    = 0x01a3;
-  MACHINE_SH4       = 0x01a6;
-  MACHINE_SH5       = 0x01a8;
-  MACHINE_THUMB     = 0x01c2;
+  MACHINE_R4000 = 0x0166;
+  MACHINE_SH3 = 0x01a2;
+  MACHINE_SH3DSP = 0x01a3;
+  MACHINE_SH4 = 0x01a6;
+  MACHINE_SH5 = 0x01a8;
+  MACHINE_THUMB = 0x01c2;
   MACHINE_WCEMIPSV2 = 0x0169;
 }
 
 enum Subsystem {
   option (yara.enum_options).inline = true;
-  SUBSYSTEM_UNKNOWN                  = 0;
-  SUBSYSTEM_NATIVE                   = 1;
-  SUBSYSTEM_WINDOWS_GUI              = 2;
-  SUBSYSTEM_WINDOWS_CUI              = 3;
-  SUBSYSTEM_OS2_CUI                  = 5;
-  SUBSYSTEM_POSIX_CUI                = 7;
-  SUBSYSTEM_NATIVE_WINDOWS           = 8;
-  SUBSYSTEM_WINDOWS_CE_GUI           = 9;
-  SUBSYSTEM_EFI_APPLICATION          = 10;
-  SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER  = 11;
-  SUBSYSTEM_EFI_RUNTIME_DRIVER       = 12;
-  SUBSYSTEM_EFI_ROM_IMAGE            = 13;
-  SUBSYSTEM_XBOX                     = 14;
+  SUBSYSTEM_UNKNOWN = 0;
+  SUBSYSTEM_NATIVE = 1;
+  SUBSYSTEM_WINDOWS_GUI = 2;
+  SUBSYSTEM_WINDOWS_CUI = 3;
+  SUBSYSTEM_OS2_CUI = 5;
+  SUBSYSTEM_POSIX_CUI = 7;
+  SUBSYSTEM_NATIVE_WINDOWS = 8;
+  SUBSYSTEM_WINDOWS_CE_GUI = 9;
+  SUBSYSTEM_EFI_APPLICATION = 10;
+  SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER = 11;
+  SUBSYSTEM_EFI_RUNTIME_DRIVER = 12;
+  SUBSYSTEM_EFI_ROM_IMAGE = 13;
+  SUBSYSTEM_XBOX = 14;
   SUBSYSTEM_WINDOWS_BOOT_APPLICATION = 16;
 }
 
@@ -312,123 +312,118 @@ enum ImportFlags {
   IMPORT_ANY = 0x03;
 }
 
-enum OptHdrMagic {
-  IMAGE_NT_OPTIONAL_HDR32_MAGIC = 0x10b;
-  IMAGE_NT_OPTIONAL_HDR64_MAGIC = 0x20b;
-}
-
 enum Characteristics {
   option (yara.enum_options).inline = true;
   // Relocation info stripped from file.
-  RELOCS_STRIPPED         = 0x0001;
+  RELOCS_STRIPPED = 0x0001;
   // File is executable (i.e. no unresolved external references).
-  EXECUTABLE_IMAGE        = 0x0002;
+  EXECUTABLE_IMAGE = 0x0002;
   // Line numbers stripped from file.
-  LINE_NUMS_STRIPPED      = 0x0004;
+  LINE_NUMS_STRIPPED = 0x0004;
   // Local symbols stripped from file.
-  LOCAL_SYMS_STRIPPED     = 0x0008;
+  LOCAL_SYMS_STRIPPED = 0x0008;
   // Aggressively trim working set
-  AGGRESIVE_WS_TRIM       = 0x0010;
+  AGGRESIVE_WS_TRIM = 0x0010;
   // App can handle >2gb addresses
-  LARGE_ADDRESS_AWARE     = 0x0020;
+  LARGE_ADDRESS_AWARE = 0x0020;
   // Bytes of machine word are reversed.
-  BYTES_REVERSED_LO       = 0x0080;
+  BYTES_REVERSED_LO = 0x0080;
   // 32 bit word machine.
-  MACHINE_32BIT           = 0x0100;
+  MACHINE_32BIT = 0x0100;
   // Debugging info stripped from file in .DBG file
-  DEBUG_STRIPPED          = 0x0200;
+  DEBUG_STRIPPED = 0x0200;
   // If Image is on removable media, copy and run from the swap file.
   REMOVABLE_RUN_FROM_SWAP = 0x0400;
   // If Image is on Net, copy and run from the swap file.
-  NET_RUN_FROM_SWAP       = 0x0800;
+  NET_RUN_FROM_SWAP = 0x0800;
   // System File.
-  SYSTEM                  = 0x1000;
+  SYSTEM = 0x1000;
   // File is a DLL.s
-  DLL                     = 0x2000;
+  DLL = 0x2000;
   // File should only be run on a UP machine
-  UP_SYSTEM_ONLY          = 0x4000;
+  UP_SYSTEM_ONLY = 0x4000;
   // Bytes of machine word are reversed.
-  BYTES_REVERSED_HI       = 0x8000;
+  BYTES_REVERSED_HI = 0x8000;
 }
 
 enum OptionalMagic {
   option (yara.enum_options).inline = true;
   IMAGE_NT_OPTIONAL_HDR32_MAGIC = 0x10b;
   IMAGE_NT_OPTIONAL_HDR64_MAGIC = 0x20b;
-  IMAGE_ROM_OPTIONAL_HDR_MAGIC  = 0x107;
+  IMAGE_ROM_OPTIONAL_HDR_MAGIC = 0x107;
 }
 
 enum DirectoryEntry {
   option (yara.enum_options).inline = true;
-  IMAGE_DIRECTORY_ENTRY_EXPORT        =  0  [(yara.enum_value).i64 = 0];
-  IMAGE_DIRECTORY_ENTRY_IMPORT        =  1  [(yara.enum_value).i64 = 1];
-  IMAGE_DIRECTORY_ENTRY_RESOURCE      =  2  [(yara.enum_value).i64 = 2];
-  IMAGE_DIRECTORY_ENTRY_EXCEPTION     =  3  [(yara.enum_value).i64 = 3];
-  IMAGE_DIRECTORY_ENTRY_SECURITY      =  4  [(yara.enum_value).i64 = 4];
-  IMAGE_DIRECTORY_ENTRY_BASERELOC     =  5  [(yara.enum_value).i64 = 5];
-  IMAGE_DIRECTORY_ENTRY_DEBUG         =  6  [(yara.enum_value).i64 = 6];
+  IMAGE_DIRECTORY_ENTRY_EXPORT = 0  [(yara.enum_value).i64 = 0];
+  IMAGE_DIRECTORY_ENTRY_IMPORT = 1  [(yara.enum_value).i64 = 1];
+  IMAGE_DIRECTORY_ENTRY_RESOURCE = 2  [(yara.enum_value).i64 = 2];
+  IMAGE_DIRECTORY_ENTRY_EXCEPTION = 3  [(yara.enum_value).i64 = 3];
+  IMAGE_DIRECTORY_ENTRY_SECURITY = 4  [(yara.enum_value).i64 = 4];
+  IMAGE_DIRECTORY_ENTRY_BASERELOC = 5  [(yara.enum_value).i64 = 5];
+  IMAGE_DIRECTORY_ENTRY_DEBUG = 6  [(yara.enum_value).i64 = 6];
   // IMAGE_DIRECTORY_ENTRY_COPYRIGHT and IMAGE_DIRECTORY_ENTRY_ARCHITECTURE
   // have the same value (7).
-  IMAGE_DIRECTORY_ENTRY_COPYRIGHT     =  7  [(yara.enum_value).i64 = 7];
-  IMAGE_DIRECTORY_ENTRY_ARCHITECTURE  =  8  [(yara.enum_value).i64 = 7];
-  IMAGE_DIRECTORY_ENTRY_GLOBALPTR     =  9  [(yara.enum_value).i64 = 8];
-  IMAGE_DIRECTORY_ENTRY_TLS           =  10 [(yara.enum_value).i64 = 9];
-  IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG    = 11 [(yara.enum_value).i64 = 10];
-  IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT   = 12 [(yara.enum_value).i64 = 11];
-  IMAGE_DIRECTORY_ENTRY_IAT            = 13 [(yara.enum_value).i64 = 12];
-  IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT   = 14 [(yara.enum_value).i64 = 13];
+  IMAGE_DIRECTORY_ENTRY_COPYRIGHT = 7  [(yara.enum_value).i64 = 7];
+  IMAGE_DIRECTORY_ENTRY_ARCHITECTURE = 8  [(yara.enum_value).i64 = 7];
+  IMAGE_DIRECTORY_ENTRY_GLOBALPTR = 9  [(yara.enum_value).i64 = 8];
+  IMAGE_DIRECTORY_ENTRY_TLS = 10 [(yara.enum_value).i64 = 9];
+  IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG = 11 [(yara.enum_value).i64 = 10];
+  IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT = 12 [(yara.enum_value).i64 = 11];
+  IMAGE_DIRECTORY_ENTRY_IAT = 13 [(yara.enum_value).i64 = 12];
+  IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT = 14 [(yara.enum_value).i64 = 13];
   IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR = 15 [(yara.enum_value).i64 = 14];
 }
 
 enum SectionCharacteristics {
   option (yara.enum_options).inline = true;
-  SECTION_NO_PAD                 = 1 [(yara.enum_value).i64 = 0x00000008];
-  SECTION_CNT_CODE               = 2 [(yara.enum_value).i64 = 0x00000020];
-  SECTION_CNT_INITIALIZED_DATA   = 3 [(yara.enum_value).i64 = 0x00000040];
+  SECTION_NO_PAD = 1 [(yara.enum_value).i64 = 0x00000008];
+  SECTION_CNT_CODE = 2 [(yara.enum_value).i64 = 0x00000020];
+  SECTION_CNT_INITIALIZED_DATA = 3 [(yara.enum_value).i64 = 0x00000040];
   SECTION_CNT_UNINITIALIZED_DATA = 4 [(yara.enum_value).i64 = 0x00000080];
-  SECTION_LNK_OTHER              = 5 [(yara.enum_value).i64 = 0x00000100];
-  SECTION_LNK_INFO               = 6 [(yara.enum_value).i64 = 0x00000200];
-  SECTION_LNK_REMOVE             = 7 [(yara.enum_value).i64 = 0x00000800];
-  SECTION_LNK_COMDAT             = 8 [(yara.enum_value).i64 = 0x00001000];
-  SECTION_NO_DEFER_SPEC_EXC      = 9 [(yara.enum_value).i64 = 0x00004000];
-  SECTION_GPREL                  = 10 [(yara.enum_value).i64 = 0x00008000];
-  SECTION_ALIGN_1BYTES           = 11 [(yara.enum_value).i64 = 0x00100000];
-  SECTION_ALIGN_2BYTES           = 12 [(yara.enum_value).i64 = 0x00200000];
-  SECTION_ALIGN_4BYTES           = 13 [(yara.enum_value).i64 = 0x00300000];
-  SECTION_ALIGN_8BYTES           = 14 [(yara.enum_value).i64 = 0x00400000];
-  SECTION_ALIGN_16BYTES          = 15 [(yara.enum_value).i64 = 0x00500000];
-  SECTION_ALIGN_32BYTES          = 16 [(yara.enum_value).i64 = 0x00600000];
-  SECTION_ALIGN_64BYTES          = 17 [(yara.enum_value).i64 = 0x00700000];
-  SECTION_ALIGN_128BYTES         = 18 [(yara.enum_value).i64 = 0x00800000];
-  SECTION_ALIGN_256BYTES         = 19 [(yara.enum_value).i64 = 0x00900000];
-  SECTION_ALIGN_512BYTES         = 20 [(yara.enum_value).i64 = 0x00A00000];
-  SECTION_ALIGN_1024BYTES        = 21 [(yara.enum_value).i64 = 0x00B00000];
-  SECTION_ALIGN_2048BYTES        = 22 [(yara.enum_value).i64 = 0x00C00000];
-  SECTION_ALIGN_4096BYTES        = 23 [(yara.enum_value).i64 = 0x00D00000];
-  SECTION_ALIGN_8192BYTES        = 24 [(yara.enum_value).i64 = 0x00E00000];
-  SECTION_ALIGN_MASK             = 25 [(yara.enum_value).i64 = 0x00F00000];
-  SECTION_LNK_NRELOC_OVFL        = 26 [(yara.enum_value).i64 = 0x01000000];
-  SECTION_MEM_DISCARDABLE        = 27 [(yara.enum_value).i64 = 0x02000000];
-  SECTION_MEM_NOT_CACHED         = 28 [(yara.enum_value).i64 = 0x04000000];
-  SECTION_MEM_NOT_PAGED          = 29 [(yara.enum_value).i64 = 0x08000000];
-  SECTION_MEM_SHARED             = 30 [(yara.enum_value).i64 = 0x10000000];
-  SECTION_MEM_EXECUTE            = 31 [(yara.enum_value).i64 = 0x20000000];
-  SECTION_MEM_READ               = 32 [(yara.enum_value).i64 = 0x40000000];
-  SECTION_MEM_WRITE              = 33 [(yara.enum_value).i64 = 0x80000000];
-  SECTION_SCALE_INDEX            = 34 [(yara.enum_value).i64 = 0x00000001];
+  SECTION_LNK_OTHER = 5 [(yara.enum_value).i64 = 0x00000100];
+  SECTION_LNK_INFO = 6 [(yara.enum_value).i64 = 0x00000200];
+  SECTION_LNK_REMOVE = 7 [(yara.enum_value).i64 = 0x00000800];
+  SECTION_LNK_COMDAT = 8 [(yara.enum_value).i64 = 0x00001000];
+  SECTION_NO_DEFER_SPEC_EXC = 9 [(yara.enum_value).i64 = 0x00004000];
+  SECTION_GPREL = 10 [(yara.enum_value).i64 = 0x00008000];
+  SECTION_ALIGN_1BYTES = 11 [(yara.enum_value).i64 = 0x00100000];
+  SECTION_ALIGN_2BYTES = 12 [(yara.enum_value).i64 = 0x00200000];
+  SECTION_ALIGN_4BYTES = 13 [(yara.enum_value).i64 = 0x00300000];
+  SECTION_ALIGN_8BYTES = 14 [(yara.enum_value).i64 = 0x00400000];
+  SECTION_ALIGN_16BYTES = 15 [(yara.enum_value).i64 = 0x00500000];
+  SECTION_ALIGN_32BYTES = 16 [(yara.enum_value).i64 = 0x00600000];
+  SECTION_ALIGN_64BYTES = 17 [(yara.enum_value).i64 = 0x00700000];
+  SECTION_ALIGN_128BYTES = 18 [(yara.enum_value).i64 = 0x00800000];
+  SECTION_ALIGN_256BYTES = 19 [(yara.enum_value).i64 = 0x00900000];
+  SECTION_ALIGN_512BYTES = 20 [(yara.enum_value).i64 = 0x00A00000];
+  SECTION_ALIGN_1024BYTES = 21 [(yara.enum_value).i64 = 0x00B00000];
+  SECTION_ALIGN_2048BYTES = 22 [(yara.enum_value).i64 = 0x00C00000];
+  SECTION_ALIGN_4096BYTES = 23 [(yara.enum_value).i64 = 0x00D00000];
+  SECTION_ALIGN_8192BYTES = 24 [(yara.enum_value).i64 = 0x00E00000];
+  SECTION_ALIGN_MASK = 25 [(yara.enum_value).i64 = 0x00F00000];
+  SECTION_LNK_NRELOC_OVFL = 26 [(yara.enum_value).i64 = 0x01000000];
+  SECTION_MEM_DISCARDABLE = 27 [(yara.enum_value).i64 = 0x02000000];
+  SECTION_MEM_NOT_CACHED = 28 [(yara.enum_value).i64 = 0x04000000];
+  SECTION_MEM_NOT_PAGED = 29 [(yara.enum_value).i64 = 0x08000000];
+  SECTION_MEM_SHARED = 30 [(yara.enum_value).i64 = 0x10000000];
+  SECTION_MEM_EXECUTE = 31 [(yara.enum_value).i64 = 0x20000000];
+  SECTION_MEM_READ = 32 [(yara.enum_value).i64 = 0x40000000];
+  SECTION_MEM_WRITE = 33 [(yara.enum_value).i64 = 0x80000000];
+  SECTION_SCALE_INDEX = 34 [(yara.enum_value).i64 = 0x00000001];
 }
 
 enum DllCharacteristics {
   option (yara.enum_options).inline = true;
-  HIGH_ENTROPY_VA       = 0x0020;
-  DYNAMIC_BASE          = 0x0040;
-  FORCE_INTEGRITY       = 0x0080;
-  NX_COMPAT             = 0x0100;
-  NO_ISOLATION          = 0x0200;
-  NO_SEH                = 0x0400;
-  NO_BIND               = 0x0800;
-  APPCONTAINER          = 0x1000;
-  WDM_DRIVER            = 0x2000;
-  GUARD_CF              = 0x4000;
+  HIGH_ENTROPY_VA = 0x0020;
+  DYNAMIC_BASE = 0x0040;
+  FORCE_INTEGRITY = 0x0080;
+  NX_COMPAT = 0x0100;
+  NO_ISOLATION = 0x0200;
+  NO_SEH = 0x0400;
+  NO_BIND = 0x0800;
+  APPCONTAINER = 0x1000;
+  WDM_DRIVER = 0x2000;
+  GUARD_CF = 0x4000;
   TERMINAL_SERVER_AWARE = 0x8000;
 }

--- a/lib/src/modules/protos/test_proto2.proto
+++ b/lib/src/modules/protos/test_proto2.proto
@@ -181,8 +181,8 @@ message TestProto2 {
   /// This field will be visible in YARA as `items` instead of `Enumeration2`.
   enum Enumeration2 {
     option (yara.enum_options).name = "items";
-    ITEM_0 = 0;
-    ITEM_1 = 1;
+    ITEM_4 = 0;
+    ITEM_5 = 1;
   }
 
   optional uint64 file_size = 400;

--- a/lib/src/modules/protos/yaml.proto
+++ b/lib/src/modules/protos/yaml.proto
@@ -5,9 +5,9 @@ package yaml;
 import "google/protobuf/descriptor.proto";
 
 message FieldOptions {
-    optional string fmt = 3;
+  optional string fmt = 3;
 }
 
 extend google.protobuf.FieldOptions {
-    optional FieldOptions field = 51504;
+  optional FieldOptions field = 60000;
 }

--- a/lib/src/symbols/mod.rs
+++ b/lib/src/symbols/mod.rs
@@ -80,7 +80,7 @@ impl Symbol {
 /// Implements [`SymbolLookup`] for `Option<Symbol>` so that lookup
 /// operations can be chained.
 ///
-/// For example you can do:
+/// For example, you can do:
 ///
 /// ```text
 /// symbol_table.lookup("foo").lookup("bar")
@@ -295,8 +295,8 @@ mod tests {
         );
 
         assert_eq!(
-            test.lookup("items").lookup("ITEM_1").unwrap().as_integer(),
-            Some(Enumeration2::ITEM_1.value() as i64)
+            test.lookup("items").lookup("ITEM_4").unwrap().as_integer(),
+            Some(Enumeration2::ITEM_4.value() as i64)
         );
     }
 

--- a/proto-yaml/src/yaml.proto
+++ b/proto-yaml/src/yaml.proto
@@ -5,9 +5,9 @@ package yaml;
 import "google/protobuf/descriptor.proto";
 
 message FieldOptions {
-    optional string fmt = 3;
+  optional string fmt = 3;
 }
 
 extend google.protobuf.FieldOptions {
-    optional FieldOptions field = 51504;
+  optional FieldOptions field = 60000;
 }


### PR DESCRIPTION
By default, .proto files are compiled using the pure-Rust compiler implemented by the `protobuf-rust`, but the `protoc` feature allows switching to `protoc`, the official Protobuf compiler. 

This required some changes in .proto files, because `protoc` is stricter than the pure-Rust protobuf compiler.
