### PR TITLE
fix: setns related issues

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -229,7 +229,10 @@ thiserror = { workspace = true }
 tlsh-fixed = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true, features = ["v4"] }
 walrus = { workspace = true }
-wasmtime = { workspace = true, default-features = false, features = ["cranelift", "parallel-compilation", "runtime"] }
+wasmtime = { workspace = true, default-features = false, features = [
+    "cranelift",
+    "runtime",
+] }
 x509-parser = { workspace = true, optional = true }
 yansi = { workspace = true }
 yara-x-macros = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -240,6 +240,10 @@ yara-x-parser = { workspace = true, features = ["serde"] }
 
 lingua = { version = "1.6.2", optional = true, default-features = false, features = ["english", "german", "french", "spanish"] }
 
+# syscalls crate is only available for Linux
+[target.'cfg(target_os = "linux")'.dependencies]
+syscalls = "0.6.18"
+
 [build-dependencies]
 anyhow = { workspace = true }
 globwalk = { workspace = true }

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -540,6 +540,15 @@ impl<'r> Scanner<'r> {
         if self.timeout.is_some() {
             INIT_HEARTBEAT.call_once(|| {
                 thread::spawn(|| loop {
+                    #[cfg(target_os = "linux")]
+                    unsafe {
+                        // unshare(CLONE_FS) preventing setns syscall to fail
+                        // if a timeout is set for the scanner.
+                        // see issue: https://github.com/VirusTotal/yara-x/issues/182
+                        syscalls::syscall!(syscalls::Sysno::unshare, 512)
+                            .unwrap();
+                    }
+
                     thread::sleep(Duration::from_secs(1));
                     ENGINE.increment_epoch();
                     HEARTBEAT_COUNTER


### PR DESCRIPTION
This PR addresses issues raised in https://github.com/VirusTotal/yara-x/issues/182

In short, there are issue using `setns` syscall in projects embedding `yara-x` as a dependency.
The reason is that `setns` does not work if the current thread has parent or child thread with `CLONE_FS` flag.

The following has been done in this PR:
 - allow library user to disable `wasmtime` parallelization **without** affecting default behavior.
 - fix heartbeat thread so that it doesn't affect `setns` syscall of projects embedding `yara-x` and using `Scanner::set_timeout`