### PR TITLE
refactor: improve implementation of regex repetitions

### DIFF
--- a/lib/src/compiler/tests/testdata/errors/138.in
+++ b/lib/src/compiler/tests/testdata/errors/138.in
@@ -1,0 +1,6 @@
+rule test {
+	strings:
+		$a = /abcd((efg){0,10000}){0,10000}/
+	condition:
+		$a
+}

--- a/lib/src/compiler/tests/testdata/errors/138.out
+++ b/lib/src/compiler/tests/testdata/errors/138.out
@@ -1,0 +1,6 @@
+error[E014]: invalid regular expression
+ --> line:3:3
+  |
+3 |   $a = /abcd((efg){0,10000}){0,10000}/
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ regexp is too large
+  |

--- a/lib/src/re/bitmapset.rs
+++ b/lib/src/re/bitmapset.rs
@@ -81,7 +81,7 @@ where
         if first.0 == key && first.1 == value {
             return false;
         }
-        
+
         let offset = key as isize - first.0 as isize;
 
         match offset {

--- a/lib/src/re/bitmapset.rs
+++ b/lib/src/re/bitmapset.rs
@@ -180,7 +180,7 @@ mod tests {
         assert!(s.insert(10, 0));
         assert!(s.insert(0, 0));
         assert!(s.insert(2000, 0));
-        
+
         assert!(!s.insert(4, 0));
         assert!(!s.insert(2, 0));
         assert!(!s.insert(3, 0));
@@ -192,7 +192,7 @@ mod tests {
 
         assert_eq!(
             s.items,
-            vec![(4, 0), (2, 0), (3,0), (10, 0), (0, 0), (2000, 0), (4, 1)]
+            vec![(4, 0), (2, 0), (3, 0), (10, 0), (0, 0), (2000, 0), (4, 1)]
         );
 
         s.clear();
@@ -205,7 +205,7 @@ mod tests {
         assert!(s.insert(10, 0));
         assert!(s.insert(300, 0));
         assert!(s.insert(250, 0));
-        
+
         assert_eq!(
             s.items,
             vec![(200, 0), (3, 0), (10, 0), (300, 0), (250, 0)]

--- a/lib/src/re/bitmapset.rs
+++ b/lib/src/re/bitmapset.rs
@@ -1,75 +1,80 @@
 use bitvec::vec::BitVec;
 
-/// A high-performance set of `usize` values.
+/// A high-performance set of (`usize`, T) pairs.
 ///
-/// As in any set, the values are guaranteed to be unique, the `insert`
-/// operation is a no-op if the new value already exists in the set.
-/// Additionally, this type supports iterating the values in insertion order.
+/// As in any set, the pairs are guaranteed to be unique, the `insert`
+/// operation is a no-op if the new pair already exists in the set.
+/// Additionally, this type supports iterating the pairs in insertion order.
 ///
 /// The distinguishing feature of this set lies in its utilization of bitmaps
-/// for efficient membership checks. However, practical limitations prevent
-/// having a bitmap with one bit per possible `usize` value, spanning from 0 to
-/// `usize::MAX`. Instead, positions in the bitmap are determined relative to
-/// the initial value inserted in the set. For instance, if the first value is
-/// `1234`, the first bitmap bit corresponds to `1234`, the second to `1235`,
-/// the third to `1236`, and so on. A separate bitmap is maintained for values
-/// lower than the initial one, with `1233` represented as the first bit in
-/// this other bitmap. Both bitmaps dynamically expand to accommodate newly
-/// inserted values.
+/// for checking if the `usize` key in a pair already exists in the set.
+/// However, practical limitations prevent having a bitmap with one bit per
+/// possible `usize` value, spanning from 0 to `usize::MAX`. Instead, positions
+/// in the bitmap are determined relative to the initial key inserted in the
+/// set. For instance, if the first value is (`1234`, T), the first bitmap bit
+/// corresponds to key `1234`, the second to key `1235`, the third to key
+/// `1236`, and so on. A separate bitmap is maintained for keys lower than
+/// the initial one, with `1233` represented as the first bit in this other
+/// bitmap. Both bitmaps dynamically expand to accommodate newly inserted
+/// values.
 ///
-/// `BitmapSet` works well with values that are close to each other. Outliers
+/// `BitmapSet` works well with keys that are close to each other. Outliers
 /// can make the memory required for storing the bitmaps to grow very quickly.
 /// Another property of this type is that values inserted in the set can be
 /// iterated in insertion order.
 #[derive(Debug, PartialEq, Default)]
-pub(crate) struct BitmapSet {
-    // Vector that contains the values in the set, in insertion order.
-    values: Vec<usize>,
-    // First value inserted in the set.
-    initial_value: usize,
-    // Bitmap for values that are > initial_value.
+pub(crate) struct BitmapSet<T>
+where
+    T: Default + Clone + PartialEq,
+{
+    // Vector that contains the (key,value) pairs in the map, in insertion
+    // order.
+    items: Vec<(usize, T)>,
+    // First key inserted in the set.
+    initial_key: usize,
+    // Bitmap for keys that are > initial_key.
     p_bitmap: BitVec<usize>,
-    // Bitmap for values that are < initial_value.
+    // Bitmap for keys that are < initial_key.
     n_bitmap: BitVec<usize>,
 }
 
-impl BitmapSet {
+impl<T> BitmapSet<T>
+where
+    T: Default + Clone + PartialEq,
+{
     pub const MAX_OFFSET: usize = 524288;
 
     pub fn new() -> Self {
         Self {
-            values: Vec::new(),
-            initial_value: 0,
+            items: Vec::new(),
             p_bitmap: BitVec::repeat(false, 1024),
             n_bitmap: BitVec::repeat(false, 1024),
+            ..Default::default()
         }
     }
 
-    /// Adds a value to the set.
+    /// Adds a (key,value) pair to the set.
     ///
-    /// Returns `true` if the value didn't exist in the set and was added, and
-    /// `false` if the value already existed.
+    /// Returns `true` if the (key,value) pair didn't exist in the map and was
+    /// added, and `false` if the pair already existed.
     ///
     /// # Panics
     ///
-    /// If `value` is too far from the first value added to the set.
-    /// Specifically, it panics when `abs(value - initial_value) >= MAX_OFFSET`
+    /// If `key` is too far from the first key added to the set.
+    /// Specifically, it panics when `abs(key - initial_key) >= MAX_OFFSET`
     ///
     #[inline]
-    pub fn insert(&mut self, value: usize) -> bool {
+    pub fn insert(&mut self, key: usize, value: T) -> bool {
         // Special case when the set is totally empty.
-        if self.values.is_empty() {
-            self.initial_value = value;
-            self.values.push(value);
+        if self.items.is_empty() {
+            self.initial_key = key;
+            self.p_bitmap.resize(1, false);
+            unsafe { self.p_bitmap.set_unchecked(0, true) };
+            self.items.push((key, value));
             return true;
         }
-        // Special case where the new value is equal to the first value
-        // added to the set. We don't need to spare a bit on this value.
-        if self.initial_value == value {
-            return false;
-        }
 
-        let offset = value as isize - self.initial_value as isize;
+        let offset = key as isize - self.initial_key as isize;
 
         match offset {
             offset if offset < 0 => {
@@ -79,11 +84,18 @@ impl BitmapSet {
                         assert!(offset < Self::MAX_OFFSET);
                         self.n_bitmap.resize(offset + 1, false);
                         self.n_bitmap.set_unchecked(offset, true);
-                        self.values.push(value);
+                        self.items.push((key, value));
                         true
                     } else if !*self.n_bitmap.get_unchecked(offset) {
                         self.n_bitmap.set_unchecked(offset, true);
-                        self.values.push(value);
+                        self.items.push((key, value));
+                        true
+                    } else if !self
+                        .items
+                        .iter()
+                        .any(|(k, v)| *k == key && v.eq(&value))
+                    {
+                        self.items.push((key, value));
                         true
                     } else {
                         false
@@ -91,19 +103,24 @@ impl BitmapSet {
                 }
             }
             offset => {
-                // At this point `offset` cannot be zero, it's safe to subtract
-                // 1 so that the first bit in the `p_bitmap` is used.
-                let offset = offset as usize - 1;
+                let offset = offset as usize;
                 unsafe {
                     if self.p_bitmap.len() <= offset {
                         assert!(offset < Self::MAX_OFFSET);
                         self.p_bitmap.resize(offset + 1, false);
                         self.p_bitmap.set_unchecked(offset, true);
-                        self.values.push(value);
+                        self.items.push((key, value));
                         true
                     } else if !*self.p_bitmap.get_unchecked(offset) {
                         self.p_bitmap.set_unchecked(offset, true);
-                        self.values.push(value);
+                        self.items.push((key, value));
+                        true
+                    } else if !self
+                        .items
+                        .iter()
+                        .any(|(k, v)| *k == key && v.eq(&value))
+                    {
+                        self.items.push((key, value));
                         true
                     } else {
                         false
@@ -115,24 +132,20 @@ impl BitmapSet {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.values.is_empty()
+        self.items.is_empty()
     }
 
     /// Removes all values in the set.
     #[inline]
     pub fn clear(&mut self) {
-        for thread in self.values.drain(0..) {
-            let offset = thread as isize - self.initial_value as isize;
+        for (key, _) in self.items.drain(0..) {
+            let offset = key as isize - self.initial_key as isize;
             match offset {
-                offset if offset > 0 => {
-                    self.p_bitmap.set((offset - 1) as usize, false);
-                }
                 offset if offset < 0 => {
                     self.n_bitmap.set((-offset) as usize, false);
                 }
-                _ => {
-                    // when `offset` is 0 there's no bit to clear, the initial
-                    // value doesn't have a bit in neither of the bitmaps.
+                offset => {
+                    self.p_bitmap.set(offset as usize, false);
                 }
             }
         }
@@ -141,8 +154,8 @@ impl BitmapSet {
     /// Returns an iterator for the items in the set.
     ///
     /// Items are returned in insertion order.
-    pub fn iter(&self) -> impl Iterator<Item = &usize> {
-        self.values.iter()
+    pub fn iter(&self) -> impl Iterator<Item = &(usize, T)> {
+        self.items.iter()
     }
 }
 
@@ -154,28 +167,48 @@ mod tests {
     fn thread_set() {
         let mut s = BitmapSet::new();
 
-        assert!(s.insert(4));
-        assert!(s.insert(2));
-        assert!(s.insert(10));
-        assert!(s.insert(0));
-        assert!(s.insert(2000));
+        assert!(s.insert(4, 0));
+        assert!(s.insert(2, 0));
+        assert!(s.insert(10, 0));
+        assert!(s.insert(0, 0));
+        assert!(s.insert(2000, 0));
 
-        assert!(!s.insert(4));
-        assert!(!s.insert(2));
-        assert!(!s.insert(10));
-        assert!(!s.insert(0));
-        assert!(!s.insert(2000));
+        assert_eq!(s.p_bitmap.count_ones(), 3);
+        assert_eq!(s.n_bitmap.count_ones(), 2);
 
-        assert_eq!(s.values, vec![4, 2, 10, 0, 2000]);
+        assert!(!s.insert(4, 0));
+        assert!(!s.insert(2, 0));
+        assert!(!s.insert(10, 0));
+        assert!(!s.insert(0, 0));
+        assert!(!s.insert(2000, 0));
+        assert!(s.insert(4, 1));
+        assert!(!s.insert(4, 1));
+
+        assert_eq!(s.p_bitmap.count_ones(), 3);
+        assert_eq!(s.n_bitmap.count_ones(), 2);
+
+        assert_eq!(
+            s.items,
+            vec![(4, 0), (2, 0), (10, 0), (0, 0), (2000, 0), (4, 1)]
+        );
 
         s.clear();
 
-        assert!(s.insert(200));
-        assert!(s.insert(2));
-        assert!(s.insert(10));
-        assert!(s.insert(300));
-        assert!(s.insert(250));
+        assert_eq!(s.p_bitmap.count_ones(), 0);
+        assert_eq!(s.n_bitmap.count_ones(), 0);
 
-        assert_eq!(s.values, vec![200, 2, 10, 300, 250]);
+        assert!(s.insert(200, 0));
+        assert!(s.insert(3, 0));
+        assert!(s.insert(10, 0));
+        assert!(s.insert(300, 0));
+        assert!(s.insert(250, 0));
+
+        assert_eq!(s.p_bitmap.count_ones(), 3);
+        assert_eq!(s.n_bitmap.count_ones(), 2);
+
+        assert_eq!(
+            s.items,
+            vec![(200, 0), (3, 0), (10, 0), (300, 0), (250, 0)]
+        );
     }
 }

--- a/lib/src/re/bitmapset.rs
+++ b/lib/src/re/bitmapset.rs
@@ -144,11 +144,6 @@ impl BitmapSet {
     pub fn iter(&self) -> impl Iterator<Item = &usize> {
         self.values.iter()
     }
-
-    #[cfg(test)]
-    pub fn into_vec(self) -> Vec<usize> {
-        self.values
-    }
 }
 
 #[cfg(test)]

--- a/lib/src/re/thompson/mod.rs
+++ b/lib/src/re/thompson/mod.rs
@@ -1,6 +1,24 @@
-/*! A regexp compiler using the [Thompson's construction][1] algorithm that
+/*! A regexp compiler based on the [Thompson's construction][1] algorithm that
 produces code for the Pike VM described in Russ Cox's article
 [Regular Expression Matching: the Virtual Machine Approach][2].
+
+The only fundamental difference with the algorithms described in the cited
+articles are the way in which repetitions are handled. In the original
+algorithm a repetition like `abc{3}` is actually implemented by repeating
+the pattern three times, as in `abcabcabc`. A pattern like `abc{2,4}` is
+expressed like `abcabc(abc)?(abc)?`.
+
+This approach is simple, but the size of the code produced for the Pike VM
+is very large when the number of repetitions is large. Also, the number of
+active threads can become very large, which has an important impact on
+performance.
+
+In this implementation we introduce two new instructions for the Pike VM:
+REPEAT_GREEDY and REPEAT_UNGREEDY, which are used for expressing some of the
+repetitions found in the regular expression. Particularly those that are
+repeated a large number of times. This also implies that each thread not only
+has an instruction pointer, it also has a repetition count. Both the
+instruction pointer and the repetition count are part of the thread's state.
 
 [1]: https://en.wikipedia.org/wiki/Thompson%27s_construction
 [2]: https://swtch.com/~rsc/regexp/regexp2.html

--- a/lib/src/re/thompson/pikevm.rs
+++ b/lib/src/re/thompson/pikevm.rs
@@ -244,6 +244,8 @@ impl<'r> PikeVM<'r> {
 /// its state during the computation of an epsilon closure. See the
 /// documentation of [`epsilon_closure`] for details.
 pub struct EpsilonClosureState {
+    /// Pairs (instruction pointer, repetition count) describing the existing
+    /// threads.
     threads: Vec<(usize, u32)>,
     /// This bit array has one bit per possible value of SplitId. If the
     /// split instruction with SplitId = N is executed, the N-th bit in the

--- a/lib/src/re/thompson/tests.rs
+++ b/lib/src/re/thompson/tests.rs
@@ -4,6 +4,7 @@ use pretty_assertions::assert_eq;
 use crate::compiler::Atom;
 use crate::re;
 use crate::re::bitmapset::BitmapSet;
+use crate::re::{BckCodeLoc, FwdCodeLoc};
 use crate::types::Regexp;
 
 use super::compiler::{CodeLoc, Compiler, RegexpAtom};
@@ -28,9 +29,8 @@ macro_rules! assert_re_code {
 
         epsilon_closure(
             fwd_code.as_ref(),
+            FwdCodeLoc::try_from(0_usize).unwrap(),
             0,
-            0,
-            false,
             None,
             None,
             &mut cache,
@@ -45,9 +45,8 @@ macro_rules! assert_re_code {
         let mut bck_closure = BitmapSet::<u32>::new();
         epsilon_closure(
             bck_code.as_ref(),
+            BckCodeLoc::try_from(0_usize).unwrap(),
             0,
-            0,
-            true,
             None,
             None,
             &mut cache,

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -1255,6 +1255,74 @@ fn regexp_patterns_2() {
 
 #[test]
 fn regexp_patterns_3() {
+    pattern_match!(r#"/.b{15}/"#, b"abbbbbbbbbbbbbbb", b"abbbbbbbbbbbbbbb");
+    pattern_match!(
+        r#"/.b{15,16}/"#,
+        b"abbbbbbbbbbbbbbbb",
+        b"abbbbbbbbbbbbbbbb"
+    );
+    pattern_match!(
+        r#"/.b{15,16}?/"#,
+        b"abbbbbbbbbbbbbbbb",
+        b"abbbbbbbbbbbbbbb"
+    );
+    pattern_match!(
+        r#"/ab{15,16}?c/"#,
+        b"abbbbbbbbbbbbbbbc",
+        b"abbbbbbbbbbbbbbbc"
+    );
+    pattern_match!(
+        r#"/.b{15,16}cccc/"#,
+        b"abbbbbbbbbbbbbbbbcccc",
+        b"abbbbbbbbbbbbbbbbcccc"
+    );
+    pattern_match!(
+        r#"/.b{15,16}?cccc/"#,
+        b"abbbbbbbbbbbbbbbcccc",
+        b"abbbbbbbbbbbbbbbcccc"
+    );
+    pattern_match!(
+        r#"/a.b{15,16}cccc/"#,
+        b"aabbbbbbbbbbbbbbbcccc",
+        b"aabbbbbbbbbbbbbbbcccc"
+    );
+    pattern_match!(
+        r#"/abcd.{0,11}efgh.{0,11}ijk/"#,
+        b"abcd123456789ABefgh123456789ABijk",
+        b"abcd123456789ABefgh123456789ABijk"
+    );
+    pattern_match!(
+        r#"/abcd.{0,11}?efgh.{0,11}?ijk/"#,
+        b"abcd123456789ABefgh123456789ABijk",
+        b"abcd123456789ABefgh123456789ABijk"
+    );
+    pattern_match!(r#"/abcd.{0,11}?abcd/"#, b"abcdabcdabcd", b"abcdabcd");
+    pattern_match!(r#"/abcd.{0,11}abcd/"#, b"abcdabcdabcd", b"abcdabcdabcd");
+    pattern_match!(r#"/ab{2,15}c/"#, b"abbbc", b"abbbc");
+    pattern_match!(r#"/ab{2,15}?c/"#, b"abbbc", b"abbbc");
+    pattern_match!(r#"/ab{0,15}?c/"#, b"abc", b"abc");
+    pattern_match!(r#"/ab{,15}?c/"#, b"abc", b"abc");
+    pattern_match!(r#"/a{0,15}bc/"#, b"bbc", b"bc");
+    pattern_match!(r#"/a{0,15}?bc/"#, b"abc", b"abc");
+    pattern_match!(r#"/a{0,15}?bc/"#, b"bc", b"bc");
+    pattern_match!(r#"/aa{0,15}?bc/"#, b"abc", b"abc");
+    pattern_match!(r#"/aa{0,15}bc/"#, b"abc", b"abc");
+    pattern_match!(r#"/ab{11}c/"#, b"abbbbbbbbbbbc", b"abbbbbbbbbbbc");
+    pattern_false!(r#"/ab{11}c/"#, b"ac");
+    pattern_match!(r#"/ab{11,}c/"#, b"abbbbbbbbbbbbc", b"abbbbbbbbbbbbc");
+    pattern_false!(r#"/ab{11,}b/"#, b"abbbbbbbbbbb");
+    pattern_match!(r#"/ab{0,11}c/"#, b"abbbbbbbbbc", b"abbbbbbbbbc");
+    pattern_match!(r#"/(a{2,13}b){2,13}/"#, b"aabaaabaab", b"aabaaabaab");
+    pattern_match!(r#"/(a{2,13}?b){2,13}?/"#, b"aabaaabaab", b"aabaaab");
+    pattern_match!(
+        r#"/(a{4,5}b){4,15}/"#,
+        b"aaaabaaaabaaaaabaaaaab",
+        b"aaaabaaaabaaaaabaaaaab"
+    );
+}
+
+#[test]
+fn regexp_patterns_4() {
     pattern_match!(r#"/a[bx]c/"#, b"abc", b"abc");
     pattern_match!(r#"/a[bx]c/"#, b"axc", b"axc");
     pattern_match!(r#"/a[0-9]*b/"#, b"ab", b"ab");
@@ -1375,7 +1443,7 @@ fn regexp_patterns_3() {
 }
 
 #[test]
-fn regexp_patterns_4() {
+fn regexp_patterns_5() {
     pattern_match!(r"/\\/", b"\\", b"\\");
     pattern_match!(r"/\babc/", b"abc", b"abc");
     pattern_match!(r"/abc\b/", b"abc", b"abc");
@@ -1445,7 +1513,7 @@ fn regexp_patterns_4() {
 }
 
 #[test]
-fn regexp_patterns_5() {
+fn regexp_patterns_6() {
     rule_true!(
         r#"rule test {
             strings:


### PR DESCRIPTION
This introduces 2 new instructions in the PikeVM: `RepeatGreedy` and `RepeatNonGreedy`. These instructions are used for implementing repetitions that are larger than 10, reducing the size of the compiled regex and avoiding errors.