### PR TITLE
docs: add imports, exports, linker_options vectors to mach-o docs

### DIFF
--- a/site/content/docs/modules/macho.md
+++ b/site/content/docs/modules/macho.md
@@ -320,6 +320,8 @@ rule sym_hash_example {
 | build_version       | [BuildVersion](#buildversion) |
 | min_version         | [MinVersion](#minversion)     |
 | exports             | string array                  |
+| imports             | string array                  |
+| linker_options      | string array                  |
 | fat_magic           | integer                       |
 | nfat_arch           | integer                       |
 | fat_arch            | [FatArch](#fatarch) array     |
@@ -438,6 +440,9 @@ rule sym_hash_example {
 | uuid                | string                        |
 | build_version       | [BuildVersion](#buildversion) |
 | min_version         | [MinVersion](#minversion)     |
+| exports             | string array                  |
+| imports             | string array                  |
+| linker_options      | string array                  |
 
 ### LinkedItData
 


### PR DESCRIPTION
When reviewing the docs, noticed a few arrays for some of the things parsed were missing:
- imports
- linker_options