### PR TITLE
feat: Implement extra data from dump mode.

### DIFF
--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -89,7 +89,7 @@ pub fn exec_dump(args: &ArgMatches) -> anyhow::Result<()> {
         stdin().read_to_end(&mut buffer)?
     };
 
-    let mut module_output = invoke_all(&buffer);
+    let mut module_output = invoke_all_dump(&buffer);
 
     if let Some(modules) = requested_modules {
         // The user asked explicitly for one or more modules, clear out

--- a/lib/src/modules/console.rs
+++ b/lib/src/modules/console.rs
@@ -2,7 +2,7 @@ use crate::modules::prelude::*;
 use crate::modules::protos::console::*;
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> Console {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Console {
     // Nothing to do, but we have to return our protobuf
     Console::new()
 }

--- a/lib/src/modules/cuckoo/mod.rs
+++ b/lib/src/modules/cuckoo/mod.rs
@@ -16,7 +16,7 @@ thread_local! {
 }
 
 #[module_main]
-fn main(_data: &[u8], meta: Option<&[u8]>) -> Cuckoo {
+fn main(_data: &[u8], meta: Option<&[u8]>, _dump: bool) -> Cuckoo {
     if let Some(meta) = meta {
         match serde_json::from_slice::<Value>(meta) {
             Ok(Value::Object(json)) => CUCKOO_REPORT.set(Some(json)),

--- a/lib/src/modules/dotnet/mod.rs
+++ b/lib/src/modules/dotnet/mod.rs
@@ -9,7 +9,7 @@ use crate::modules::protos::dotnet::*;
 pub mod parser;
 
 #[module_main]
-fn main(data: &[u8], _meta: Option<&[u8]>) -> Dotnet {
+fn main(data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Dotnet {
     match parser::Dotnet::parse(data) {
         Ok(dotnet) => dotnet.into(),
         Err(_) => {

--- a/lib/src/modules/elf/mod.rs
+++ b/lib/src/modules/elf/mod.rs
@@ -19,7 +19,7 @@ pub mod parser;
 mod tests;
 
 #[module_main]
-fn main(data: &[u8], _meta: Option<&[u8]>) -> ELF {
+fn main(data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> ELF {
     match parser::ElfParser::new().parse(data) {
         Ok(elf) => elf,
         Err(_) => ELF::new(),

--- a/lib/src/modules/hash/mod.rs
+++ b/lib/src/modules/hash/mod.rs
@@ -29,7 +29,7 @@ thread_local!(
 );
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> Hash {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Hash {
     // With every scanned file the cache must be cleared.
     SHA256_CACHE.with(|cache| cache.borrow_mut().clear());
     SHA1_CACHE.with(|cache| cache.borrow_mut().clear());

--- a/lib/src/modules/lnk/mod.rs
+++ b/lib/src/modules/lnk/mod.rs
@@ -17,7 +17,7 @@ use crate::modules::protos::lnk::*;
 pub mod parser;
 
 #[module_main]
-fn main(data: &[u8], _meta: Option<&[u8]>) -> Lnk {
+fn main(data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Lnk {
     match parser::LnkParser::new().parse(data) {
         Ok(lnk) => lnk,
         Err(_) => {

--- a/lib/src/modules/macho/mod.rs
+++ b/lib/src/modules/macho/mod.rs
@@ -484,7 +484,7 @@ fn sym_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 }
 
 #[module_main]
-fn main(data: &[u8], _meta: Option<&[u8]>) -> Macho {
+fn main(data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Macho {
     match parser::MachO::parse(data) {
         Ok(macho) => macho.into(),
         Err(_) => Macho::new(),

--- a/lib/src/modules/magic/mod.rs
+++ b/lib/src/modules/magic/mod.rs
@@ -34,7 +34,7 @@ thread_local! {
 }
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> Magic {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Magic {
     // With every scanned file the cache must be cleared.
     TYPE_CACHE.set(None);
     MIME_TYPE_CACHE.set(None);

--- a/lib/src/modules/math.rs
+++ b/lib/src/modules/math.rs
@@ -8,7 +8,7 @@ use crate::modules::prelude::*;
 use crate::modules::protos::math::*;
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> Math {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Math {
     // Nothing to do, but we have to return our protobuf
     Math::new()
 }

--- a/lib/src/modules/protos/pe.proto
+++ b/lib/src/modules/protos/pe.proto
@@ -86,6 +86,7 @@ message PE {
   repeated Signature signatures = 59;
 
   optional Overlay overlay = 60;
+  optional string imphash_digest = 61; // "dump" mode only.
 }
 
 message Version {

--- a/lib/src/modules/string.rs
+++ b/lib/src/modules/string.rs
@@ -2,7 +2,7 @@ use crate::modules::prelude::*;
 use crate::modules::protos::string::*;
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> String {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> String {
     // Nothing to do, but we have to return our protobuf
     String::new()
 }

--- a/lib/src/modules/test_proto2/mod.rs
+++ b/lib/src/modules/test_proto2/mod.rs
@@ -66,7 +66,7 @@ fn to_int(ctx: &ScanContext, string: RuntimeString) -> Option<i64> {
 }
 
 #[module_main]
-fn main(data: &[u8], _meta: Option<&[u8]>) -> TestProto2 {
+fn main(data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> TestProto2 {
     let mut test = TestProto2::new();
 
     test.set_int32_zero(0);

--- a/lib/src/modules/test_proto3/mod.rs
+++ b/lib/src/modules/test_proto3/mod.rs
@@ -2,7 +2,7 @@ use crate::modules::prelude::*;
 use crate::modules::protos::test_proto3::TestProto3;
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> TestProto3 {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> TestProto3 {
     let mut test = TestProto3::new();
 
     test.int32_zero = 0;

--- a/lib/src/modules/time.rs
+++ b/lib/src/modules/time.rs
@@ -3,7 +3,7 @@ use crate::modules::protos::time::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[module_main]
-fn main(_data: &[u8], _meta: Option<&[u8]>) -> Time {
+fn main(_data: &[u8], _meta: Option<&[u8]>, _dump: bool) -> Time {
     // Nothing to do, but we have to return our protobuf
     Time::new()
 }

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -655,7 +655,9 @@ impl<'r> Scanner<'r> {
                     options.module_metadata.get(module_name).copied()
                 });
 
-                module.main_fn.map(|main_fn| main_fn(data.as_ref(), meta))
+                module
+                    .main_fn
+                    .map(|main_fn| main_fn(data.as_ref(), meta, false))
             };
 
             if let Some(module_output) = &module_output {

--- a/macros/src/module_main.rs
+++ b/macros/src/module_main.rs
@@ -9,8 +9,8 @@ pub(crate) fn impl_module_main_macro(input: ItemFn) -> Result<TokenStream> {
 
     let main_stub = quote! {
         use protobuf::MessageDyn;
-        pub(crate) fn __main__(data: &[u8], meta: Option<&[u8]>) -> Box<dyn MessageDyn> {
-            Box::new(#fn_name(data, meta))
+        pub(crate) fn __main__(data: &[u8], meta: Option<&[u8]>, dump: bool) -> Box<dyn MessageDyn> {
+            Box::new(#fn_name(data, meta, dump))
         }
     };
 


### PR DESCRIPTION
This commit is a prototype for adding a "dump" mode for modules. This is a flag that can be passed to modules that tells them to perform "extra" processing that they would normally not do during "scan" mode. This is meant for things like `pe.imphash()` which is normally calculated on-demand.