### PR TITLE
feat(cuckoo-update): data processed via serde schema, module_export fns return option

### DIFF
--- a/lib/src/modules/cuckoo/mod.rs
+++ b/lib/src/modules/cuckoo/mod.rs
@@ -1,312 +1,247 @@
-use std::cell::RefCell;
-
 #[cfg(feature = "logging")]
 use log::error;
-use serde_json::{Map, Value};
 
 use crate::compiler::RegexpId;
 use crate::modules::prelude::*;
 use crate::modules::protos::cuckoo::*;
 
+mod schema;
 #[cfg(test)]
 mod tests;
 
+use std::cell::RefCell;
+use std::rc::Rc;
 thread_local! {
-    static CUCKOO_REPORT: RefCell<Option<Map<String, Value>>> = const { RefCell::new(None) };
+    static LOCAL_DATA: RefCell<Option<Rc<schema::CuckooJson>>> = const { RefCell::new(None) };
+}
+
+fn get_local() -> Option<Rc<schema::CuckooJson>> {
+    LOCAL_DATA.with(|data| data.borrow().clone())
+}
+
+fn set_local(value: schema::CuckooJson) {
+    LOCAL_DATA.with(|data| {
+        *data.borrow_mut() = Some(Rc::new(value));
+    });
 }
 
 #[module_main]
 fn main(_data: &[u8], meta: Option<&[u8]>) -> Cuckoo {
-    if let Some(meta) = meta {
-        match serde_json::from_slice::<Value>(meta) {
-            Ok(Value::Object(json)) => CUCKOO_REPORT.set(Some(json)),
-            Ok(_) => {
-                #[cfg(feature = "logging")]
-                error!("cuckoo report is not a valid JSON")
-            }
-            #[cfg(feature = "logging")]
-            Err(err) => error!("can't parse cuckoo report: {}", err),
-            #[cfg(not(feature = "logging"))]
-            Err(_) => {}
+    let parsed =
+        serde_json::from_slice::<schema::CuckooJson>(meta.unwrap_or_default());
+
+    match parsed {
+        Ok(parsed) => {
+            set_local(parsed);
         }
-    }
+        Err(e) => {
+            #[cfg(feature = "logging")]
+            error!("can't parse cuckoo report: {}", e);
+        }
+    };
+
     Cuckoo::new()
 }
 
 #[module_export(name = "network.dns_lookup")]
-fn network_dns_lookup(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        let find_match = |objects: &Vec<Value>, field_name: &str| {
-            objects.iter().any(|object| {
-                object
-                    .get(field_name)
-                    .and_then(|val| val.as_str())
-                    .map(|val| ctx.regexp_matches(regexp_id, val.as_bytes()))
-                    .unwrap_or(false)
-            })
-        };
-
-        // The top-level object contains a "network" key that contains
-        // network-related information.
-        let network = report.as_ref().and_then(|report| report.get("network"));
-
-        // Recent versions of Cuckoo generate domain resolution information with
-        // this format:
-        //
-        //       "domains": [
-        //           {
-        //               "ip": "192.168.0.1",
-        //               "domain": "foo.bar.com"
-        //           }
-        //        ]
-        //
-        // But older versions with this other format:
-        //
-        //       "dns": [
-        //           {
-        //               "ip": "192.168.0.1",
-        //               "hostname": "foo.bar.com"
-        //           }
-        //        ]
-        //
-        // Additionally, the newer versions also have a "dns" field. So, let's try
-        // to locate the "domains" field first, if not found fall back to the older
-        // format.
-        if network
-            .and_then(|report| report.get("domains"))
-            .and_then(|domains| domains.as_array())
-            .map(|domains| find_match(domains, "domain"))
-            .unwrap_or(false)
-        {
-            return true;
-        }
-
-        if network
-            .and_then(|report| report.get("dns"))
-            .and_then(|dns| dns.as_array())
-            .map(|dns| find_match(dns, "hostname"))
-            .unwrap_or(false)
-        {
-            return true;
-        }
-
-        false
-    })
-}
-
-enum RequestType {
-    Get,
-    Post,
-    Both,
-}
-
-fn http_request(
+fn network_dns_lookup_r(
     ctx: &ScanContext,
     regexp_id: RegexpId,
-    request_type: RequestType,
-) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("network"))
-            .and_then(|network| network.get("http"))
-            .and_then(|http| http.as_array())
-            .map(|http| {
-                http.iter().any(|request| {
-                    let req_method = match request
-                        .get("method")
-                        .and_then(|req_method| req_method.as_str())
-                    {
-                        Some(req_method) => req_method,
-                        None => return false,
-                    };
-
-                    let req_uri = match request
-                        .get("uri")
-                        .and_then(|req_uri| req_uri.as_str())
-                    {
-                        Some(req_uri) => req_uri,
-                        None => return false,
-                    };
-
-                    match request_type {
-                        RequestType::Get => {
-                            if !req_method.eq_ignore_ascii_case("get") {
-                                return false;
-                            }
-                        }
-                        RequestType::Post => {
-                            if !req_method.eq_ignore_ascii_case("post") {
-                                return false;
-                            }
-                        }
-                        RequestType::Both => {
-                            if !req_method.eq_ignore_ascii_case("get")
-                                && !req_method.eq_ignore_ascii_case("post")
-                            {
-                                return false;
-                            }
-                        }
-                    }
-
-                    return ctx.regexp_matches(regexp_id, req_uri.as_bytes());
-                })
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .domains
+            .iter()
+            .flatten()
+            .filter(|domain| {
+                ctx.regexp_matches(regexp_id, domain.domain.as_bytes())
             })
-            .unwrap_or(false)
-    })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.http_request")]
-fn network_http_request(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    http_request(ctx, regexp_id, RequestType::Both)
+fn network_http_request_r(
+    ctx: &ScanContext,
+    regexp_id: RegexpId,
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .http
+            .iter()
+            .flatten()
+            .filter(|http| {
+                http.method.is_some() // ~> is request (is not response)
+                    && ctx.regexp_matches(regexp_id, http.uri.as_bytes())
+            })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.http_get")]
-fn network_http_get(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    http_request(ctx, regexp_id, RequestType::Get)
+fn network_http_get_r(ctx: &ScanContext, regexp_id: RegexpId) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .http
+            .iter()
+            .flatten()
+            .filter(|http| {
+                http.method
+                    .as_ref()
+                    .map(|method| method.eq_ignore_ascii_case("get"))
+                    .unwrap_or(false)
+                    && ctx.regexp_matches(regexp_id, http.uri.as_bytes())
+            })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.http_post")]
-fn network_http_post(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    http_request(ctx, regexp_id, RequestType::Post)
+fn network_http_post_r(ctx: &ScanContext, regexp_id: RegexpId) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .http
+            .iter()
+            .flatten()
+            .filter(|http| {
+                http.method
+                    .as_ref()
+                    .map(|method| method.eq_ignore_ascii_case("post"))
+                    .unwrap_or(false)
+                    && ctx.regexp_matches(regexp_id, http.uri.as_bytes())
+            })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.http_user_agent")]
-fn network_http_user_agent(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("network"))
-            .and_then(|network| network.get("http"))
-            .and_then(|http| http.as_array())
-            .map(|http| {
-                http.iter()
-                    .filter_map(|request| request.get("user-agent"))
-                    .filter_map(|ua| ua.as_str())
-                    .any(|ua| ctx.regexp_matches(regexp_id, ua.as_bytes()))
-            })
-            .unwrap_or(false)
-    })
-}
-
-fn network_conn(
+fn network_http_user_agent_r(
     ctx: &ScanContext,
     regexp_id: RegexpId,
-    conn: &str,
-    port: i64,
-) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("network"))
-            .and_then(|network| network.get(conn))
-            .and_then(|connections| connections.as_array())
-            .map(|connections| {
-                connections.iter().any(|conn| {
-                    let dst_port = match conn
-                        .get("dport")
-                        .and_then(|dst_port| dst_port.as_i64())
-                    {
-                        Some(dst_port) => dst_port,
-                        None => return false,
-                    };
-
-                    let dst_addr = match conn
-                        .get("dst")
-                        .and_then(|dst_addr| dst_addr.as_str())
-                    {
-                        Some(dst_addr) => dst_addr,
-                        None => return false,
-                    };
-
-                    dst_port == port
-                        && ctx.regexp_matches(regexp_id, dst_addr.as_bytes())
-                })
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .http
+            .iter()
+            .flatten()
+            .flat_map(|http| http.user_agent.iter())
+            .filter(|user_agent| {
+                ctx.regexp_matches(regexp_id, user_agent.as_bytes())
             })
-            .unwrap_or(false)
-    })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.tcp")]
-fn network_tcp(ctx: &ScanContext, regexp_id: RegexpId, port: i64) -> bool {
-    network_conn(ctx, regexp_id, "tcp", port)
+fn network_tcp_ri(
+    ctx: &ScanContext,
+    dst_re: RegexpId,
+    port: i64,
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .tcp
+            .iter()
+            .flatten()
+            .filter(|tcp| {
+                tcp.dport == port as u64
+                    && tcp
+                        .dst
+                        .iter()
+                        .chain(tcp.dst_domain.iter())
+                        .any(|dst| ctx.regexp_matches(dst_re, dst.as_bytes()))
+            })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.udp")]
-fn network_udp(ctx: &ScanContext, regexp_id: RegexpId, port: i64) -> bool {
-    network_conn(ctx, regexp_id, "udp", port)
+fn network_udp_ri(
+    ctx: &ScanContext,
+    dst_re: RegexpId,
+    port: i64,
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .udp
+            .iter()
+            .flatten()
+            .filter(|udp| {
+                udp.dport == port as u64
+                    && udp
+                        .dst
+                        .iter()
+                        .chain(udp.dst_domain.iter())
+                        .any(|dst| ctx.regexp_matches(dst_re, dst.as_bytes()))
+            })
+            .count() as _,
+    )
 }
 
 #[module_export(name = "network.host")]
-fn network_host(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("network"))
-            .and_then(|network| network.get("hosts"))
-            .and_then(|hosts| hosts.as_array())
-            .map(|hosts| {
-                hosts
-                    .iter()
-                    .filter_map(|host| host.as_str())
-                    .any(|host| ctx.regexp_matches(regexp_id, host.as_bytes()))
-            })
-            .unwrap_or(false)
-    })
+fn network_host_r(ctx: &ScanContext, re: RegexpId) -> Option<i64> {
+    Some(
+        get_local()?
+            .network
+            .hosts
+            .iter()
+            .flatten()
+            .filter(|host| ctx.regexp_matches(re, host.as_bytes()))
+            .count() as _,
+    )
 }
 
 #[module_export(name = "sync.mutex")]
-fn sync_mutex(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("behavior"))
-            .and_then(|behaviour| behaviour.get("summary"))
-            .and_then(|summary| summary.get("mutexes"))
-            .and_then(|mutexes| mutexes.as_array())
-            .map(|mutexes| {
-                mutexes
-                    .iter()
-                    .filter_map(|m| m.as_str())
-                    .any(|m| ctx.regexp_matches(regexp_id, m.as_bytes()))
-            })
-            .unwrap_or(false)
-    })
+fn sync_mutex_r(ctx: &ScanContext, mutex_re: RegexpId) -> Option<i64> {
+    Some(
+        get_local()?
+            .behavior
+            .summary
+            .mutexes
+            .iter()
+            .flatten()
+            .filter(|mutex| ctx.regexp_matches(mutex_re, mutex.as_bytes()))
+            .count() as _,
+    )
 }
 
 #[module_export(name = "filesystem.file_access")]
