### PR TITLE
refactor: allocate md5 object only after validation of mach-o fields

### DIFF
--- a/lib/src/modules/macho/mod.rs
+++ b/lib/src/modules/macho/mod.rs
@@ -320,7 +320,6 @@ fn has_export(ctx: &ScanContext, export: RuntimeString) -> Option<bool> {
 #[module_export]
 fn dylib_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     let macho = ctx.module_output::<Macho>()?;
-    let mut md5_hash = Md5::new();
     let mut dylibs_to_hash = &macho.dylibs;
 
     // if there are not any dylibs in the main Macho, the dylibs of the nested
@@ -333,6 +332,8 @@ fn dylib_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     if dylibs_to_hash.is_empty() {
         return None;
     }
+
+    let mut md5_hash = Md5::new();
 
     let dylibs_to_hash: String = dylibs_to_hash
         .iter()
@@ -358,7 +359,6 @@ fn dylib_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 #[module_export]
 fn entitlement_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     let macho = ctx.module_output::<Macho>()?;
-    let mut md5_hash = Md5::new();
     let mut entitlements_to_hash = &macho.entitlements;
 
     // if there are not any entitlements in the main Macho, the entitlements of the
@@ -371,6 +371,8 @@ fn entitlement_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     if entitlements_to_hash.is_empty() {
         return None;
     }
+
+    let mut md5_hash = Md5::new();
 
     let entitlements_str: String = entitlements_to_hash
         .iter()
@@ -389,7 +391,6 @@ fn entitlement_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 #[module_export]
 fn export_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     let macho = ctx.module_output::<Macho>()?;
-    let mut md5_hash = Md5::new();
     let mut exports_to_hash = &macho.exports;
 
     // if there are not any exports in the main Macho, the exports of the
@@ -402,6 +403,8 @@ fn export_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     if exports_to_hash.is_empty() {
         return None;
     }
+
+    let mut md5_hash = Md5::new();
 
     let exports_str: String = exports_to_hash
         .iter()
@@ -420,7 +423,6 @@ fn export_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 #[module_export]
 fn import_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     let macho = ctx.module_output::<Macho>()?;
-    let mut md5_hash = Md5::new();
     let mut imports_to_hash = &macho.imports;
 
     // if there are not any imports in the main Macho, the imports of the
@@ -433,6 +435,8 @@ fn import_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     if imports_to_hash.is_empty() {
         return None;
     }
+
+    let mut md5_hash = Md5::new();
 
     let imports_str: String = imports_to_hash
         .iter()


### PR DESCRIPTION
Following up on a comment here: https://github.com/VirusTotal/yara-x/pull/248#discussion_r1850935651, which suggests only allocating the `md5_hash` object after passing initial validations for the given mach-o fields.