### PR TITLE
refactor: redesign the IR tree in order to allow its mutability

### DIFF
--- a/lib/src/compiler/base64.rs
+++ b/lib/src/compiler/base64.rs
@@ -58,7 +58,7 @@ use bstr::{BString, ByteVec};
 /// characters long and can't have repeated characters.
 ///
 /// Also panics if the length of s is 1 or less.
-pub fn base64_patterns(
+pub(crate) fn base64_patterns(
     s: &[u8],
     alphabet: Option<&str>,
 ) -> Vec<(u8, BString)> {

--- a/lib/src/compiler/base64.rs
+++ b/lib/src/compiler/base64.rs
@@ -58,7 +58,7 @@ use bstr::{BString, ByteVec};
 /// characters long and can't have repeated characters.
 ///
 /// Also panics if the length of s is 1 or less.
-pub(crate) fn base64_patterns(
+pub fn base64_patterns(
     s: &[u8],
     alphabet: Option<&str>,
 ) -> Vec<(u8, BString)> {
@@ -190,7 +190,7 @@ mod test {
             base64_patterns(b"foobar", Some("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")),
             vec![
                 (2, BString::from("mb29iYX")),
-                (1, BString::from("Zvb2Jhc")),                      
+                (1, BString::from("Zvb2Jhc")),
                 (0, BString::from("Zm9vYmFy"))
             ]
         );

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -15,7 +15,7 @@ use crate::wasm;
 
 /// Structure that contains information and data structures required during the
 /// compilation of a rule.
-pub struct CompileContext<'a, 'src, 'sym> {
+pub(crate) struct CompileContext<'a, 'src, 'sym> {
     /// Builder for creating error and warning reports.
     pub report_builder: &'a ReportBuilder,
 
@@ -51,7 +51,7 @@ pub struct CompileContext<'a, 'src, 'sym> {
     pub error_on_slow_loop: bool,
 
     /// Indicates how deep we are inside `for .. of` statements.
-    pub(crate) for_of_depth: usize,
+    pub for_of_depth: usize,
 }
 
 impl<'a, 'src, 'sym> CompileContext<'a, 'src, 'sym> {
@@ -96,7 +96,7 @@ impl<'a, 'src, 'sym> CompileContext<'a, 'src, 'sym> {
 ///
 /// This stack is stored in WASM main memory, in a memory region that goes
 /// from [`wasm::VARS_STACK_START`] to [`wasm::VARS_STACK_END`].
-pub struct VarStack {
+pub(crate) struct VarStack {
     pub used: i32,
 }
 
@@ -140,7 +140,7 @@ impl VarStack {
 /// Frames are stacked one in top of another, individual variables are
 /// allocated within a frame.
 #[derive(Clone, Debug)]
-pub struct VarStackFrame {
+pub(crate) struct VarStackFrame {
     start: i32,
     capacity: i32,
     used: Cell<i32>,
@@ -164,7 +164,7 @@ impl VarStackFrame {
 
 /// Represents a variable in the stack.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Var {
+pub(crate) struct Var {
     /// The type of the variable
     pub ty: Type,
     /// The index corresponding to this variable. This index is used for

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -15,7 +15,7 @@ use crate::wasm;
 
 /// Structure that contains information and data structures required during the
 /// compilation of a rule.
-pub(in crate::compiler) struct CompileContext<'a, 'src, 'sym> {
+pub struct CompileContext<'a, 'src, 'sym> {
     /// Builder for creating error and warning reports.
     pub report_builder: &'a ReportBuilder,
 
@@ -96,7 +96,7 @@ impl<'a, 'src, 'sym> CompileContext<'a, 'src, 'sym> {
 ///
 /// This stack is stored in WASM main memory, in a memory region that goes
 /// from [`wasm::VARS_STACK_START`] to [`wasm::VARS_STACK_END`].
-pub(crate) struct VarStack {
+pub struct VarStack {
     pub used: i32,
 }
 
@@ -140,7 +140,7 @@ impl VarStack {
 /// Frames are stacked one in top of another, individual variables are
 /// allocated within a frame.
 #[derive(Clone, Debug)]
-pub(crate) struct VarStackFrame {
+pub struct VarStackFrame {
     start: i32,
     capacity: i32,
     used: Cell<i32>,
@@ -164,7 +164,7 @@ impl VarStackFrame {
 
 /// Represents a variable in the stack.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct Var {
+pub struct Var {
     /// The type of the variable
     pub ty: Type,
     /// The index corresponding to this variable. This index is used for
@@ -175,7 +175,7 @@ pub(crate) struct Var {
 
 impl Var {
     /// Returns the number of bytes that the variable occupies in memory.
-    pub(crate) const fn mem_size() -> i32 {
+    pub const fn mem_size() -> i32 {
         size_of::<i64>() as i32
     }
 }

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -21,7 +21,7 @@ use walrus::ValType::{I32, I64};
 use walrus::{FunctionId, InstrSeqBuilder, ValType};
 
 use crate::compiler::ir::{
-    Expr, ForIn, ForOf, Iterable, MatchAnchor, NodeIdx, Of, OfItems,
+    Expr, ExprId, ForIn, ForOf, Iterable, MatchAnchor, Of, OfItems,
     PatternIdx, Quantifier, With, IR,
 };
 use crate::compiler::{
@@ -248,7 +248,7 @@ pub(crate) fn emit_rule_condition(
     ctx: &mut EmitContext,
     ir: &IR,
     rule_id: RuleId,
-    condition: NodeIdx,
+    condition: ExprId,
     builder: &mut WasmModuleBuilder,
 ) {
     let mut instr = builder.start_rule(rule_id, ctx.current_rule.is_global);
@@ -273,7 +273,7 @@ pub(crate) fn emit_rule_condition(
 fn emit_expr(
     ctx: &mut EmitContext,
     ir: &IR,
-    expr: NodeIdx,
+    expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     match ir.get(expr) {
@@ -668,7 +668,7 @@ fn emit_expr(
 fn emit_defined(
     ctx: &mut EmitContext,
     ir: &IR,
-    operand: NodeIdx,
+    operand: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     // The `defined` expression is emitted as:
@@ -705,7 +705,7 @@ fn emit_defined(
 fn emit_not(
     ctx: &mut EmitContext,
     ir: &IR,
-    operand: NodeIdx,
+    operand: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     // The `not` expression is emitted as:
@@ -732,7 +732,7 @@ fn emit_not(
 fn emit_and(
     ctx: &mut EmitContext,
     ir: &IR,
-    operands: &[NodeIdx],
+    operands: &[ExprId],
     instr: &mut InstrSeqBuilder,
 ) {
     // The `or` expression is emitted as:
@@ -797,7 +797,7 @@ fn emit_and(
 fn emit_or(
     ctx: &mut EmitContext,
     ir: &IR,
-    operands: &[NodeIdx],
+    operands: &[ExprId],
     instr: &mut InstrSeqBuilder,
 ) {
     // The `or` expression is emitted as:
@@ -862,7 +862,7 @@ fn emit_or(
 fn emit_div(
     ctx: &mut EmitContext,
     ir: &IR,
-    operands: &[NodeIdx],
+    operands: &[ExprId],
     instr: &mut InstrSeqBuilder,
 ) {
     let mut operands = operands.iter();
@@ -902,7 +902,7 @@ fn emit_div(
 fn emit_mod(
     ctx: &mut EmitContext,
     ir: &IR,
-    operands: &[NodeIdx],
+    operands: &[ExprId],
     instr: &mut InstrSeqBuilder,
 ) {
     let mut operands = operands.iter();
@@ -974,7 +974,7 @@ fn emit_lazy_pattern_search(
 fn emit_pattern_match(
     ctx: &mut EmitContext,
     ir: &IR,
-    expr: NodeIdx,
+    expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     emit_lazy_pattern_search(ctx, instr);
@@ -1026,7 +1026,7 @@ fn emit_pattern_match(
 fn emit_pattern_count(
     ctx: &mut EmitContext,
     ir: &IR,
-    expr: NodeIdx,
+    expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     emit_lazy_pattern_search(ctx, instr);
@@ -1071,7 +1071,7 @@ fn emit_pattern_count(
 fn emit_pattern_offset(
     ctx: &mut EmitContext,
     ir: &IR,
-    expr: NodeIdx,
+    expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     emit_lazy_pattern_search(ctx, instr);
@@ -1120,7 +1120,7 @@ fn emit_pattern_offset(
 fn emit_pattern_length(
     ctx: &mut EmitContext,
     ir: &IR,
-    expr: NodeIdx,
+    expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     emit_lazy_pattern_search(ctx, instr);
@@ -2486,7 +2486,7 @@ fn incr_var(ctx: &mut EmitContext, instr: &mut InstrSeqBuilder, var: Var) {
 fn emit_bool_expr(
     ctx: &mut EmitContext,
     ir: &IR,
-    expr: NodeIdx,
+    expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
     emit_expr(ctx, ir, expr, instr);

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -177,7 +177,7 @@ type ExceptionHandler = Box<dyn Fn(&mut EmitContext, &mut InstrSeqBuilder)>;
 
 /// Structure that contains information used while emitting the code that
 /// corresponds to the condition of a YARA rule.
-pub struct EmitContext<'a> {
+pub(crate) struct EmitContext<'a> {
     /// Signature index associated the function call being emitted. This
     /// is an index in the array returned by `func.signatures()`, where
     /// `func` is an instance of [`Type::Func`] that represents the
@@ -243,7 +243,7 @@ impl<'a> EmitContext<'a> {
 }
 
 /// Emits WASM code of a rule.
-pub fn emit_rule_condition(
+pub(crate) fn emit_rule_condition(
     ctx: &mut EmitContext,
     ir: &IR,
     rule_id: RuleId,

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -177,7 +177,7 @@ type ExceptionHandler = Box<dyn Fn(&mut EmitContext, &mut InstrSeqBuilder)>;
 
 /// Structure that contains information used while emitting the code that
 /// corresponds to the condition of a YARA rule.
-pub(in crate::compiler) struct EmitContext<'a> {
+pub struct EmitContext<'a> {
     /// Signature index associated the function call being emitted. This
     /// is an index in the array returned by `func.signatures()`, where
     /// `func` is an instance of [`Type::Func`] that represents the
@@ -243,7 +243,7 @@ impl<'a> EmitContext<'a> {
 }
 
 /// Emits WASM code of a rule.
-pub(super) fn emit_rule_condition(
+pub fn emit_rule_condition(
     ctx: &mut EmitContext,
     ir: &IR,
     rule_id: RuleId,

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -41,7 +41,7 @@ use crate::types::{Map, Regexp, Type, TypeValue, Value};
 /// patterns the [`TooManyPatterns`] error is returned.
 const MAX_PATTERNS_PER_RULE: usize = 100_000;
 
-pub fn patterns_from_ast<'src>(
+pub(in crate::compiler) fn patterns_from_ast<'src>(
     ctx: &mut CompileContext<'_, 'src, '_>,
     rule: &ast::Rule<'src>,
 ) -> Result<(), CompileError> {
@@ -875,7 +875,7 @@ fn expr_from_ast(
     }
 }
 
-pub fn rule_condition_from_ast(
+pub(in crate::compiler) fn rule_condition_from_ast(
     ctx: &mut CompileContext,
     rule: &ast::Rule,
 ) -> Result<NodeIdx, CompileError> {

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -41,7 +41,7 @@ use crate::types::{Map, Regexp, Type, TypeValue, Value};
 /// patterns the [`TooManyPatterns`] error is returned.
 const MAX_PATTERNS_PER_RULE: usize = 100_000;
 
-pub(in crate::compiler) fn patterns_from_ast<'src>(
+pub fn patterns_from_ast<'src>(
     ctx: &mut CompileContext<'_, 'src, '_>,
     rule: &ast::Rule<'src>,
 ) -> Result<(), CompileError> {
@@ -875,7 +875,7 @@ fn expr_from_ast(
     }
 }
 
-pub(in crate::compiler) fn rule_condition_from_ast(
+pub fn rule_condition_from_ast(
     ctx: &mut CompileContext,
     rule: &ast::Rule,
 ) -> Result<NodeIdx, CompileError> {

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -854,12 +854,7 @@ fn expr_from_ast(
 
                     // The type of the key/index expression should correspond
                     // with the type of the map's keys.
-                    check_type(
-                        ctx,
-                        index,
-                        expr.index.span().into(),
-                        &[key_ty],
-                    )?;
+                    check_type(ctx, index, expr.index.span(), &[key_ty])?;
 
                     Ok(ctx.ir.lookup(deputy_value.clone(), primary, index))
                 }

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -22,9 +22,9 @@ use crate::compiler::errors::{
 };
 use crate::compiler::ir::hex2hir::hex_pattern_hir_from_ast;
 use crate::compiler::ir::{
-    Expr, ForIn, ForOf, FuncCall, Iterable, LiteralPattern, Lookup,
-    MatchAnchor, Of, OfItems, Pattern, PatternFlagSet, PatternFlags,
-    PatternIdx, PatternInRule, Quantifier, Range, RegexpPattern, With,
+    Expr, Iterable, LiteralPattern, MatchAnchor, NodeIdx, OfItems, Pattern,
+    PatternFlagSet, PatternFlags, PatternIdx, PatternInRule, Quantifier,
+    Range, RegexpPattern,
 };
 use crate::compiler::report::ReportBuilder;
 use crate::compiler::{
@@ -405,35 +405,35 @@ pub(in crate::compiler) fn regexp_pattern_from_ast<'src>(
 }
 
 /// Given the AST for some expression, creates its IR.
-pub(in crate::compiler) fn expr_from_ast(
+fn expr_from_ast(
     ctx: &mut CompileContext,
     expr: &ast::Expr,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     match expr {
         ast::Expr::Entrypoint { span } => {
             Err(EntrypointUnsupported::build(ctx.report_builder, span.into()))
         }
-        ast::Expr::Filesize { .. } => Ok(Expr::Filesize),
+        ast::Expr::Filesize { .. } => Ok(ctx.ir.filesize()),
 
         ast::Expr::True { .. } => {
-            Ok(Expr::Const(TypeValue::const_bool_from(true)))
+            Ok(ctx.ir.constant(TypeValue::const_bool_from(true)))
         }
 
         ast::Expr::False { .. } => {
-            Ok(Expr::Const(TypeValue::const_bool_from(false)))
+            Ok(ctx.ir.constant(TypeValue::const_bool_from(false)))
         }
 
         ast::Expr::LiteralInteger(literal) => {
-            Ok(Expr::Const(TypeValue::const_integer_from(literal.value)))
+            Ok(ctx.ir.constant(TypeValue::const_integer_from(literal.value)))
         }
 
         ast::Expr::LiteralFloat(literal) => {
-            Ok(Expr::Const(TypeValue::const_float_from(literal.value)))
+            Ok(ctx.ir.constant(TypeValue::const_float_from(literal.value)))
         }
 
-        ast::Expr::LiteralString(literal) => Ok(Expr::Const(
-            TypeValue::const_string_from(literal.value.as_bytes()),
-        )),
+        ast::Expr::LiteralString(literal) => Ok(ctx
+            .ir
+            .constant(TypeValue::const_string_from(literal.value.as_bytes()))),
 
         ast::Expr::Regexp(regexp) => {
             re::parser::Parser::new()
@@ -443,7 +443,7 @@ pub(in crate::compiler) fn expr_from_ast(
                     re_error_to_compile_error(ctx.report_builder, regexp, err)
                 })?;
 
-            Ok(Expr::Const(TypeValue::Regexp(Some(Regexp::new(
+            Ok(ctx.ir.constant(TypeValue::Regexp(Some(Regexp::new(
                 regexp.literal,
             )))))
         }
@@ -483,43 +483,51 @@ pub(in crate::compiler) fn expr_from_ast(
             let lhs = expr_from_ast(ctx, &expr.lhs)?;
             let rhs = expr_from_ast(ctx, &expr.rhs)?;
 
+            let lhs_expr = ctx.ir.get(lhs);
+            let rhs_expr = ctx.ir.get(rhs);
+
             // Detect cases in which the equal operator is comparing a boolean
             // expression with an integer constant (e.g: `pe.is_signed == 0`).
             // This is quite common in YARA rules, it is accepted without
             // errors, but a warning is raised.
-            let replacement = match (lhs.type_value(), rhs.type_value()) {
-                (TypeValue::Bool(_), TypeValue::Integer(Value::Const(0))) => {
-                    Some((
-                        Expr::not(lhs),
+            let replacement =
+                match (lhs_expr.type_value(), rhs_expr.type_value()) {
+                    (
+                        TypeValue::Bool(_),
+                        TypeValue::Integer(Value::Const(0)),
+                    ) => Some((
+                        ctx.ir.not(lhs),
                         format!(
                             "not {}",
                             ctx.report_builder.get_snippet(&lhs_span.into())
                         ),
-                    ))
-                }
-                (TypeValue::Integer(Value::Const(0)), TypeValue::Bool(_)) => {
-                    Some((
-                        Expr::not(rhs),
+                    )),
+                    (
+                        TypeValue::Integer(Value::Const(0)),
+                        TypeValue::Bool(_),
+                    ) => Some((
+                        ctx.ir.not(rhs),
                         format!(
                             "not {}",
                             ctx.report_builder.get_snippet(&rhs_span.into())
                         ),
-                    ))
-                }
-                (TypeValue::Bool(_), TypeValue::Integer(Value::Const(1))) => {
-                    Some((
+                    )),
+                    (
+                        TypeValue::Bool(_),
+                        TypeValue::Integer(Value::Const(1)),
+                    ) => Some((
                         lhs,
                         ctx.report_builder.get_snippet(&lhs_span.into()),
-                    ))
-                }
-                (TypeValue::Integer(Value::Const(1)), TypeValue::Bool(_)) => {
-                    Some((
+                    )),
+                    (
+                        TypeValue::Integer(Value::Const(1)),
+                        TypeValue::Bool(_),
+                    ) => Some((
                         rhs,
                         ctx.report_builder.get_snippet(&rhs_span.into()),
-                    ))
-                }
-                _ => None,
-            };
+                    )),
+                    _ => None,
+                };
 
             if let Some((expr, msg)) = replacement {
                 ctx.warnings.add(|| {
@@ -563,14 +571,14 @@ pub(in crate::compiler) fn expr_from_ast(
             // will change in the future when other types can have methods.
             for operand in expr.operands.iter().dropping_back(1) {
                 let expr = expr_from_ast(ctx, operand)?;
-                check_type(ctx, expr.ty(), operand.span(), &[Type::Struct])?;
+                check_type(ctx, expr, operand.span(), &[Type::Struct])?;
                 // Set `current_symbol_table` to the symbol table for the type
                 // of the expression at the left the field access operator (.).
                 // In the expression `foo.bar`, the `current_symbol_table` is
                 // set to the symbol table for foo's type, which should have
                 // a field or method named `bar`.
                 ctx.current_symbol_table =
-                    Some(expr.type_value().symbol_table());
+                    Some(ctx.ir.get(expr).type_value().symbol_table());
 
                 operands.push(expr);
             }
@@ -582,15 +590,16 @@ pub(in crate::compiler) fn expr_from_ast(
             // If the last operand is constant, the whole expression is
             // constant.
             #[cfg(feature = "constant-folding")]
-            if let Expr::Const(type_value) = last_operand {
-                // A constant always have a defined value.
-                assert!(type_value.is_const());
-                return Ok(Expr::Const(type_value));
+            {
+                let type_value = ctx.ir.get(last_operand).type_value();
+                if type_value.is_const() {
+                    return Ok(ctx.ir.constant(type_value.clone()));
+                }
             }
 
             operands.push(last_operand);
 
-            Ok(Expr::field_access(operands))
+            Ok(ctx.ir.field_access(operands))
         }
 
         ast::Expr::Ident(ident) => {
@@ -632,15 +641,16 @@ pub(in crate::compiler) fn expr_from_ast(
             }
 
             let symbol = symbol.unwrap();
+
             #[cfg(feature = "constant-folding")]
             {
                 let type_value = symbol.type_value();
                 if type_value.is_const() {
-                    return Ok(Expr::Const(type_value.clone()));
+                    return Ok(ctx.ir.constant(type_value.clone()));
                 }
             }
 
-            Ok(Expr::Ident { symbol })
+            Ok(ctx.ir.ident(symbol))
         }
 
         ast::Expr::PatternMatch(p) => {
@@ -662,24 +672,36 @@ pub(in crate::compiler) fn expr_from_ast(
                     // each iteration. In those cases the symbol table must
                     // contain an entry for `$`, corresponding to the variable
                     // that holds the current PatternId for the loop.
-                    Ok(Expr::PatternMatchVar {
-                        symbol: ctx.symbol_table.lookup("$").unwrap(),
+                    Ok(ctx.ir.pattern_match_var(
+                        ctx.symbol_table.lookup("$").unwrap(),
                         anchor,
-                    })
+                    ))
                 }
                 _ => {
+                    let at = match anchor {
+                        MatchAnchor::At(expr) => {
+                            let value = ctx.ir.get(expr).type_value();
+                            if value.is_const() {
+                                value.try_as_integer()
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    };
+
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.identifier)?;
 
                     pattern.mark_as_used();
 
-                    if let Some(offset) = anchor.at() {
+                    if let Some(offset) = at {
                         pattern.anchor_at(offset as usize);
                     } else {
                         pattern.make_non_anchorable();
                     }
 
-                    Ok(Expr::PatternMatch { pattern: pattern_idx, anchor })
+                    Ok(ctx.ir.pattern_match(pattern_idx, anchor))
                 }
             }
         }
@@ -696,32 +718,30 @@ pub(in crate::compiler) fn expr_from_ast(
             }
             match (p.ident.name, &p.range) {
                 // Cases where the identifier is `#`.
-                ("#", Some(range)) => Ok(Expr::PatternCountVar {
-                    symbol: ctx.symbol_table.lookup("$").unwrap(),
-                    range: Some(range_from_ast(ctx, range)?),
-                }),
-                ("#", None) => Ok(Expr::PatternCountVar {
-                    symbol: ctx.symbol_table.lookup("$").unwrap(),
-                    range: None,
-                }),
+                ("#", Some(range)) => {
+                    let range = range_from_ast(ctx, range)?;
+                    Ok(ctx.ir.pattern_count_var(
+                        ctx.symbol_table.lookup("$").unwrap(),
+                        Some(range),
+                    ))
+                }
+                ("#", None) => Ok(ctx.ir.pattern_count_var(
+                    ctx.symbol_table.lookup("$").unwrap(),
+                    None,
+                )),
                 // Cases where the identifier is not `#`.
                 (_, Some(range)) => {
+                    let range = range_from_ast(ctx, range)?;
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.ident)?;
                     pattern.make_non_anchorable().mark_as_used();
-                    Ok(Expr::PatternCount {
-                        pattern: pattern_idx,
-                        range: Some(range_from_ast(ctx, range)?),
-                    })
+                    Ok(ctx.ir.pattern_count(pattern_idx, Some(range)))
                 }
                 (_, None) => {
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.ident)?;
                     pattern.make_non_anchorable().mark_as_used();
-                    Ok(Expr::PatternCount {
-                        pattern: pattern_idx,
-                        range: None,
-                    })
+                    Ok(ctx.ir.pattern_count(pattern_idx, None))
                 }
             }
         }
@@ -738,40 +758,32 @@ pub(in crate::compiler) fn expr_from_ast(
             }
             match (p.ident.name, &p.index) {
                 // Cases where the identifier is `@`.
-                ("@", Some(index)) => Ok(Expr::PatternOffsetVar {
-                    symbol: ctx.symbol_table.lookup("$").unwrap(),
-                    index: Some(Box::new(integer_in_range_from_ast(
-                        ctx,
-                        index,
-                        1..=i64::MAX,
-                    )?)),
-                }),
-                ("@", None) => Ok(Expr::PatternOffsetVar {
-                    symbol: ctx.symbol_table.lookup("$").unwrap(),
-                    index: None,
-                }),
+                ("@", Some(index)) => {
+                    let range =
+                        integer_in_range_from_ast(ctx, index, 1..=i64::MAX)?;
+                    Ok(ctx.ir.pattern_offset_var(
+                        ctx.symbol_table.lookup("$").unwrap(),
+                        Some(range),
+                    ))
+                }
+                ("@", None) => Ok(ctx.ir.pattern_offset_var(
+                    ctx.symbol_table.lookup("$").unwrap(),
+                    None,
+                )),
                 // Cases where the identifier is not `@`.
                 (_, Some(index)) => {
+                    let range =
+                        integer_in_range_from_ast(ctx, index, 1..=i64::MAX)?;
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.ident)?;
                     pattern.make_non_anchorable().mark_as_used();
-                    Ok(Expr::PatternOffset {
-                        pattern: pattern_idx,
-                        index: Some(Box::new(integer_in_range_from_ast(
-                            ctx,
-                            index,
-                            1..=i64::MAX,
-                        )?)),
-                    })
+                    Ok(ctx.ir.pattern_offset(pattern_idx, Some(range)))
                 }
                 (_, None) => {
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.ident)?;
                     pattern.make_non_anchorable().mark_as_used();
-                    Ok(Expr::PatternOffset {
-                        pattern: pattern_idx,
-                        index: None,
-                    })
+                    Ok(ctx.ir.pattern_offset(pattern_idx, None))
                 }
             }
         }
@@ -788,59 +800,44 @@ pub(in crate::compiler) fn expr_from_ast(
             }
             match (p.ident.name, &p.index) {
                 // Cases where the identifier is `!`.
-                ("!", Some(index)) => Ok(Expr::PatternLengthVar {
-                    symbol: ctx.symbol_table.lookup("$").unwrap(),
-                    index: Some(Box::new(integer_in_range_from_ast(
-                        ctx,
-                        index,
-                        1..=i64::MAX,
-                    )?)),
-                }),
-                ("!", None) => Ok(Expr::PatternLengthVar {
-                    symbol: ctx.symbol_table.lookup("$").unwrap(),
-                    index: None,
-                }),
+                ("!", Some(index)) => {
+                    let index =
+                        integer_in_range_from_ast(ctx, index, 1..=i64::MAX)?;
+                    Ok(ctx.ir.pattern_length_var(
+                        ctx.symbol_table.lookup("$").unwrap(),
+                        Some(index),
+                    ))
+                }
+                ("!", None) => Ok(ctx.ir.pattern_length_var(
+                    ctx.symbol_table.lookup("$").unwrap(),
+                    None,
+                )),
                 // Cases where the identifier is not `!`.
                 (_, Some(index)) => {
+                    let index =
+                        integer_in_range_from_ast(ctx, index, 1..=i64::MAX)?;
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.ident)?;
                     pattern.make_non_anchorable().mark_as_used();
-                    Ok(Expr::PatternLength {
-                        pattern: pattern_idx,
-                        index: Some(Box::new(integer_in_range_from_ast(
-                            ctx,
-                            index,
-                            1..=i64::MAX,
-                        )?)),
-                    })
+                    Ok(ctx.ir.pattern_length(pattern_idx, Some(index)))
                 }
                 (_, None) => {
                     let (pattern_idx, pattern) =
                         ctx.get_pattern_mut(&p.ident)?;
                     pattern.make_non_anchorable().mark_as_used();
-                    Ok(Expr::PatternLength {
-                        pattern: pattern_idx,
-                        index: None,
-                    })
+                    Ok(ctx.ir.pattern_length(pattern_idx, None))
                 }
             }
         }
 
         ast::Expr::Lookup(expr) => {
-            let primary = Box::new(expr_from_ast(ctx, &expr.primary)?);
+            let primary = expr_from_ast(ctx, &expr.primary)?;
 
-            match primary.type_value() {
+            match ctx.ir.get(primary).type_value() {
                 TypeValue::Array(array) => {
-                    let index = Box::new(non_negative_integer_from_ast(
-                        ctx,
-                        &expr.index,
-                    )?);
-
-                    Ok(Expr::Lookup(Box::new(Lookup {
-                        type_value: array.deputy(),
-                        primary,
-                        index,
-                    })))
+                    let index =
+                        non_negative_integer_from_ast(ctx, &expr.index)?;
+                    Ok(ctx.ir.lookup(array.deputy(), primary, index))
                 }
                 TypeValue::Map(map) => {
                     let (key_ty, deputy_value) = match map.borrow() {
@@ -853,26 +850,18 @@ pub(in crate::compiler) fn expr_from_ast(
                         _ => unreachable!(),
                     };
 
-                    let index = Box::new(expr_from_ast(ctx, &expr.index)?);
-                    let ty = index.ty();
+                    let index = expr_from_ast(ctx, &expr.index)?;
 
                     // The type of the key/index expression should correspond
                     // with the type of the map's keys.
-                    if key_ty != ty {
-                        return Err(WrongType::build(
-                            ctx.report_builder,
-                            format!("`{}`", key_ty),
-                            format!("`{}`", ty),
-                            expr.index.span().into(),
-                            None,
-                        ));
-                    }
-
-                    Ok(Expr::Lookup(Box::new(Lookup {
-                        type_value: deputy_value.clone(),
-                        primary,
+                    check_type(
+                        ctx,
                         index,
-                    })))
+                        expr.index.span().into(),
+                        &[key_ty],
+                    )?;
+
+                    Ok(ctx.ir.lookup(deputy_value.clone(), primary, index))
                 }
                 type_value => Err(WrongType::build(
                     ctx.report_builder,
@@ -886,14 +875,47 @@ pub(in crate::compiler) fn expr_from_ast(
     }
 }
 
-pub(in crate::compiler) fn bool_expr_from_ast(
+pub(in crate::compiler) fn rule_condition_from_ast(
+    ctx: &mut CompileContext,
+    rule: &ast::Rule,
+) -> Result<NodeIdx, CompileError> {
+    // Start with clean IR tree.
+    ctx.ir.clear();
+
+    let condition = bool_expr_from_ast(ctx, &rule.condition)?;
+
+    // Check if the value of the condition is known at compile time and
+    // raise a warning if that's the case. Rules with constant conditions
+    // are not very useful in real life, except for testing.
+    if let Some(value) =
+        ctx.ir.get(condition).type_value().cast_to_bool().try_as_bool()
+    {
+        ctx.warnings.add(|| {
+            warnings::InvariantBooleanExpression::build(
+                ctx.report_builder,
+                value,
+                rule.condition.span().into(),
+                Some(format!(
+                    "rule `{}` is always `{}`",
+                    rule.identifier.name, value
+                )),
+            )
+        });
+    }
+
+    ctx.ir.root = Some(condition);
+
+    Ok(condition)
+}
+
+fn bool_expr_from_ast(
     ctx: &mut CompileContext,
     ast: &ast::Expr,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let code_loc = ast.span().into();
     let expr = expr_from_ast(ctx, ast)?;
 
-    match expr.type_value() {
+    match ctx.ir.get(expr).type_value() {
         TypeValue::Func(func) => {
             let help = func
                 .signatures()
@@ -942,8 +964,8 @@ pub(in crate::compiler) fn bool_expr_from_ast(
                 None,
             ))
         }
-        _ => {
-            warn_if_not_bool(ctx, expr.ty(), ast.span());
+        type_value => {
+            warn_if_not_bool(ctx, type_value.ty(), ast.span());
         }
     }
 
@@ -953,7 +975,7 @@ pub(in crate::compiler) fn bool_expr_from_ast(
 fn of_expr_from_ast(
     ctx: &mut CompileContext,
     of: &ast::Of,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let quantifier = quantifier_from_ast(ctx, &of.quantifier)?;
     // Create new stack frame with 5 slots:
     //   1 slot for the loop variable, a bool in this case.
@@ -969,7 +991,7 @@ fn of_expr_from_ast(
                     let expr = bool_expr_from_ast(ctx, e)?;
                     Ok(expr)
                 })
-                .collect::<Result<Vec<Expr>, CompileError>>()?;
+                .collect::<Result<Vec<NodeIdx>, CompileError>>()?;
 
             let num_items = tuple.len();
             (OfItems::BoolExprTuple(tuple), num_items)
@@ -985,7 +1007,10 @@ fn of_expr_from_ast(
     // If the quantifier expression is greater than the number of items,
     // the `of` expression is always false.
     if let Quantifier::Expr(expr) = &quantifier {
-        if let TypeValue::Integer(Value::Const(value)) = expr.type_value() {
+        // TODO: simplify?
+        if let TypeValue::Integer(Value::Const(value)) =
+            ctx.ir.get(*expr).type_value()
+        {
             if value > num_items.try_into().unwrap() {
                 ctx.warnings.add(|| warnings::InvariantBooleanExpression::build(
                     ctx.report_builder,
@@ -1023,18 +1048,20 @@ fn of_expr_from_ast(
             Quantifier::All { .. } => num_items > 1,
             // `<expr> of <items> at <expr>: the warning is raised if <expr> is
             // 2 or more.
-            Quantifier::Expr(expr) => match expr.type_value() {
+            Quantifier::Expr(expr) => match ctx.ir.get(*expr).type_value() {
                 TypeValue::Integer(Value::Const(value)) => value >= 2,
                 _ => false,
             },
             // `<expr>% of <items> at <expr>: the warning is raised if the
             // <expr> percent of the items is 2 or more.
-            Quantifier::Percentage(expr) => match expr.type_value() {
-                TypeValue::Integer(Value::Const(percentage)) => {
-                    num_items as f64 * percentage as f64 / 100.0 >= 2.0
+            Quantifier::Percentage(expr) => {
+                match ctx.ir.get(*expr).type_value() {
+                    TypeValue::Integer(Value::Const(percentage)) => {
+                        num_items as f64 * percentage as f64 / 100.0 >= 2.0
+                    }
+                    _ => false,
                 }
-                _ => false,
-            },
+            }
             Quantifier::None { .. } | Quantifier::Any { .. } => false,
         };
 
@@ -1053,19 +1080,19 @@ fn of_expr_from_ast(
 
     ctx.vars.unwind(&stack_frame);
 
-    Ok(Expr::Of(Box::new(Of { quantifier, items, anchor, stack_frame })))
+    Ok(ctx.ir.of(quantifier, items, anchor, stack_frame))
 }
 
 fn for_of_expr_from_ast(
     ctx: &mut CompileContext,
     for_of: &ast::ForOf,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let quantifier = quantifier_from_ast(ctx, &for_of.quantifier)?;
     let pattern_set = pattern_set_from_ast(ctx, &for_of.pattern_set)?;
     // Create new stack frame with 5 slots:
     //   1 slot for the loop variable, a pattern ID in this case
     //   4 up to slots used for loop control variables (see: emit::emit_for)
-    let mut stack_frame = ctx.vars.new_frame(5);
+    let stack_frame = ctx.vars.new_frame(5);
     let next_pattern_id = stack_frame.new_var(Type::Integer);
     let mut loop_vars = SymbolTable::new();
 
@@ -1086,40 +1113,45 @@ fn for_of_expr_from_ast(
     ctx.symbol_table.pop();
     ctx.vars.unwind(&stack_frame);
 
-    Ok(Expr::ForOf(Box::new(ForOf {
+    Ok(ctx.ir.for_of(
         quantifier,
+        next_pattern_id,
         pattern_set,
         condition,
         stack_frame,
-        variable: next_pattern_id,
-    })))
+    ))
 }
 
-fn is_potentially_large_range(range: &Range) -> bool {
+fn is_potentially_large_range(ctx: &CompileContext, range: &Range) -> bool {
     // If the range's lower bound is not constant, we don't consider it a
     // potentially large range. For instance (filesize-100, filesize) is not
     // potentially large.
-    if !range.lower_bound.type_value().is_const() {
+    if !ctx.ir.get(range.lower_bound).type_value().is_const() {
         return false;
     }
+
     // If the lower bound is constant, and the upper bound is some expression
     // that depends on `filesize` or the number of occurrences of some pattern
     // (i.e: #a), we consider it a potentially large range. The only exception
     // is when `math.min` is used, like in `(0..math.min(filesize, 1000))`
-    range
-        .upper_bound
+    ctx.ir
         .dfs_find(
+            range.upper_bound,
             // Traverse the upper bound expression looking for the use of filesize
             // or a pattern count.
             |node| matches!(node, Expr::Filesize | Expr::PatternCount { .. }),
             // Don't traverse the arguments of `math.min`.
             |node| {
                 if let Expr::FuncCall(f) = node {
-                    f.callable.type_value().as_func().signatures().iter().any(
-                        |signature| {
+                    ctx.ir
+                        .get(f.callable)
+                        .type_value()
+                        .as_func()
+                        .signatures()
+                        .iter()
+                        .any(|signature| {
                             signature.mangled_name.as_str().eq("math.min@ii@i")
-                        },
-                    )
+                        })
                 } else {
                     false
                 }
@@ -1131,7 +1163,7 @@ fn is_potentially_large_range(range: &Range) -> bool {
 fn for_in_expr_from_ast(
     ctx: &mut CompileContext,
     for_in: &ast::ForIn,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let quantifier = quantifier_from_ast(ctx, &for_in.quantifier)?;
     let iterable = iterable_from_ast(ctx, &for_in.iterable)?;
 
@@ -1139,7 +1171,7 @@ fn for_in_expr_from_ast(
         Iterable::Range(range) => {
             // Raise warning when the `for` loop iterates over a range that
             // may be very large.
-            if is_potentially_large_range(range) {
+            if is_potentially_large_range(ctx, range) {
                 if ctx.error_on_slow_loop {
                     return Err(PotentiallySlowLoop::build(
                         ctx.report_builder,
@@ -1167,11 +1199,11 @@ fn for_in_expr_from_ast(
             // loop variable is not known until the loop is executed.
             vec![expressions
                 .first()
+                .map(|node_idx| ctx.ir.get(*node_idx).type_value())
                 .unwrap()
-                .type_value()
                 .clone_without_value()]
         }
-        Iterable::Expr(expr) => match expr.type_value() {
+        Iterable::Expr(expr) => match ctx.ir.get(*expr).type_value() {
             TypeValue::Array(array) => vec![array.deputy()],
             TypeValue::Map(map) => match map.as_ref() {
                 Map::IntegerKeys { .. } => {
@@ -1207,7 +1239,7 @@ fn for_in_expr_from_ast(
     // temporary variables used for controlling the loop (see emit_for),
     // plus one additional variable used in loops over arrays and maps
     // (see emit_for_in_array and emit_for_in_map).
-    let mut stack_frame = ctx.vars.new_frame(loop_vars.len() as i32 + 5);
+    let stack_frame = ctx.vars.new_frame(loop_vars.len() as i32 + 5);
     let mut symbols = SymbolTable::new();
     let mut variables = Vec::new();
 
@@ -1232,21 +1264,15 @@ fn for_in_expr_from_ast(
 
     ctx.vars.unwind(&stack_frame);
 
-    Ok(Expr::ForIn(Box::new(ForIn {
-        quantifier,
-        variables,
-        iterable,
-        condition,
-        stack_frame,
-    })))
+    Ok(ctx.ir.for_in(quantifier, variables, iterable, condition, stack_frame))
 }
 
 fn with_expr_from_ast(
     ctx: &mut CompileContext,
     with: &ast::With,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     // Create stack frame with capacity for the with statement variables
-    let mut stack_frame = ctx.vars.new_frame(with.declarations.len() as i32);
+    let stack_frame = ctx.vars.new_frame(with.declarations.len() as i32);
     let mut symbols = SymbolTable::new();
     let mut declarations = Vec::new();
 
@@ -1254,12 +1280,11 @@ fn with_expr_from_ast(
     // for each one. Both identifiers and corresponding expressions are stored
     // in separate vectors.
     for item in with.declarations.iter() {
-        let type_value = expr_from_ast(ctx, &item.expression)?
-            .type_value()
-            .clone_without_value();
+        let expr = expr_from_ast(ctx, &item.expression)?;
+        let type_value = ctx.ir.get(expr).type_value();
         let var = stack_frame.new_var(type_value.ty());
 
-        declarations.push((var, expr_from_ast(ctx, &item.expression)?));
+        declarations.push((var, expr));
 
         // Insert the variable into the symbol table.
         symbols.insert(
@@ -1278,7 +1303,7 @@ fn with_expr_from_ast(
 
     ctx.vars.unwind(&stack_frame);
 
-    Ok(Expr::With(Box::new(With { declarations, condition })))
+    Ok(ctx.ir.with(declarations, condition))
 }
 
 fn iterable_from_ast(
@@ -1293,7 +1318,7 @@ fn iterable_from_ast(
             let span = expr.span();
             let expr = expr_from_ast(ctx, expr)?;
             // Make sure that the expression has a type that is iterable.
-            check_type(ctx, expr.ty(), span, &[Type::Array, Type::Map])?;
+            check_type(ctx, expr, span, &[Type::Array, Type::Map])?;
             Ok(Iterable::Expr(expr))
         }
         ast::Iterable::ExprTuple(expr_tuple) => {
@@ -1302,18 +1327,19 @@ fn iterable_from_ast(
             for expr in expr_tuple {
                 let span = expr.span();
                 let expr = expr_from_ast(ctx, expr)?;
-                let ty = expr.ty();
                 // Items in the tuple must be either integer, float, string
                 // or bool.
                 check_type(
                     ctx,
-                    ty,
+                    expr,
                     span.clone(),
                     &[Type::Integer, Type::Float, Type::String, Type::Bool],
                 )?;
+
                 // All items in the item must have the same type. Compare
                 // with the previous item and return as soon as we find a
                 // type mismatch.
+                let ty = ctx.ir.get(expr).ty();
                 if let Some((prev_ty, prev_span)) = prev {
                     if prev_ty != ty {
                         return Err(MismatchingTypes::build(
@@ -1338,9 +1364,9 @@ fn anchor_from_ast(
     anchor: &Option<ast::MatchAnchor>,
 ) -> Result<MatchAnchor, CompileError> {
     match anchor {
-        Some(ast::MatchAnchor::At(at_)) => Ok(MatchAnchor::At(Box::new(
-            non_negative_integer_from_ast(ctx, &at_.expr)?,
-        ))),
+        Some(ast::MatchAnchor::At(at_)) => {
+            Ok(MatchAnchor::At(non_negative_integer_from_ast(ctx, &at_.expr)?))
+        }
         Some(ast::MatchAnchor::In(in_)) => {
             Ok(MatchAnchor::In(range_from_ast(ctx, &in_.range)?))
         }
@@ -1352,11 +1378,8 @@ fn range_from_ast(
     ctx: &mut CompileContext,
     range: &ast::Range,
 ) -> Result<Range, CompileError> {
-    let lower_bound =
-        Box::new(non_negative_integer_from_ast(ctx, &range.lower_bound)?);
-
-    let upper_bound =
-        Box::new(non_negative_integer_from_ast(ctx, &range.upper_bound)?);
+    let lower_bound = non_negative_integer_from_ast(ctx, &range.lower_bound)?;
+    let upper_bound = non_negative_integer_from_ast(ctx, &range.upper_bound)?;
 
     // If both the lower and upper bounds are known at compile time, make sure
     // that lower_bound <= upper_bound. If they are not know (because they are
@@ -1365,8 +1388,10 @@ fn range_from_ast(
     if let (
         TypeValue::Integer(Value::Const(lower_bound)),
         TypeValue::Integer(Value::Const(upper_bound)),
-    ) = (lower_bound.type_value(), upper_bound.type_value())
-    {
+    ) = (
+        ctx.ir.get(lower_bound).type_value(),
+        ctx.ir.get(upper_bound).type_value(),
+    ) {
         if lower_bound > upper_bound {
             return Err(InvalidRange::build(
                 ctx.report_builder,
@@ -1385,13 +1410,13 @@ fn range_from_ast(
 fn non_negative_integer_from_ast(
     ctx: &mut CompileContext,
     expr: &ast::Expr,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let span = expr.span();
     let expr = expr_from_ast(ctx, expr)?;
-    let type_value = expr.type_value();
 
-    check_type(ctx, type_value.ty(), span.clone(), &[Type::Integer])?;
+    check_type(ctx, expr, span.clone(), &[Type::Integer])?;
 
+    let type_value = ctx.ir.get(expr).type_value();
     if let TypeValue::Integer(Value::Const(value)) = type_value {
         if value < 0 {
             return Err(UnexpectedNegativeNumber::build(
@@ -1408,15 +1433,16 @@ fn integer_in_range_from_ast(
     ctx: &mut CompileContext,
     expr: &ast::Expr,
     range: RangeInclusive<i64>,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let span = expr.span();
     let expr = expr_from_ast(ctx, expr)?;
-    let type_value = expr.type_value();
 
-    check_type(ctx, type_value.ty(), span.clone(), &[Type::Integer])?;
+    check_type(ctx, expr, span.clone(), &[Type::Integer])?;
 
     // If the value is known at compile time make sure that it is within
     // the given range.
+    let type_value = ctx.ir.get(expr).type_value();
+
     if let TypeValue::Integer(Value::Const(value)) = type_value {
         if !range.contains(&value) {
             return Err(NumberOutOfRange::build(
@@ -1529,28 +1555,24 @@ fn pattern_set_from_ast(
 fn func_call_from_ast(
     ctx: &mut CompileContext,
     func_call: &ast::FuncCall,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let callable = expr_from_ast(ctx, &func_call.callable)?;
-    let type_value = callable.type_value();
 
-    check_type(
-        ctx,
-        type_value.ty(),
-        func_call.callable.span(),
-        &[Type::Func],
-    )?;
+    check_type(ctx, callable, func_call.callable.span(), &[Type::Func])?;
 
     let args = func_call
         .args
         .iter()
         .map(|arg| expr_from_ast(ctx, arg))
-        .collect::<Result<Vec<Expr>, CompileError>>()?;
+        .collect::<Result<Vec<NodeIdx>, CompileError>>()?;
 
-    let arg_types: Vec<Type> = args.iter().map(|arg| arg.ty()).collect();
+    let arg_types: Vec<Type> =
+        args.iter().map(|arg| ctx.ir.get(*arg).ty()).collect();
 
     let mut expected_args = Vec::new();
     let mut matching_signature = None;
-    let func = type_value.as_func();
+
+    let func = ctx.ir.get(callable).type_value().as_func();
 
     // Determine if any of the signatures for the called function matches
     // the provided arguments.
@@ -1600,32 +1622,34 @@ fn func_call_from_ast(
 
     let (signature_index, type_value) = matching_signature.unwrap();
 
-    Ok(Expr::FuncCall(Box::new(FuncCall {
-        callable,
-        type_value,
-        signature_index,
-        args,
-    })))
+    Ok(ctx.ir.func_call(callable, args, type_value, signature_index))
 }
 
 fn matches_expr_from_ast(
     ctx: &mut CompileContext,
     expr: &ast::BinaryExpr,
-) -> Result<Expr, CompileError> {
+) -> Result<NodeIdx, CompileError> {
     let span = expr.span();
     let lhs_span = expr.lhs.span();
     let rhs_span = expr.rhs.span();
 
-    let lhs = Box::new(expr_from_ast(ctx, &expr.lhs)?);
-    let rhs = Box::new(expr_from_ast(ctx, &expr.rhs)?);
+    let lhs = expr_from_ast(ctx, &expr.lhs)?;
+    let rhs = expr_from_ast(ctx, &expr.rhs)?;
 
-    check_type(ctx, lhs.ty(), lhs_span, &[Type::String])?;
-    check_type(ctx, rhs.ty(), rhs_span, &[Type::Regexp])?;
+    check_type(ctx, lhs, lhs_span, &[Type::String])?;
+    check_type(ctx, rhs, rhs_span, &[Type::Regexp])?;
 
-    let expr = Expr::Matches { lhs, rhs };
+    let expr = ctx.ir.matches(lhs, rhs);
 
     if cfg!(feature = "constant-folding") {
-        expr.fold(ctx, span)
+        ctx.ir.fold(expr).ok_or_else(|| {
+            NumberOutOfRange::build(
+                ctx.report_builder,
+                i64::MIN,
+                i64::MAX,
+                span.into(),
+            )
+        })
     } else {
         Ok(expr)
     }
@@ -1633,10 +1657,11 @@ fn matches_expr_from_ast(
 
 fn check_type(
     ctx: &CompileContext,
-    ty: Type,
+    expr: NodeIdx,
     span: Span,
     accepted_types: &[Type],
 ) -> Result<(), CompileError> {
+    let ty = ctx.ir.get(expr).ty();
     if accepted_types.contains(&ty) {
         Ok(())
     } else {
@@ -1652,19 +1677,22 @@ fn check_type(
 
 fn check_operands(
     ctx: &CompileContext,
-    lhs_ty: Type,
-    rhs_ty: Type,
+    lhs: NodeIdx,
+    rhs: NodeIdx,
     lhs_span: Span,
     rhs_span: Span,
     accepted_types: &[Type],
     compatible_types: &[Type],
 ) -> Result<(), CompileError> {
+    let lhs_ty = ctx.ir.get(lhs).ty();
+    let rhs_ty = ctx.ir.get(rhs).ty();
+
     // Both types must be known.
     assert!(!matches!(lhs_ty, Type::Unknown));
     assert!(!matches!(rhs_ty, Type::Unknown));
 
-    check_type(ctx, lhs_ty, lhs_span.clone(), accepted_types)?;
-    check_type(ctx, rhs_ty, rhs_span.clone(), accepted_types)?;
+    check_type(ctx, lhs, lhs_span.clone(), accepted_types)?;
+    check_type(ctx, rhs, rhs_span.clone(), accepted_types)?;
 
     let types_are_compatible = {
         // If the types are the same, they are compatible.
@@ -1778,29 +1806,34 @@ macro_rules! gen_unary_op {
         fn $name(
             ctx: &mut CompileContext,
             expr: &ast::UnaryExpr,
-        ) -> Result<Expr, CompileError> {
+        ) -> Result<NodeIdx, CompileError> {
             let span = expr.span();
             let operand = expr_from_ast(ctx, &expr.operand)?;
 
             check_type(
                 ctx,
-                operand.ty(),
+                operand,
                 expr.operand.span(),
                 &[$( $accepted_types ),+],
             )?;
 
             let check_fn:
-                Option<fn(&mut CompileContext, &Expr, Span) -> Result<(), CompileError>>
+                Option<fn(&mut CompileContext, NodeIdx, Span) -> Result<(), CompileError>>
                 = $check_fn;
 
             if let Some(check_fn) = check_fn {
-                check_fn(ctx, &operand, expr.operand.span())?;
+                check_fn(ctx, operand, expr.operand.span())?;
             }
 
-            let expr = Expr::$variant(operand);
+            let expr = ctx.ir.$variant(operand);
 
             if cfg!(feature = "constant-folding") {
-                expr.fold(ctx, span)
+                ctx.ir.fold(expr).ok_or_else(
+                    || NumberOutOfRange::build(
+                        ctx.report_builder,
+                        i64::MIN,
+                        i64::MAX,
+                        span.into()))
             } else {
                 Ok(expr)
             }
@@ -1813,7 +1846,7 @@ macro_rules! gen_binary_op {
         fn $name(
             ctx: &mut CompileContext,
             expr: &ast::BinaryExpr,
-        ) -> Result<Expr, CompileError> {
+        ) -> Result<NodeIdx, CompileError> {
             let span = expr.span();
             let lhs_span = expr.lhs.span();
             let rhs_span = expr.rhs.span();
@@ -1823,8 +1856,8 @@ macro_rules! gen_binary_op {
 
             check_operands(
                 ctx,
-                lhs.ty(),
-                rhs.ty(),
+                lhs,
+                rhs,
                 lhs_span.clone(),
                 rhs_span.clone(),
                 &[$( $accepted_types ),+],
@@ -1832,17 +1865,22 @@ macro_rules! gen_binary_op {
             )?;
 
             let check_fn:
-                Option<fn(&mut CompileContext, &Expr, &Expr, Span, Span) -> Result<(), CompileError>>
+                Option<fn(&mut CompileContext, NodeIdx, NodeIdx, Span, Span) -> Result<(), CompileError>>
                 = $check_fn;
 
             if let Some(check_fn) = check_fn {
-                check_fn(ctx, &lhs, &rhs, lhs_span, rhs_span)?;
+                check_fn(ctx, lhs, rhs, lhs_span, rhs_span)?;
             }
 
-            let expr = Expr::$variant(lhs, rhs);
+            let expr = ctx.ir.$variant(lhs, rhs);
 
             if cfg!(feature = "constant-folding") {
-                expr.fold(ctx, span)
+                ctx.ir.fold(expr).ok_or_else(
+                    || NumberOutOfRange::build(
+                        ctx.report_builder,
+                        i64::MIN,
+                        i64::MAX,
+                        span.into()))
             } else {
                 Ok(expr)
             }
@@ -1855,7 +1893,7 @@ macro_rules! gen_string_op {
         fn $name(
             ctx: &mut CompileContext,
             expr: &ast::BinaryExpr,
-        ) -> Result<Expr, CompileError> {
+        ) -> Result<NodeIdx, CompileError> {
             let span = expr.span();
             let lhs_span = expr.lhs.span();
             let rhs_span = expr.rhs.span();
@@ -1865,18 +1903,25 @@ macro_rules! gen_string_op {
 
             check_operands(
                 ctx,
-                lhs.ty(),
-                rhs.ty(),
+                lhs,
+                rhs,
                 lhs_span.clone(),
                 rhs_span.clone(),
                 &[Type::String],
                 &[Type::String],
             )?;
 
-            let expr = Expr::$variant(lhs, rhs);
+            let expr = ctx.ir.$variant(lhs, rhs);
 
             if cfg!(feature = "constant-folding") {
-                expr.fold(ctx, span)
+                ctx.ir.fold(expr).ok_or_else(|| {
+                    NumberOutOfRange::build(
+                        ctx.report_builder,
+                        i64::MIN,
+                        i64::MAX,
+                        span.into(),
+                    )
+                })
             } else {
                 Ok(expr)
             }
@@ -1889,25 +1934,25 @@ macro_rules! gen_n_ary_operation {
         fn $name(
             ctx: &mut CompileContext,
             expr: &ast::NAryExpr,
-        ) -> Result<Expr, CompileError> {
+        ) -> Result<NodeIdx, CompileError> {
             let span = expr.span();
             let accepted_types = &[$( $accepted_types ),+];
             let compatible_types = &[$( $compatible_types ),+];
 
-            let operands_hir: Vec<Expr> = expr
+            let operands_hir: Vec<NodeIdx> = expr
                 .operands()
                 .map(|expr| expr_from_ast(ctx, expr))
-                .collect::<Result<Vec<Expr>, CompileError>>()?;
+                .collect::<Result<Vec<NodeIdx>, CompileError>>()?;
 
             let check_fn:
-                Option<fn(&mut CompileContext, &Expr, Span) -> Result<(), CompileError>>
+                Option<fn(&mut CompileContext, NodeIdx, Span) -> Result<(), CompileError>>
                 = $check_fn;
 
             // Make sure that all operands have one of the accepted types.
             for (hir, ast) in iter::zip(operands_hir.iter(), expr.operands()) {
-                check_type(ctx, hir.ty(), ast.span(), accepted_types)?;
+                check_type(ctx, *hir, ast.span(), accepted_types)?;
                 if let Some(check_fn) = check_fn {
-                    check_fn(ctx, hir, ast.span())?;
+                    check_fn(ctx, *hir, ast.span())?;
                 }
             }
 
@@ -1916,8 +1961,8 @@ macro_rules! gen_n_ary_operation {
             for ((lhs_hir, rhs_ast), (rhs_hir, lhs_ast)) in
                 iter::zip(operands_hir.iter(), expr.operands()).tuple_windows()
             {
-                let lhs_ty = lhs_hir.ty();
-                let rhs_ty = rhs_hir.ty();
+                let lhs_ty = ctx.ir.get(*lhs_hir).ty();
+                let rhs_ty = ctx.ir.get(*rhs_hir).ty();
 
                 let types_are_compatible = {
                     // If the types are the same, they are compatible.
@@ -1941,10 +1986,15 @@ macro_rules! gen_n_ary_operation {
                 }
             }
 
-            let expr = Expr::$variant(operands_hir);
+            let expr = ctx.ir.$variant(operands_hir);
 
             if cfg!(feature = "constant-folding") {
-                expr.fold(ctx, span)
+                ctx.ir.fold(expr).ok_or_else(
+                    || NumberOutOfRange::build(
+                        ctx.report_builder,
+                        i64::MIN,
+                        i64::MAX,
+                        span.into()))
             } else {
                 Ok(expr)
             }
@@ -1967,7 +2017,8 @@ gen_unary_op!(
     Type::Bool | Type::Integer | Type::Float | Type::String,
     // Raise warning if the operand is not bool.
     Some(|ctx, operand, span| {
-        warn_if_not_bool(ctx, operand.ty(), span);
+        let ty = ctx.ir.get(operand).ty();
+        warn_if_not_bool(ctx, ty, span);
         Ok(())
     })
 );
@@ -1982,7 +2033,8 @@ gen_n_ary_operation!(
     // are casted to boolean anyways.
     Type::Bool | Type::Integer | Type::Float | Type::String,
     Some(|ctx, operand, span| {
-        warn_if_not_bool(ctx, operand.ty(), span);
+        let ty = ctx.ir.get(operand).ty();
+        warn_if_not_bool(ctx, ty, span);
         Ok(())
     })
 );
@@ -1997,7 +2049,8 @@ gen_n_ary_operation!(
     // are casted to boolean anyways.
     Type::Bool | Type::Integer | Type::Float | Type::String,
     Some(|ctx, operand, span| {
-        warn_if_not_bool(ctx, operand.ty(), span);
+        let ty = ctx.ir.get(operand).ty();
+        warn_if_not_bool(ctx, ty, span);
         Ok(())
     })
 );
@@ -2050,7 +2103,9 @@ gen_binary_op!(
     Type::Integer,
     Type::Integer,
     Some(|ctx, _lhs, rhs, _lhs_span, rhs_span| {
-        if let TypeValue::Integer(Value::Const(value)) = rhs.type_value() {
+        if let TypeValue::Integer(Value::Const(value)) =
+            ctx.ir.get(rhs).type_value()
+        {
             if value < 0 {
                 return Err(UnexpectedNegativeNumber::build(
                     ctx.report_builder,
@@ -2068,7 +2123,9 @@ gen_binary_op!(
     Type::Integer,
     Type::Integer,
     Some(|ctx, _lhs, rhs, _lhs_span, rhs_span| {
-        if let TypeValue::Integer(Value::Const(value)) = rhs.type_value() {
+        if let TypeValue::Integer(Value::Const(value)) =
+            ctx.ir.get(rhs).type_value()
+        {
             if value < 0 {
                 return Err(UnexpectedNegativeNumber::build(
                     ctx.report_builder,

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -119,8 +119,7 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                 | Expr::Sub { operands, .. }
                 | Expr::Mul { operands, .. }
                 | Expr::Div { operands, .. }
-                | Expr::Mod { operands, .. }
-                | Expr::FieldAccess { operands, .. } => {
+                | Expr::Mod { operands, .. } => {
                     for operand in operands.iter().rev() {
                         self.stack.push(Event::Enter(*operand))
                     }

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -1,6 +1,6 @@
 use crate::compiler::ir::{Expr, Iterable, MatchAnchor, NodeIdx, Quantifier};
 
-pub enum Event<T> {
+pub(crate) enum Event<T> {
     Enter(T),
     Leave(T),
 }
@@ -35,7 +35,7 @@ pub enum Event<T> {
 /// Leave(a)
 /// ```
 ///
-pub struct DepthFirstSearch<'a> {
+pub(crate) struct DepthFirstSearch<'a> {
     nodes: &'a [Expr],
     stack: Vec<Event<NodeIdx>>,
 }
@@ -102,7 +102,7 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
 
         if let Event::Enter(expr) = next {
             self.stack.push(Event::Leave(expr));
-            match &self.nodes[expr.0 as usize] {
+            match &self.nodes[expr] {
                 Expr::Const(_) => {}
                 Expr::Filesize => {}
                 Expr::Ident { .. } => {}
@@ -223,12 +223,8 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
         }
 
         let next = match next {
-            Event::Enter(expr) => {
-                Event::Enter((expr, &self.nodes[expr.0 as usize]))
-            }
-            Event::Leave(expr) => {
-                Event::Leave((expr, &self.nodes[expr.0 as usize]))
-            }
+            Event::Enter(expr) => Event::Enter((expr, &self.nodes[expr])),
+            Event::Leave(expr) => Event::Leave((expr, &self.nodes[expr])),
         };
 
         Some(next)

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -65,8 +65,7 @@ impl<'a> DepthFirstSearch<'a> {
     /// node that was exited.
     #[allow(dead_code)] // TODO: remove when this is used.
     pub fn prune(&mut self) {
-        // Remove all StackEvent::Enter from the stack until finding a
-        // StackEvent::Leave.
+        // Remove all Event::Enter from the stack until finding an Event::Leave.
         while let Some(Event::Enter(_)) = self.stack.last() {
             self.stack.pop();
         }
@@ -172,6 +171,12 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                     }
                 }
 
+                Expr::FieldAccess(field_access) => {
+                    for operand in field_access.operands.iter().rev() {
+                        self.stack.push(Event::Enter(*operand))
+                    }
+                }
+
                 Expr::FuncCall(fn_call) => {
                     for arg in fn_call.args.iter().rev() {
                         self.stack.push(Event::Enter(*arg))
@@ -232,7 +237,7 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::compiler::ir::dfs::Event;
     use crate::compiler::ir::{Expr, NodeIdx, IR};
     use crate::types::TypeValue;

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -248,8 +248,8 @@ mod tests {
         let const_1 = ir.constant(TypeValue::const_integer_from(1));
         let const_2 = ir.constant(TypeValue::const_integer_from(2));
         let const_3 = ir.constant(TypeValue::const_integer_from(2));
-        let add = ir.add(vec![const_2, const_3]);
-        let root = ir.add(vec![const_1, add]);
+        let add = ir.add(vec![const_2, const_3]).unwrap();
+        let root = ir.add(vec![const_1, add]).unwrap();
 
         let mut dfs = ir.dfs_iter(root);
 

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -217,9 +217,9 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                     self.stack.push(Event::Enter(lookup.primary));
                 }
 
-                Expr::With(with) => {
-                    self.stack.push(Event::Enter(with.condition));
-                    for (_id, expr) in with.declarations.iter().rev() {
+                Expr::With { declarations, condition } => {
+                    self.stack.push(Event::Enter(*condition));
+                    for (_id, expr) in declarations.iter().rev() {
                         self.stack.push(Event::Enter(*expr))
                     }
                 }

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -1,6 +1,12 @@
-use crate::compiler::ir::{Expr, Iterable, MatchAnchor, Quantifier};
+use crate::compiler::ir::{
+    Expr, Iterable, MatchAnchor, NodeIdx, Quantifier, IR,
+};
 
-#[allow(dead_code)]
+enum StackEvent {
+    Enter(NodeIdx),
+    Leave(NodeIdx),
+}
+
 pub enum Event<'a> {
     Enter(&'a Expr),
     Leave(&'a Expr),
@@ -37,13 +43,15 @@ pub enum Event<'a> {
 /// ```
 ///
 pub struct DepthFirstSearch<'a> {
-    stack: Vec<Event<'a>>,
+    ir: &'a IR,
+    stack: Vec<StackEvent>,
 }
 
 impl<'a> DepthFirstSearch<'a> {
-    /// Creates a new [`DepthFirstSearch`] that traverses the given expression.
-    pub fn new(expr: &'a Expr) -> Self {
-        Self { stack: vec![Event::Enter(expr)] }
+    /// Creates a new [`DepthFirstSearch`] that traverses the tree starting
+    /// at the given node.
+    pub fn new(ir: &'a IR, start: NodeIdx) -> Self {
+        Self { ir, stack: vec![StackEvent::Enter(start)] }
     }
 
     /// Prunes the search tree, preventing the traversal from visiting the
@@ -51,21 +59,22 @@ impl<'a> DepthFirstSearch<'a> {
     ///
     /// The effect of this function depends on the current position in the
     /// tree. For example, if `prune` is called immediately after an
-    /// [`Event::Enter`], the current node is the one that was just entered.
+    /// [`StackEvent::Enter`], the current node is the one that was just entered.
     /// In this scenario, pruning ensures that none of this node's children
     /// are visited, and the next event will be the corresponding
-    /// [`Event::Leave`] for the node that was entered.
+    /// [`StackEvent::Leave`] for the node that was entered.
     ///
-    /// Conversely, if `prune` is called right after an [`Event::Leave`], the
+    /// Conversely, if `prune` is called right after an [`StackEvent::Leave`], the
     /// current node is the parent of the node that was just exited. In this
     /// case, pruning prevents any remaining children of the current node
     /// (i.e., the siblings of the node that was just left) from being visited.
-    /// The next event will then be the [`Event::Leave`] for the parent of the
+    /// The next event will then be the [`StackEvent::Leave`] for the parent of the
     /// node that was exited.
     #[allow(dead_code)] // TODO: remove when this is used.
     pub fn prune(&mut self) {
-        // Remove all Event::Enter from the stack until an Event::Leave.
-        while let Some(Event::Enter(_)) = self.stack.last() {
+        // Remove all StackEvent::Enter from the stack until finding a
+        // StackEvent::Leave.
+        while let Some(StackEvent::Enter(_)) = self.stack.last() {
             self.stack.pop();
         }
     }
@@ -78,53 +87,55 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
         let next = self.stack.pop()?;
 
         let push_quantifier =
-            |quantifier: &'a Quantifier, stack: &mut Vec<Event<'a>>| {
+            |quantifier: &'a Quantifier, stack: &mut Vec<StackEvent>| {
                 match quantifier {
                     Quantifier::None => {}
                     Quantifier::All => {}
                     Quantifier::Any => {}
                     Quantifier::Percentage(_) => {}
-                    Quantifier::Expr(expr) => stack.push(Event::Enter(expr)),
+                    Quantifier::Expr(expr) => {
+                        stack.push(StackEvent::Enter(*expr))
+                    }
                 }
             };
 
         let push_anchor =
-            |anchor: &'a MatchAnchor, stack: &mut Vec<Event<'a>>| match anchor
+            |anchor: &'a MatchAnchor, stack: &mut Vec<StackEvent>| match anchor
             {
                 MatchAnchor::None => {}
                 MatchAnchor::At(expr) => {
-                    stack.push(Event::Enter(expr));
+                    stack.push(StackEvent::Enter(*expr));
                 }
                 MatchAnchor::In(range) => {
-                    stack.push(Event::Enter(&range.upper_bound));
-                    stack.push(Event::Enter(&range.lower_bound));
+                    stack.push(StackEvent::Enter(range.upper_bound));
+                    stack.push(StackEvent::Enter(range.lower_bound));
                 }
             };
 
-        if let Event::Enter(expr) = next {
-            self.stack.push(Event::Leave(expr));
-            match expr {
+        if let StackEvent::Enter(expr) = next {
+            self.stack.push(StackEvent::Leave(expr));
+            match self.ir.get(expr) {
                 Expr::Const(_) => {}
                 Expr::Filesize => {}
                 Expr::Ident { .. } => {}
 
                 Expr::Not { operand }
                 | Expr::Defined { operand }
-                | Expr::Minus { operand }
+                | Expr::Minus { operand, .. }
                 | Expr::BitwiseNot { operand } => {
-                    self.stack.push(Event::Enter(operand));
+                    self.stack.push(StackEvent::Enter(*operand));
                 }
 
                 Expr::And { operands }
                 | Expr::Or { operands }
-                | Expr::Add { operands }
-                | Expr::Sub { operands }
-                | Expr::Mul { operands }
-                | Expr::Div { operands }
-                | Expr::Mod { operands }
-                | Expr::FieldAccess { operands } => {
+                | Expr::Add { operands, .. }
+                | Expr::Sub { operands, .. }
+                | Expr::Mul { operands, .. }
+                | Expr::Div { operands, .. }
+                | Expr::Mod { operands, .. }
+                | Expr::FieldAccess { operands, .. } => {
                     for operand in operands.iter().rev() {
-                        self.stack.push(Event::Enter(operand))
+                        self.stack.push(StackEvent::Enter(*operand))
                     }
                 }
 
@@ -147,8 +158,8 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                 | Expr::IEndsWith { lhs, rhs }
                 | Expr::IEquals { lhs, rhs }
                 | Expr::Matches { lhs, rhs } => {
-                    self.stack.push(Event::Enter(rhs));
-                    self.stack.push(Event::Enter(lhs));
+                    self.stack.push(StackEvent::Enter(*rhs));
+                    self.stack.push(StackEvent::Enter(*lhs));
                 }
 
                 Expr::PatternMatch { anchor, .. }
@@ -159,8 +170,8 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                 Expr::PatternCount { range, .. }
                 | Expr::PatternCountVar { range, .. } => {
                     if let Some(range) = range {
-                        self.stack.push(Event::Enter(&range.upper_bound));
-                        self.stack.push(Event::Enter(&range.lower_bound));
+                        self.stack.push(StackEvent::Enter(range.upper_bound));
+                        self.stack.push(StackEvent::Enter(range.lower_bound));
                     }
                 }
 
@@ -169,15 +180,15 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                 | Expr::PatternLength { index, .. }
                 | Expr::PatternLengthVar { index, .. } => {
                     if let Some(index) = index {
-                        self.stack.push(Event::Enter(index));
+                        self.stack.push(StackEvent::Enter(*index));
                     }
                 }
 
                 Expr::FuncCall(fn_call) => {
                     for arg in fn_call.args.iter().rev() {
-                        self.stack.push(Event::Enter(arg))
+                        self.stack.push(StackEvent::Enter(*arg))
                     }
-                    self.stack.push(Event::Enter(&fn_call.callable));
+                    self.stack.push(StackEvent::Enter(fn_call.callable));
                 }
 
                 Expr::Of(of) => {
@@ -186,64 +197,71 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
                 }
 
                 Expr::ForOf(for_of) => {
-                    self.stack.push(Event::Enter(&for_of.condition));
+                    self.stack.push(StackEvent::Enter(for_of.condition));
                     push_quantifier(&for_of.quantifier, &mut self.stack);
                 }
 
                 Expr::ForIn(for_in) => {
-                    self.stack.push(Event::Enter(&for_in.condition));
+                    self.stack.push(StackEvent::Enter(for_in.condition));
                     match &for_in.iterable {
                         Iterable::Range(range) => {
-                            self.stack.push(Event::Enter(&range.upper_bound));
-                            self.stack.push(Event::Enter(&range.lower_bound));
+                            self.stack
+                                .push(StackEvent::Enter(range.upper_bound));
+                            self.stack
+                                .push(StackEvent::Enter(range.lower_bound));
                         }
                         Iterable::ExprTuple(expr_tuple) => {
                             for expr in expr_tuple.iter().rev() {
-                                self.stack.push(Event::Enter(expr))
+                                self.stack.push(StackEvent::Enter(*expr))
                             }
                         }
                         Iterable::Expr(expr) => {
-                            self.stack.push(Event::Enter(expr))
+                            self.stack.push(StackEvent::Enter(*expr))
                         }
                     }
                     push_quantifier(&for_in.quantifier, &mut self.stack);
                 }
 
                 Expr::Lookup(lookup) => {
-                    self.stack.push(Event::Enter(&lookup.index));
-                    self.stack.push(Event::Enter(&lookup.primary));
+                    self.stack.push(StackEvent::Enter(lookup.index));
+                    self.stack.push(StackEvent::Enter(lookup.primary));
                 }
 
                 Expr::With(with) => {
-                    self.stack.push(Event::Enter(&with.condition));
+                    self.stack.push(StackEvent::Enter(with.condition));
                     for (_id, expr) in with.declarations.iter().rev() {
-                        self.stack.push(Event::Enter(expr))
+                        self.stack.push(StackEvent::Enter(*expr))
                     }
                 }
             }
         }
 
-        Some(next)
+        let event = match next {
+            StackEvent::Enter(expr) => Event::Enter(self.ir.get(expr)),
+            StackEvent::Leave(expr) => Event::Leave(self.ir.get(expr)),
+        };
+
+        Some(event)
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::compiler::ir::dfs::Event;
-    use crate::compiler::ir::Expr;
+    use crate::compiler::ir::{Expr, IR};
     use crate::types::TypeValue;
 
     #[test]
     fn dfs() {
-        let expr = Expr::add(vec![
-            Expr::Const(TypeValue::const_integer_from(1)),
-            Expr::add(vec![
-                Expr::Const(TypeValue::const_integer_from(2)),
-                Expr::Const(TypeValue::const_integer_from(3)),
-            ]),
-        ]);
+        let mut ir = IR::new();
 
-        let mut dfs = expr.dfs_iter();
+        let const_1 = ir.constant(TypeValue::const_integer_from(1));
+        let const_2 = ir.constant(TypeValue::const_integer_from(2));
+        let const_3 = ir.constant(TypeValue::const_integer_from(2));
+        let add = ir.add(vec![const_2, const_3]);
+        let root = ir.add(vec![const_1, add]);
+
+        let mut dfs = ir.dfs_iter(root);
 
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Add { .. }))));
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Const(_)))));
@@ -257,14 +275,14 @@ mod test {
         assert!(matches!(dfs.next(), Some(Event::Leave(&Expr::Add { .. }))));
         assert!(dfs.next().is_none());
 
-        let mut dfs = expr.dfs_iter();
+        let mut dfs = ir.dfs_iter(root);
 
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Add { .. }))));
         dfs.prune();
         assert!(matches!(dfs.next(), Some(Event::Leave(&Expr::Add { .. }))));
         assert!(dfs.next().is_none());
 
-        let mut dfs = expr.dfs_iter();
+        let mut dfs = ir.dfs_iter(root);
 
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Add { .. }))));
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Const(_)))));
@@ -275,7 +293,7 @@ mod test {
         assert!(matches!(dfs.next(), Some(Event::Leave(&Expr::Add { .. }))));
         assert!(dfs.next().is_none());
 
-        let mut dfs = expr.dfs_iter();
+        let mut dfs = ir.dfs_iter(root);
 
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Add { .. }))));
         assert!(matches!(dfs.next(), Some(Event::Enter(&Expr::Const(_)))));

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -1,4 +1,4 @@
-use crate::compiler::ir::{Expr, Iterable, MatchAnchor, NodeIdx, Quantifier};
+use crate::compiler::ir::{Expr, ExprId, Iterable, MatchAnchor, Quantifier};
 
 pub(crate) enum Event<T> {
     Enter(T),
@@ -37,13 +37,13 @@ pub(crate) enum Event<T> {
 ///
 pub(crate) struct DepthFirstSearch<'a> {
     nodes: &'a [Expr],
-    stack: Vec<Event<NodeIdx>>,
+    stack: Vec<Event<ExprId>>,
 }
 
 impl<'a> DepthFirstSearch<'a> {
     /// Creates a new [`DepthFirstSearch`] that traverses the tree starting
     /// at the given node.
-    pub fn new(start: NodeIdx, nodes: &'a [Expr]) -> Self {
+    pub fn new(start: ExprId, nodes: &'a [Expr]) -> Self {
         Self { nodes, stack: vec![Event::Enter(start)] }
     }
 
@@ -73,7 +73,7 @@ impl<'a> DepthFirstSearch<'a> {
 }
 
 impl<'a> Iterator for DepthFirstSearch<'a> {
-    type Item = Event<(NodeIdx, &'a Expr)>;
+    type Item = Event<(ExprId, &'a Expr)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.stack.pop()?;
@@ -238,7 +238,7 @@ impl<'a> Iterator for DepthFirstSearch<'a> {
 #[cfg(test)]
 mod tests {
     use crate::compiler::ir::dfs::Event;
-    use crate::compiler::ir::{Expr, NodeIdx, IR};
+    use crate::compiler::ir::{Expr, ExprId, IR};
     use crate::types::TypeValue;
 
     #[test]
@@ -255,43 +255,43 @@ mod tests {
 
         assert!(matches!(
             dfs.next(),
-            Some(Event::Enter((NodeIdx(4), &Expr::Add { .. })))
+            Some(Event::Enter((ExprId(4), &Expr::Add { .. })))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Enter((NodeIdx(0), &Expr::Const(_))))
+            Some(Event::Enter((ExprId(0), &Expr::Const(_))))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Leave((NodeIdx(0), &Expr::Const(_))))
+            Some(Event::Leave((ExprId(0), &Expr::Const(_))))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Enter((NodeIdx(3), &Expr::Add { .. })))
+            Some(Event::Enter((ExprId(3), &Expr::Add { .. })))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Enter((NodeIdx(1), &Expr::Const(_))))
+            Some(Event::Enter((ExprId(1), &Expr::Const(_))))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Leave((NodeIdx(1), &Expr::Const(_))))
+            Some(Event::Leave((ExprId(1), &Expr::Const(_))))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Enter((NodeIdx(2), &Expr::Const(_))))
+            Some(Event::Enter((ExprId(2), &Expr::Const(_))))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Leave((NodeIdx(2), &Expr::Const(_))))
+            Some(Event::Leave((ExprId(2), &Expr::Const(_))))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Leave((NodeIdx(3), &Expr::Add { .. })))
+            Some(Event::Leave((ExprId(3), &Expr::Add { .. })))
         ));
         assert!(matches!(
             dfs.next(),
-            Some(Event::Leave((NodeIdx(4), &Expr::Add { .. })))
+            Some(Event::Leave((ExprId(4), &Expr::Add { .. })))
         ));
         assert!(dfs.next().is_none());
 
@@ -299,12 +299,12 @@ mod tests {
 
         assert!(matches!(
             dfs.next(),
-            Some(Event::Enter((NodeIdx(4), &Expr::Add { .. })))
+            Some(Event::Enter((ExprId(4), &Expr::Add { .. })))
         ));
         dfs.prune();
         assert!(matches!(
             dfs.next(),
-            Some(Event::Leave((NodeIdx(4), &Expr::Add { .. })))
+            Some(Event::Leave((ExprId(4), &Expr::Add { .. })))
         ));
         assert!(dfs.next().is_none());
 

--- a/lib/src/compiler/ir/hex2hir.rs
+++ b/lib/src/compiler/ir/hex2hir.rs
@@ -187,6 +187,7 @@ mod tests {
 
     use super::hex_byte_to_class;
     use crate::compiler::context::{CompileContext, VarStack};
+    use crate::compiler::ir::IR;
     use crate::compiler::report::ReportBuilder;
     use crate::compiler::Warnings;
     use crate::re::hir;
@@ -210,12 +211,14 @@ mod tests {
 
     #[test]
     fn hex_tokens_to_hir() {
+        let mut ir = IR::new();
         let mut report_builder = ReportBuilder::default();
         let mut symbol_table = StackedSymbolTable::new();
         let mut warnings = Warnings::default();
         let mut rule_patterns = vec![];
 
         let mut ctx = CompileContext {
+            ir: &mut ir,
             relaxed_re_syntax: false,
             error_on_slow_loop: false,
             current_symbol_table: None,

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -712,7 +712,10 @@ impl IR {
     /// Creates a new [`Expr::FieldAccess`].
     pub fn field_access(&mut self, operands: Vec<NodeIdx>) -> NodeIdx {
         let type_value = self.get(*operands.last().unwrap()).type_value();
-        self.nodes.push(Expr::FieldAccess { operands, type_value });
+        self.nodes.push(Expr::FieldAccess(Box::new(FieldAccess {
+            operands,
+            type_value,
+        })));
         NodeIdx::from(self.nodes.len() - 1)
     }
 

--- a/lib/src/compiler/ir/tests/mod.rs
+++ b/lib/src/compiler/ir/tests/mod.rs
@@ -1,9 +1,8 @@
 use std::fs;
 use std::io::BufWriter;
+use std::mem::size_of;
 
-use crate::compiler::{Expr, MatchAnchor, NodeIdx, Range};
-use crate::symbols::Symbol;
-use crate::types::TypeValue;
+use crate::compiler::Expr;
 use crate::Compiler;
 
 #[test]

--- a/lib/src/compiler/ir/tests/mod.rs
+++ b/lib/src/compiler/ir/tests/mod.rs
@@ -1,6 +1,17 @@
-use crate::Compiler;
 use std::fs;
 use std::io::BufWriter;
+
+use crate::compiler::{Expr, MatchAnchor, NodeIdx, Range};
+use crate::symbols::Symbol;
+use crate::types::TypeValue;
+use crate::Compiler;
+
+#[test]
+fn expr_size() {
+    // Sentinel test for making sure tha Expr doesn't grow in future
+    // changes.
+    assert_eq!(size_of::<Expr>(), 32);
+}
 
 #[test]
 fn ir() {

--- a/lib/src/compiler/ir/tests/testdata/1.folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.folding.ir
@@ -20,16 +20,27 @@ RULE test_3
     CONST integer(2)
 
 RULE test_4
+  EQ
+    CONST integer(8)
+    CONST integer(8)
+
+RULE test_5
   AND
     EQ
       FIELD_ACCESS
         IDENT Symbol { type_value: struct, kind: Field(0, true) }
         IDENT Symbol { type_value: integer(unknown), kind: Field(1, false) }
       CONST integer(0)
-    NOT
-      CONST boolean(false)
 
-RULE test_5
+RULE test_6
+  ADD
+    FIELD_ACCESS
+      IDENT Symbol { type_value: struct, kind: Field(0, true) }
+      IDENT Symbol { type_value: integer(unknown), kind: Field(1, false) }
+    CONST integer(1)
+    CONST integer(2)
+
+RULE test_7
   AND
     CONTAINS
       CONST string("foobar")

--- a/lib/src/compiler/ir/tests/testdata/1.in
+++ b/lib/src/compiler/ir/tests/testdata/1.in
@@ -17,10 +17,20 @@ rule test_3 {
 
 rule test_4 {
 	condition:
-		test_proto2.int64_zero == 0 and true and not false
+		4 --2 * 2 == 8
 }
 
 rule test_5 {
+	condition:
+		test_proto2.int64_zero == 0 and true and not false
+}
+
+rule test_6 {
+	condition:
+		test_proto2.int64_zero + 1 + 2
+}
+
+rule test_7 {
   condition:
      "foobar" contains "bar" and
      "foobar" icontains "BAR" and

--- a/lib/src/compiler/ir/tests/testdata/1.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.no-folding.ir
@@ -26,6 +26,16 @@ RULE test_3
     CONST integer(2)
 
 RULE test_4
+  EQ
+    SUB
+      CONST integer(4)
+      MUL
+        MINUS
+          CONST integer(2)
+        CONST integer(2)
+    CONST integer(8)
+
+RULE test_5
   AND
     EQ
       FIELD_ACCESS
@@ -36,7 +46,15 @@ RULE test_4
     NOT
       CONST boolean(false)
 
-RULE test_5
+RULE test_6
+  ADD
+    FIELD_ACCESS
+      IDENT Symbol { type_value: struct, kind: Field(0, true) }
+      IDENT Symbol { type_value: integer(unknown), kind: Field(1, false) }
+    CONST integer(1)
+    CONST integer(2)
+
+RULE test_7
   AND
     CONTAINS
       CONST string("foobar")

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -1177,14 +1177,15 @@ impl<'a> Compiler<'a> {
         // following cases:
         //
         // 1) When the pattern is anchored, because anchored pattern can appear
-        //    only at a fixed pattern and are not searched by Aho-Corasick.
+        //    only at a fixed offset and are not searched by Aho-Corasick.
+        //
         // 2) When the pattern has attributes: xor, fullword, base64 or
         //    base64wide, because in those cases the real pattern is not that
         //    common.
         //
-        // Note: this can't be done before calling `bool_expr_from_ast`, because
-        // we don't know which patterns are anchored until the condition is
-        // processed.
+        // Note: this can't be done before calling `rule_condition_from_ast`,
+        // because we don't know which patterns are anchored until the condition
+        // is processed.
         for pat in rule_patterns.iter() {
             if pat.anchored_at().is_none()
                 && !pat.pattern().flags().intersects(

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -433,7 +433,14 @@ impl<'a> Compiler<'a> {
         let wasm_symbols = wasm_mod.wasm_symbols();
         let wasm_exports = wasm_mod.wasm_exports();
 
+        let mut ir = IR::new();
+
+        if cfg!(feature = "constant-folding") {
+            ir.constant_folding(true);
+        }
+
         Self {
+            ir,
             ident_pool,
             global_symbols,
             symbol_table,
@@ -462,7 +469,6 @@ impl<'a> Compiler<'a> {
             lit_pool: BStringPool::new(),
             regexp_pool: StringPool::new(),
             patterns: FxHashMap::default(),
-            ir: IR::new(),
             #[cfg(test)]
             ir_writer: None,
         }

--- a/lib/src/compiler/tests/mod.rs
+++ b/lib/src/compiler/tests/mod.rs
@@ -81,8 +81,8 @@ fn namespaces() {
 fn var_stack() {
     let mut stack = VarStack::new();
 
-    let mut frame1 = stack.new_frame(4);
-    let mut frame2 = stack.new_frame(4);
+    let frame1 = stack.new_frame(4);
+    let frame2 = stack.new_frame(4);
 
     assert_eq!(
         frame1.new_var(Type::Integer),

--- a/lib/src/re/hir.rs
+++ b/lib/src/re/hir.rs
@@ -355,7 +355,7 @@ impl<'a, H: Hasher> regex_syntax::hir::Visitor for HirHasher<'a, H> {
 ///
 /// For example `??` in an hex pattern, or `.` in a regexp that uses the `/s`
 /// modifier (i.e: `dot_matches_new_line` is true).
-pub fn any_byte(hir_kind: &HirKind) -> bool {
+pub(crate) fn any_byte(hir_kind: &HirKind) -> bool {
     match hir_kind {
         HirKind::Class(Class::Bytes(class)) => {
             if let Some(range) = class.ranges().first() {
@@ -380,7 +380,7 @@ pub fn any_byte(hir_kind: &HirKind) -> bool {
 ///
 /// For example `.` in a regexp that doesn't use the `/s` modifier
 /// (i.e: `dot_matches_new_line` is false).
-pub fn any_byte_except_newline(hir_kind: &HirKind) -> bool {
+pub(crate) fn any_byte_except_newline(hir_kind: &HirKind) -> bool {
     match hir_kind {
         HirKind::Class(Class::Bytes(class)) => {
             // The class must contain two ranges, one that contains all bytes
@@ -410,7 +410,7 @@ pub fn any_byte_except_newline(hir_kind: &HirKind) -> bool {
 /// This function basically does the opposite than [`hex_byte_to_class`].
 /// However, not all the classes represent a masked byte, in such cases
 /// this function returns [`None`].
-pub fn class_to_masked_byte(c: &ClassBytes) -> Option<HexByte> {
+pub(crate) fn class_to_masked_byte(c: &ClassBytes) -> Option<HexByte> {
     if c.ranges().is_empty() {
         return None;
     }
@@ -457,7 +457,7 @@ pub fn class_to_masked_byte(c: &ClassBytes) -> Option<HexByte> {
     Some(HexByte { value: smallest_byte, mask: !neg_mask })
 }
 
-pub fn class_to_masked_bytes_alternation(
+pub(crate) fn class_to_masked_bytes_alternation(
     c: &ClassBytes,
 ) -> Option<Vec<HexByte>> {
     if c.ranges().is_empty() {

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -1377,7 +1377,7 @@ impl RuntimeObject {
 /// A runtime object handle is an opaque integer value that identifies a
 /// runtime object.
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
-pub struct RuntimeObjectHandle(i64);
+pub(crate) struct RuntimeObjectHandle(i64);
 
 impl RuntimeObjectHandle {
     pub(crate) const NULL: Self = RuntimeObjectHandle(-1);

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -34,9 +34,9 @@ The memory of these WASM modules is organized as follows.
   │ Variable #n              │
   : ...                      :
   │                          │
-  ├──────────────────────────┤ 1032
+  ├──────────────────────────┤ 1040
   │ Field lookup indexes     │
-  ├──────────────────────────┤ 2056
+  ├──────────────────────────┤ 2064
   │ Matching rules bitmap    │
   │                          │
   :                          :


### PR DESCRIPTION
With this change the IR tree is represented by a vector of `Expr`. References to other expressions in the tree are represented by the index of the expression in the vector.