-fn filesystem_file_access(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("behavior"))
-            .and_then(|behaviour| behaviour.get("summary"))
-            .and_then(|summary| summary.get("files"))
-            .and_then(|files| files.as_array())
-            .map(|files| {
-                files
-                    .iter()
-                    .filter_map(|file| file.as_str())
-                    .any(|file| ctx.regexp_matches(regexp_id, file.as_bytes()))
-            })
-            .unwrap_or(false)
-    })
+fn filesystem_file_access_r(
+    ctx: &ScanContext,
+    regexp_id: RegexpId,
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .behavior
+            .summary
+            .files
+            .iter()
+            .flatten()
+            .filter(|file| ctx.regexp_matches(regexp_id, file.as_bytes()))
+            .count() as _,
+    )
 }
 
 #[module_export(name = "registry.key_access")]
-fn registry_key_access(ctx: &ScanContext, regexp_id: RegexpId) -> bool {
-    CUCKOO_REPORT.with_borrow(|report| {
-        report
-            .as_ref()
-            .and_then(|report| report.get("behavior"))
-            .and_then(|behaviour| behaviour.get("summary"))
-            .and_then(|summary| summary.get("keys"))
-            .and_then(|keys| keys.as_array())
-            .map(|keys| {
-                keys.iter()
-                    .filter_map(|key| key.as_str())
-                    .any(|key| ctx.regexp_matches(regexp_id, key.as_bytes()))
-            })
-            .unwrap_or(false)
-    })
+fn registry_key_access_r(
+    ctx: &ScanContext,
+    regexp_id: RegexpId,
+) -> Option<i64> {
+    Some(
+        get_local()?
+            .behavior
+            .summary
+            .keys
+            .iter()
+            .flatten()
+            .filter(|key| ctx.regexp_matches(regexp_id, key.as_bytes()))
+            .count() as _,
+    )
 }

--- a/lib/src/modules/cuckoo/schema.rs
+++ b/lib/src/modules/cuckoo/schema.rs
@@ -1,0 +1,196 @@
+use std::fmt;
+
+use serde::{de::Visitor, Deserialize, Deserializer};
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct DomainJson {
+    pub domain: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct HttpJson {
+    #[serde(rename = "user-agent")]
+    pub user_agent: Option<String>,
+    pub method: Option<String>, // string ftw
+    pub uri: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct TcpJson {
+    pub dst: Option<String>,
+    pub dst_domain: Option<String>,
+    pub dport: u64,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct UdpJson {
+    pub dst: Option<String>,
+    pub dst_domain: Option<String>,
+    pub dport: u64,
+}
+
+#[derive(/* serde::Deserialize, - custom */ Debug)]
+pub(super) struct NetworkJson {
+    pub domains: Option<Vec<DomainJson>>,
+    pub http: Option<Vec<HttpJson>>,
+    pub tcp: Option<Vec<TcpJson>>,
+    pub udp: Option<Vec<UdpJson>>,
+    pub hosts: Option<Vec<String>>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct SummaryJson {
+    pub mutexes: Option<Vec<String>>,
+    pub files: Option<Vec<String>>,
+    pub keys: Option<Vec<String>>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct BehaviorJson {
+    pub summary: SummaryJson,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(super) struct CuckooJson {
+    pub network: NetworkJson,
+    pub behavior: BehaviorJson,
+}
+
+impl<'de> Deserialize<'de> for NetworkJson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MyVisitor;
+
+        impl<'de> Visitor<'de> for MyVisitor {
+            type Value = NetworkJson;
+
+            fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt.write_str("string or object")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                // must not parse `old_domains` before the whole map is searched
+                // if there is a `domains` field, then the value for the key `old_domains` should be ignored
+                // - specifically, it is okay if the `old_domains` does not have the expected structure if `domains` is present
+                let mut old_domains = None::<serde_json::Value>;
+                let mut domains = None::<serde_json::Value>;
+
+                let mut http = None::<Vec<HttpJson>>;
+                let mut tcp = None::<Vec<TcpJson>>;
+                let mut udp = None::<Vec<UdpJson>>;
+                let mut hosts = None::<Vec<String>>;
+
+                while let Some((key, val)) =
+                    map.next_entry::<String, serde_json::Value>()?
+                {
+                    match key.as_str() {
+                        "domains" => {
+                            domains = Some(val);
+                        }
+                        "dns" => {
+                            if domains.is_some() {
+                                continue; // prefer "domains" over "dns"
+                            }
+
+                            old_domains = Some(val);
+                        }
+                        "http" => {
+                            http = Some(
+                                match serde::Deserialize::deserialize(val) {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        return Err(serde::de::Error::custom(
+                                            e,
+                                        ));
+                                    }
+                                },
+                            );
+                        }
+                        "tcp" => {
+                            tcp = Some(match serde::Deserialize::deserialize(
+                                val,
+                            ) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    return Err(serde::de::Error::custom(e));
+                                }
+                            });
+                        }
+                        "udp" => {
+                            udp = Some(match serde::Deserialize::deserialize(
+                                val,
+                            ) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    return Err(serde::de::Error::custom(e));
+                                }
+                            });
+                        }
+                        "hosts" => {
+                            hosts = Some(
+                                match serde::Deserialize::deserialize(val) {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        return Err(serde::de::Error::custom(
+                                            e,
+                                        ));
+                                    }
+                                },
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+
+                #[derive(serde::Deserialize, Debug)]
+                struct OldDomainJson {
+                    pub hostname: String,
+                }
+
+                let domains: Option<Vec<DomainJson>> =
+                    match (domains, old_domains) {
+                        (Some(domains), _) => {
+                            match serde::Deserialize::deserialize(domains) {
+                                Ok(v) => Some(v),
+                                Err(e) => {
+                                    return Err(serde::de::Error::custom(e));
+                                }
+                            }
+                        }
+                        (None, Some(old_domains)) => {
+                            let old_domains: Vec<OldDomainJson> =
+                                match serde::Deserialize::deserialize(
+                                    old_domains,
+                                ) {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        return Err(serde::de::Error::custom(
+                                            e,
+                                        ));
+                                    }
+                                };
+
+                            Some(
+                                old_domains
+                                    .into_iter()
+                                    .map(|old| DomainJson {
+                                        domain: old.hostname,
+                                    })
+                                    .collect(),
+                            )
+                        }
+                        (None, None) => None, // domains field is optional
+                    };
+
+                Ok(NetworkJson { domains, http, tcp, udp, hosts })
+            }
+        }
+
+        deserializer.deserialize_any(MyVisitor)
+    }
+}


### PR DESCRIPTION
updated the cuckoo module, as discussed in the past

changes:

1. the module now uses a `serde` schema to parse the input data into a struct. this improves the ergonomics of working with the data in the `#[module_export]` functions
2. the `#[module_export functions]` now return `Option<T>` rather than `T`. this is useful for when an error occurs (e.g. the input data is invalid) and there is no meaningful value to return otherwise