### PR TITLE
fix: bug while using `--compiled-rules` without namespaces.

### DIFF
--- a/cli/src/commands/compile.rs
+++ b/cli/src/commands/compile.rs
@@ -62,8 +62,9 @@ pub fn compile() -> Command {
 }
 
 pub fn exec_compile(args: &ArgMatches) -> anyhow::Result<()> {
-    let rules_path =
-        args.get_many::<(String, PathBuf)>("[NAMESPACE:]RULES_PATH").unwrap();
+    let rules_path = args
+        .get_many::<(Option<String>, PathBuf)>("[NAMESPACE:]RULES_PATH")
+        .unwrap();
 
     let output_path = args.get_one::<PathBuf>("output").unwrap();
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -167,10 +167,12 @@ where
         w.filter("**/*.yar");
         w.filter("**/*.yara");
 
-        if let Some(namespace) = namespace {
-            compiler.new_namespace(namespace.as_str());
-        }
-
+        compiler.new_namespace(
+            namespace
+                .as_ref()
+                .map(|namespace| namespace.as_str())
+                .unwrap_or("default"),
+        );
 
         if let Err(err) = w.walk(
             |file_path| {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -104,18 +104,15 @@ fn meta_file_value_parser(
 /// `[NAMESPACE:]PATH`.
 ///
 /// Returns the namespace and the path. If the namespace is not provided
-/// returns "default".
+/// returns [`None`].
 fn path_with_namespace_parser(
     input: &str,
-) -> Result<(String, PathBuf), anyhow::Error> {
-    let (namespace, path) =
-        if let Some((namespace, path)) = input.split_once(':') {
-            (namespace, path)
-        } else {
-            ("default", input)
-        };
-    let path = PathBuf::from(path);
-    Ok((namespace.to_string(), path))
+) -> Result<(Option<String>, PathBuf), anyhow::Error> {
+    if let Some((namespace, path)) = input.split_once(':') {
+        Ok((Some(namespace.to_string()), PathBuf::from(path)))
+    } else {
+        Ok((None, PathBuf::from(input)))
+    }
 }
 
 pub fn compile_rules<'a, P>(
@@ -124,7 +121,7 @@ pub fn compile_rules<'a, P>(
     args: &ArgMatches,
 ) -> Result<Rules, anyhow::Error>
 where
-    P: Iterator<Item = &'a (String, PathBuf)>,
+    P: Iterator<Item = &'a (Option<String>, PathBuf)>,
 {
     let mut compiler: Compiler<'_> = Compiler::new();
 
@@ -170,7 +167,10 @@ where
         w.filter("**/*.yar");
         w.filter("**/*.yara");
 
-        compiler.new_namespace(namespace.as_str());
+        if let Some(namespace) = namespace {
+            compiler.new_namespace(namespace.as_str());
+        }
+
 
         if let Err(err) = w.walk(
             |file_path| {

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -170,8 +170,9 @@ pub fn scan() -> Command {
 }
 
 pub fn exec_scan(args: &ArgMatches) -> anyhow::Result<()> {
-    let mut rules_path =
-        args.get_many::<(String, PathBuf)>("[NAMESPACE:]RULES_PATH").unwrap();
+    let mut rules_path = args
+        .get_many::<(Option<String>, PathBuf)>("[NAMESPACE:]RULES_PATH")
+        .unwrap();
 
     let target_path = args.get_one::<PathBuf>("TARGET_PATH").unwrap();
     let compiled_rules = args.get_flag("compiled-rules");
@@ -204,7 +205,7 @@ pub fn exec_scan(args: &ArgMatches) -> anyhow::Result<()> {
 
         let (namespace, rules_path) = rules_path.next().unwrap();
 
-        if !namespace.is_empty() {
+        if namespace.is_some() {
             bail!(
                 "can't use namespace with '{}'",
                 Paint::bold("--compiled-rules")


### PR DESCRIPTION
The CLI was failing with an error telling that you can't use `--compiled-rules` with namespaces, even though no namespace was specified.