### PR TITLE
chore: change release file extensioin from .gzip to .gz

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
                ./target/${{ matrix.target }}/release-lto/yara_x_capi.dll.lib \
                ./target/${{ matrix.target }}/release-lto/yara_x_capi.dll
         else
-            tar czf $pkgname.gzip -C target/${{ matrix.target }}/release-lto yr      
+            tar czf $pkgname.gz -C target/${{ matrix.target }}/release-lto yr      
         fi
 
     - name: Upload artifacts


### PR DESCRIPTION
The gunzip utility doesn't like .gzip as a file extension and complains about extracting it.  Changing the filename to .gz resolves this and enabled tab completion on most Linux (and probably other) systems.