### PR TITLE
feat: raise warning with some patterns that have many 2-byte atoms.

### DIFF
--- a/lib/src/compiler/tests/testdata/warnings/35.in
+++ b/lib/src/compiler/tests/testdata/warnings/35.in
@@ -1,0 +1,6 @@
+rule test{
+  strings:
+    $a = /[A-Za-z]{2,}/
+  condition:
+    $a
+}

--- a/lib/src/compiler/tests/testdata/warnings/35.out
+++ b/lib/src/compiler/tests/testdata/warnings/35.out
@@ -1,0 +1,6 @@
+warning[slow_pattern]: slow pattern
+ --> line:3:5
+  |
+3 |     $a = /[A-Za-z]{2,}/
+  |     ------------------- this pattern may slow down the scan
+  |

--- a/lib/src/compiler/tests/testdata/warnings/no_warnings.in
+++ b/lib/src/compiler/tests/testdata/warnings/no_warnings.in
@@ -43,3 +43,10 @@ rule test_6 {
   condition:
     all of ($a*, $a*) at 0
 }
+
+rule test_7 {
+  strings:
+    $a = /[A-Fa-f0-9]{2,}/
+  condition:
+    $a
+}


### PR DESCRIPTION
Regular expressions like `/[A-Za-z]/{N,}` with N>=2, can be very slow because they produce a large number of 2-bytes atoms. Raise warnings on those cases.