### PR TITLE
feat: serialize compiled rules in a platform-independent way.

### DIFF
--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -714,8 +714,9 @@ impl<'a> Compiler<'a> {
 
         let mut rules = Rules {
             serialized_globals,
+            wasm_mod,
+            compiled_wasm_mod: Some(compiled_wasm_mod),
             relaxed_re_syntax: self.relaxed_re_syntax,
-            wasm_mod: compiled_wasm_mod,
             ac: None,
             num_patterns: self.next_pattern_id.0 as usize,
             ident_pool: self.ident_pool,


### PR DESCRIPTION
With this change the `compile` command produces rules that can be used across different platforms. You can compile a set of rules in a Linux and use them in a Windows. Until now, the compiled rules were platform-specific, and could be used only in the same platform where it was compiled. 