### PR TITLE
ci: use specific OS versions while building Python extensions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,14 +107,14 @@ jobs:
         - windows
         include:
         - build: linux
-          os: ubuntu-latest
+          os: ubuntu-22.04
 
         - build: macos
-          os: macos-latest
+          os: macos-13
           arch: 'arm64 x86_64'
 
         - build: windows
-          os: windows-latest
+          os: windows-2022
           arch: 'x86 AMD64'
 
     steps:


### PR DESCRIPTION
The creation of Python packages started failing with the following error:

```
yara_x.pypy38-pp73-darwin.so has a minimum target of 10.12
  Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=10.12' to update minimum supported macOS for this wheel.
```