### PR TITLE
feat(capi+go): expose match data (strings) via YRX_MATCH

### DIFF
--- a/capi/include/yara_x.h
+++ b/capi/include/yara_x.h
@@ -107,6 +107,10 @@ typedef struct YRX_BUFFER {
 
 // Contains information about a pattern match.
 typedef struct YRX_MATCH {
+  // Slice of the data of the match.
+  const uint8_t *data;
+  // Length of the data slice.
+  size_t data_len;
   // Offset within the data where the match occurred.
   size_t offset;
   // Length of the match.

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -175,6 +175,10 @@ pub unsafe extern "C" fn yrx_last_error() -> *const c_char {
 /// Contains information about a pattern match.
 #[repr(C)]
 pub struct YRX_MATCH {
+    /// Slice of the data of the match.
+    pub data: *const u8,
+    /// Length of the data slice.
+    pub data_len: usize,
     /// Offset within the data where the match occurred.
     pub offset: usize,
     /// Length of the match.

--- a/capi/src/pattern.rs
+++ b/capi/src/pattern.rs
@@ -70,7 +70,12 @@ pub unsafe extern "C" fn yrx_pattern_iter_matches(
 
     for m in matches_iter {
         callback(
-            &YRX_MATCH { offset: m.range().start, length: m.range().len() },
+            &YRX_MATCH {
+                data: m.data().as_ptr(),
+                data_len: m.data().len(),
+                length: m.range().len(),
+                offset: m.range().start,
+            },
             user_data,
         )
     }

--- a/go/compiler.go
+++ b/go/compiler.go
@@ -291,7 +291,7 @@ func NewCompiler(opts ...CompileOption) (*Compiler, error) {
 }
 
 func (c *Compiler) initialize() error {
-	for name, _ := range c.ignoredModules {
+	for name := range c.ignoredModules {
 		c.ignoreModule(name)
 	}
 	for _, feature := range c.features {

--- a/go/main.go
+++ b/go/main.go
@@ -272,8 +272,10 @@ type Metadata struct {
 // Match contains information about the offset where a match occurred and
 // the length of the match.
 type Match struct {
-	offset uint64
-	length uint64
+	data     []byte
+	data_len uintptr
+	length   uint64
+	offset   uint64
 }
 
 // Creates a new Rule from it's C counterpart.
@@ -380,6 +382,11 @@ func (p *Pattern) Identifier() string {
 // Matches returns the matches found for this pattern.
 func (p *Pattern) Matches() []Match {
 	return p.matches
+}
+
+// Data returns the match data (i.e., strings).
+func (m *Match) Data() []byte {
+	return m.data
 }
 
 // Offset returns the offset within the scanned data where a match occurred.
@@ -509,7 +516,8 @@ func matchCallback(match *C.YRX_MATCH, handle C.uintptr_t) {
 		panic("matchCallback didn't receive a *[]Match")
 	}
 	*matches = append(*matches, Match{
-		offset: uint64(match.offset),
+		data:   C.GoBytes(unsafe.Pointer(match.data), C.int(match.data_len)),
 		length: uint64(match.length),
+		offset: uint64(match.offset),
 	})
 }

--- a/go/scanner_test.go
+++ b/go/scanner_test.go
@@ -2,10 +2,11 @@ package yara_x
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScanner1(t *testing.T) {
@@ -42,6 +43,7 @@ func TestScanner2(t *testing.T) {
 	assert.Equal(t, "$bar", matchingRules[0].Patterns()[0].Identifier())
 	assert.Equal(t, uint64(3), matchingRules[0].Patterns()[0].Matches()[0].Offset())
 	assert.Equal(t, uint64(3), matchingRules[0].Patterns()[0].Matches()[0].Length())
+	assert.Equal(t, string(matchingRules[0].Patterns()[0].Matches()[0].Data()), "bar")
 
 	s.Destroy()
 	runtime.GC()
@@ -81,6 +83,31 @@ func TestScanner4(t *testing.T) {
 	assert.NoError(t, s.SetGlobal("var_int", int64(1)))
 	scanResults, _ = s.Scan([]byte{})
 	assert.Len(t, scanResults.MatchingRules(), 1)
+}
+
+func TestScanner5(t *testing.T) {
+	r, _ := Compile(`rule t { strings: $1=/[Tt]est/ $2=/[Ss]tring/ condition: any of them}`)
+
+	s := NewScanner(r)
+	scanResults, _ := s.Scan([]byte("TestString\ntestString\nTeststring\nteststring"))
+	matchingRules := scanResults.MatchingRules()
+
+	assert.Len(t, matchingRules, 1)
+	assert.Equal(t, "t", matchingRules[0].Identifier())
+	assert.Equal(t, "default", matchingRules[0].Namespace())
+
+	assert.Len(t, matchingRules[0].Patterns(), 2)
+	assert.Equal(t, "$1", matchingRules[0].Patterns()[0].Identifier())
+	assert.Equal(t, "$2", matchingRules[0].Patterns()[1].Identifier())
+	assert.Equal(t, string(matchingRules[0].Patterns()[0].Matches()[0].Data()), "Test")
+	assert.Equal(t, string(matchingRules[0].Patterns()[0].Matches()[1].Data()), "test")
+	assert.Equal(t, string(matchingRules[0].Patterns()[0].Matches()[2].Data()), "Test")
+	assert.Equal(t, string(matchingRules[0].Patterns()[1].Matches()[0].Data()), "String")
+	assert.Equal(t, string(matchingRules[0].Patterns()[1].Matches()[1].Data()), "String")
+	assert.Equal(t, string(matchingRules[0].Patterns()[1].Matches()[2].Data()), "string")
+
+	s.Destroy()
+	runtime.GC()
 }
 
 func TestScannerTimeout(t *testing.T) {


### PR DESCRIPTION
I noticed that the API currently does not expose the strings from a given match while the CLI does: https://github.com/VirusTotal/yara-x/blob/ba8c764f8490fb2037fae539a22e0981e72188fc/cli/src/commands/scan.rs#L851

Since matches are already plumbed into the Go API, this was a pretty small lift but I still wanted to capture the desired behavior with a couple of test updates.

If there's a better or more appropriate implementation for this, please let me know!

cc: @tstromberg