### PR TITLE
Implement basic linting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4498,6 +4498,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.8",
  "smallvec",
+ "strum_macros 0.26.4",
  "thiserror 2.0.6",
  "tlsh-fixed",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ dependencies = [
  "protobuf-parse",
  "quanta",
  "rayon",
+ "regex",
  "regex-automata",
  "regex-syntax 0.8.5",
  "roxmltree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ serde_json = "1.0.133"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 smallvec = "1.13.2"
+strum_macros = "0.26.4"
 thiserror = "2.0.3"
 # Using tlsh-fixed instead of tlsh because tlsh-fixed includes a fix for this
 # issue: https://github.com/1crcbl/tlsh-rs/issues/2.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,7 @@ protobuf = { workspace = true }
 protobuf-json-mapping = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde = { workspace = true, features = ["derive"] }
+strum_macros = { workspace = true }
 yansi = { workspace = true }
 yara-x = { workspace = true, features = ["parallel-compilation"] }
 yara-x-parser = { workspace = true }
@@ -63,6 +64,5 @@ colored_json = "5.0.0"
 crossbeam = "0.8.4"
 crossterm = "0.28.1"
 encoding_rs = "0.8.35"
-strum_macros = "0.26.4"
 superconsole = "0.2.0"
 wild = "2.2.1"

--- a/cli/src/commands/check.rs
+++ b/cli/src/commands/check.rs
@@ -92,12 +92,16 @@ pub fn exec_check(
                 .with_origin(file_path.as_os_str().to_str().unwrap());
 
             let mut lines = Vec::new();
-            let mut compiler = if config.metadata.is_empty() {
-                yara_x::Compiler::new()
-            } else {
-                yara_x::Compiler::new()
-                    .required_metadata(config.metadata.clone())
-            };
+            let mut compiler = yara_x::Compiler::new();
+            if !config.metadata.is_empty() {
+                compiler.required_metadata(config.metadata.clone());
+            }
+
+            if config.rule_name_regexp.is_some() {
+                compiler.rule_name_regexp(
+                    config.rule_name_regexp.clone().unwrap().as_str(),
+                );
+            }
 
             compiler.colorize_errors(io::stdout().is_tty());
 

--- a/cli/src/commands/fmt.rs
+++ b/cli/src/commands/fmt.rs
@@ -5,8 +5,8 @@ use std::{fs, io, process};
 use clap::{arg, value_parser, ArgAction, ArgMatches, Command};
 use yara_x_fmt::Formatter;
 
-use crate::config::{load_config_from_file, FormatConfig};
-use crate::help::{CONFIG_FILE, FMT_CHECK_MODE};
+use crate::config::FormatConfig;
+use crate::help::FMT_CHECK_MODE;
 
 pub fn fmt() -> Command {
     super::command("fmt")
@@ -19,26 +19,14 @@ pub fn fmt() -> Command {
                 .action(ArgAction::Append),
         )
         .arg(arg!(-c --check  "Run in 'check' mode").long_help(FMT_CHECK_MODE))
-        .arg(
-            arg!(-C --config <CONFIG_FILE> "Config file")
-                .value_parser(value_parser!(PathBuf))
-                .long_help(CONFIG_FILE),
-        )
 }
 
 pub fn exec_fmt(
     args: &ArgMatches,
-    main_config: FormatConfig,
+    config: FormatConfig,
 ) -> anyhow::Result<()> {
     let files = args.get_many::<PathBuf>("FILE").unwrap();
     let check = args.get_flag("check");
-    let config_file = args.get_one::<PathBuf>("config");
-
-    let config: FormatConfig = if config_file.is_some() {
-        load_config_from_file(config_file.unwrap())?.fmt
-    } else {
-        main_config
-    };
 
     let formatter = Formatter::new()
         .align_metadata(config.meta.align_values)

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -23,13 +23,13 @@ use std::io::stdout;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context};
-use clap::{command, crate_authors, ArgMatches, Command};
+use clap::{arg, command, crate_authors, value_parser, ArgMatches, Command};
 use crossterm::tty::IsTty;
 use superconsole::{Component, Line, Lines, Span, SuperConsole};
 use yansi::Color::Green;
 use yansi::Paint;
 
-use crate::{commands, APP_HELP_TEMPLATE};
+use crate::{commands, help, APP_HELP_TEMPLATE};
 use yara_x::{Compiler, Rules, SourceCode};
 
 use crate::walk::Walker;
@@ -49,6 +49,11 @@ pub fn cli() -> Command {
     command!()
         .author(crate_authors!("\n")) // requires `cargo` feature
         .arg_required_else_help(true)
+        .arg(
+            arg!(-C --config <CONFIG_FILE> "Config file")
+                .value_parser(value_parser!(PathBuf))
+                .long_help(help::CONFIG_FILE),
+        )
         .help_template(APP_HELP_TEMPLATE)
         .subcommands(vec![
             commands::scan(),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,6 @@
-use std::path::Path;
 use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
 
 use yara_x::config::MetaValueType;
 
@@ -98,9 +99,15 @@ impl Default for Config {
 pub fn load_config_from_file(
     config_file: &Path,
 ) -> Result<Config, figment::Error> {
+    let config_contents = fs::read_to_string(config_file).map_err(|e| {
+        figment::Error::from(format!(
+            "Unable to read config file: {}",
+            e.to_string()
+        ))
+    })?;
     let config: Config =
         Figment::from(Serialized::defaults(Config::default()))
-            .merge(Toml::file_exact(config_file))
+            .merge(Toml::string(config_contents.as_str()))
             .extract()?;
     Ok(config)
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,7 @@
 use std::path::Path;
+use std::collections::BTreeMap;
+
+use yara_x::config::MetaValueType;
 
 use figment::{
     providers::{Format, Serialized, Toml},
@@ -11,6 +14,9 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     /// Format specific configuration information.
     pub fmt: FormatConfig,
+
+    /// Check specific configuration information.
+    pub check: CheckConfig,
 }
 
 /// Format specific configuration information.
@@ -22,6 +28,15 @@ pub struct FormatConfig {
     pub meta: Meta,
     /// Pattern specific formatting information.
     pub patterns: Patterns,
+}
+
+/// Format specific configuration information.
+#[derive(Deserialize, Serialize, Debug)]
+pub struct CheckConfig {
+    /// Meta specific formatting information.
+    // Note: Using a BTreeMap here because we want a consistent ordering when
+    // we iterate over it, so that warnings always appear in the same order.
+    pub metadata: BTreeMap<String, MetaValueType>,
 }
 
 /// Rule specific formatting information.
@@ -69,6 +84,9 @@ impl Default for Config {
                 },
                 meta: Meta { align_values: true },
                 patterns: Patterns { align_values: true },
+            },
+            check: CheckConfig {
+                metadata: BTreeMap::default(),
             },
         }
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::path::Path;
 
 use yara_x::config::MetaValueType;
 
@@ -96,15 +95,15 @@ impl Default for Config {
     }
 }
 
-/// Load config file from a given path. Path must contain a valid TOML file or
-/// this function will propagate the error. For structure of the config file
+/// Load config file from a string which must contain a valid TOML file or this
+/// function will propagate the error. For structure of the config file
 /// see "YARA-X Config Guide.md".
-pub fn load_config_from_file(
-    config_file: &Path,
+pub fn load_config_from_str(
+    config_contents: &str,
 ) -> Result<Config, figment::Error> {
     let config: Config =
         Figment::from(Serialized::defaults(Config::default()))
-            .merge(Toml::file_exact(config_file))
+            .merge(Toml::string(config_contents))
             .extract()?;
     Ok(config)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> anyhow::Result<()> {
     let result = match args.subcommand() {
         #[cfg(feature = "debug-cmd")]
         Some(("debug", args)) => commands::exec_debug(args),
-        Some(("check", args)) => commands::exec_check(args),
+        Some(("check", args)) => commands::exec_check(args, config.check),
         Some(("fix", args)) => commands::exec_fix(args),
         Some(("fmt", args)) => commands::exec_fmt(args, config.fmt),
         Some(("scan", args)) => commands::exec_scan(args),

--- a/docs/YARA-X Config Guide.md
+++ b/docs/YARA-X Config Guide.md
@@ -2,8 +2,8 @@ YARA-X Config Guide
 ===================
 
 YARA-X uses a configuration file for controlling the behavior of different
-commands. It currently supports the `fmt` command, but others will be added in
-the future.
+commands. It currently supports the `fmt` and `check` commands. More may be
+added in the future.
 
 The `yr` command looks in `${HOME}/.yara-x.toml` when starting up. If that file
 does not exist the default values are used.
@@ -143,4 +143,39 @@ meta.align_values = true
 
 # Same as meta.align_values but applies to patterns.
 patterns.align_values = true
+
+# The "check" section controls the behavior of the "check" command, which is
+# used to enforce standards on various aspects of the rule like metadata and
+# rule name.
+[check]
+# Table (dictionary) of required metadata identifiers and their corresponding
+# types.
+#
+# The key is the identifier and the value is the required type for that
+# identifier. Supported types are "string", "int", "float", "bool", "md5",
+# "sha1", "sha256", or "hash".
+#
+# To require that there be an "author" metadata field and the value must be a
+# string, and that there needs to be a date field and the value must be an
+# integer use this:
+#
+# meta = { author = "string", date = "int" }
+#
+# The "md5", "sha1" and "sha256" types are convenience types that check for a
+# string that is the correct length and only contains valid hexadecimal digits.
+#
+# The "hash" type is another convenience type that checks for any of the valid
+# hashes mentioned above. It is meant to be more flexible than requiring a
+# specific hash type in every rule.
+#
+# For example, to require that every rule have a metadata field named "sample"
+# and that the type of that field be an md5, sha1 or sha256 string use this:
+#
+# metadata = { "sample" = "hash" }
+#
+# NOTE: Inline tables must be expressed as a single line and no trailing comma
+# is allowed.
+#
+# The default value is an empty table.
+metadata = {}
 ```

--- a/docs/YARA-X Config Guide.md
+++ b/docs/YARA-X Config Guide.md
@@ -18,6 +18,8 @@ updated as more are added.
 ```toml
 # Config file for YARA-X.
 
+# Any options that are omitted from your config file will use the default value.
+
 # Any options that are not valid are ignored. However, valid keys with an
 # invalid type will cause a parsing error. For example, if you set
 # rule.indent_spaces to false, it will result in a parsing error.
@@ -171,11 +173,20 @@ patterns.align_values = true
 # For example, to require that every rule have a metadata field named "sample"
 # and that the type of that field be an md5, sha1 or sha256 string use this:
 #
-# metadata = { "sample" = "hash" }
+# metadata = { sample = "hash" }
 #
 # NOTE: Inline tables must be expressed as a single line and no trailing comma
 # is allowed.
 #
 # The default value is an empty table.
 metadata = {}
+
+# A regular expression which must match rule names. For example, if you require
+# that every rule start with a "category" description followed by an underscore
+# you could use something like this:
+#
+# rule_name_regexp = "^(APT|CRIME)_"
+#
+# The default is no regular expression.
+rule_name_regexp = ""
 ```

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -241,6 +241,8 @@ p256 = { workspace = true, optional = true, features = ["ecdsa"] }
 protobuf = { workspace = true }
 quanta = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
+# For linting purposes only!
+regex = { version = "1.11.1" }
 regex-syntax = { workspace = true }
 regex-automata = { workspace = true }
 roxmltree = { workspace = true, optional = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -248,6 +248,7 @@ rsa = { workspace = true, optional = true }
 smallvec = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
+strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tlsh-fixed = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true, features = ["v4"] }

--- a/lib/src/compiler/tests/mod.rs
+++ b/lib/src/compiler/tests/mod.rs
@@ -955,10 +955,11 @@ fn test_warnings() {
             continue;
         }
 
-        let mut compiler = if rules.starts_with("// required metadata") {
+        let mut compiler = Compiler::new();
+        if rules.starts_with("// required metadata") {
             // If it starts with "// required_metadata" set the compiler to require
             // specific metadata to enduce warnings.
-            Compiler::new().required_metadata(BTreeMap::from([
+            compiler.required_metadata(BTreeMap::from([
                 ("some_string".to_string(), MetaValueType::String),
                 ("some_int".to_string(), MetaValueType::Integer),
                 ("some_float".to_string(), MetaValueType::Float),
@@ -967,10 +968,12 @@ fn test_warnings() {
                 ("some_sha1".to_string(), MetaValueType::SHA1),
                 ("some_sha256".to_string(), MetaValueType::SHA256),
                 ("some_hash".to_string(), MetaValueType::HASH),
-            ]))
-        } else {
-            Compiler::new()
-        };
+            ]));
+        }
+
+        if rules.starts_with("// rule name regex") {
+            compiler.rule_name_regexp("^AXSERS$");
+        }
 
         src.push_str(rules.as_str());
 

--- a/lib/src/compiler/tests/testdata/warnings/36.in
+++ b/lib/src/compiler/tests/testdata/warnings/36.in
@@ -1,0 +1,18 @@
+// required metadata
+rule test {
+    meta:
+      some_string = 1234
+      some_int = "abc"
+      some_float = 1
+      some_bool = 1.0
+      some_md5 = "4945681964beab33488f12b54780cb7X"
+      some_sha1 = "79092f73d240a47dbf927dad8525e18d7a4ef0dX"
+      some_sha256 = "692b4f72f7415e5ef4dccd906fa2b2ac9b14fbf1817b5707fef765e0ad98deaX"
+      some_hash = "4945681964beab33488f12b54780cb7X"
+      some_hash = "79092f73d240a47dbf927dad8525e18d7a4ef0dX"
+      some_hash = "692b4f72f7415e5ef4dccd906fa2b2ac9b14fbf1817b5707fef765e0ad98deaX"
+    strings:
+      $a = "AXSERS"
+    condition:
+      $a
+}

--- a/lib/src/compiler/tests/testdata/warnings/36.out
+++ b/lib/src/compiler/tests/testdata/warnings/36.out
@@ -1,58 +1,58 @@
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
  --> line:7:7
   |
 7 |       some_bool = 1.0
   |       --------- expected type bool here
   |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
  --> line:6:7
   |
 6 |       some_float = 1
   |       ---------- expected type float here
   |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
   --> line:11:7
    |
 11 |       some_hash = "4945681964beab33488f12b54780cb7X"
    |       --------- expected type hash (string) here
    |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
   --> line:12:7
    |
 12 |       some_hash = "79092f73d240a47dbf927dad8525e18d7a4ef0dX"
    |       --------- expected type hash (string) here
    |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
   --> line:13:7
    |
 13 |       some_hash = "692b4f72f7415e5ef4dccd906fa2b2ac9b14fbf1817b5707fef765e0ad98deaX"
    |       --------- expected type hash (string) here
    |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
  --> line:5:7
   |
 5 |       some_int = "abc"
   |       -------- expected type int here
   |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
  --> line:8:7
   |
 8 |       some_md5 = "4945681964beab33488f12b54780cb7X"
   |       -------- expected type md5 (string) here
   |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
  --> line:9:7
   |
 9 |       some_sha1 = "79092f73d240a47dbf927dad8525e18d7a4ef0dX"
   |       --------- expected type sha1 (string) here
   |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
   --> line:10:7
    |
 10 |       some_sha256 = "692b4f72f7415e5ef4dccd906fa2b2ac9b14fbf1817b5707fef765e0ad98deaX"
    |       ----------- expected type sha256 (string) here
    |
-warning[incorrect_metadata_type]: incorrect metadata type
+warning[incorrect_metadata_type]: metadata has incorrect type
  --> line:4:7
   |
 4 |       some_string = 1234

--- a/lib/src/compiler/tests/testdata/warnings/36.out
+++ b/lib/src/compiler/tests/testdata/warnings/36.out
@@ -1,0 +1,60 @@
+warning[incorrect_metadata_type]: incorrect metadata type
+ --> line:7:7
+  |
+7 |       some_bool = 1.0
+  |       --------- expected type bool here
+  |
+warning[incorrect_metadata_type]: incorrect metadata type
+ --> line:6:7
+  |
+6 |       some_float = 1
+  |       ---------- expected type float here
+  |
+warning[incorrect_metadata_type]: incorrect metadata type
+  --> line:11:7
+   |
+11 |       some_hash = "4945681964beab33488f12b54780cb7X"
+   |       --------- expected type hash (string) here
+   |
+warning[incorrect_metadata_type]: incorrect metadata type
+  --> line:12:7
+   |
+12 |       some_hash = "79092f73d240a47dbf927dad8525e18d7a4ef0dX"
+   |       --------- expected type hash (string) here
+   |
+warning[incorrect_metadata_type]: incorrect metadata type
+  --> line:13:7
+   |
+13 |       some_hash = "692b4f72f7415e5ef4dccd906fa2b2ac9b14fbf1817b5707fef765e0ad98deaX"
+   |       --------- expected type hash (string) here
+   |
+warning[incorrect_metadata_type]: incorrect metadata type
+ --> line:5:7
+  |
+5 |       some_int = "abc"
+  |       -------- expected type int here
+  |
+warning[incorrect_metadata_type]: incorrect metadata type
+ --> line:8:7
+  |
+8 |       some_md5 = "4945681964beab33488f12b54780cb7X"
+  |       -------- expected type md5 (string) here
+  |
+warning[incorrect_metadata_type]: incorrect metadata type
+ --> line:9:7
+  |
+9 |       some_sha1 = "79092f73d240a47dbf927dad8525e18d7a4ef0dX"
+  |       --------- expected type sha1 (string) here
+  |
+warning[incorrect_metadata_type]: incorrect metadata type
+  --> line:10:7
+   |
+10 |       some_sha256 = "692b4f72f7415e5ef4dccd906fa2b2ac9b14fbf1817b5707fef765e0ad98deaX"
+   |       ----------- expected type sha256 (string) here
+   |
+warning[incorrect_metadata_type]: incorrect metadata type
+ --> line:4:7
+  |
+4 |       some_string = 1234
+  |       ----------- expected type string here
+  |

--- a/lib/src/compiler/tests/testdata/warnings/37.in
+++ b/lib/src/compiler/tests/testdata/warnings/37.in
@@ -1,0 +1,7 @@
+// required metadata
+rule test {
+    strings:
+      $a = "AXSERS"
+    condition:
+      $a
+}

--- a/lib/src/compiler/tests/testdata/warnings/37.out
+++ b/lib/src/compiler/tests/testdata/warnings/37.out
@@ -1,0 +1,48 @@
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_bool" (bool) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_float" (float) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_hash" (hash (string)) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_int" (int) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_md5" (md5 (string)) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_sha1" (sha1 (string)) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_sha256" (sha256 (string)) not found
+  |
+warning[missing_metadata]: missing metadata
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- required metadata "some_string" (string) not found
+  |

--- a/lib/src/compiler/tests/testdata/warnings/37.out
+++ b/lib/src/compiler/tests/testdata/warnings/37.out
@@ -1,46 +1,46 @@
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_bool" (bool) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_float" (float) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_hash" (hash (string)) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_int" (int) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_md5" (md5 (string)) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_sha1" (sha1 (string)) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {
   |      ---- required metadata "some_sha256" (sha256 (string)) not found
   |
-warning[missing_metadata]: missing metadata
+warning[missing_metadata]: required metadata missing
  --> line:2:6
   |
 2 | rule test {

--- a/lib/src/compiler/tests/testdata/warnings/38.in
+++ b/lib/src/compiler/tests/testdata/warnings/38.in
@@ -1,0 +1,7 @@
+// rule name regex
+rule test {
+    strings:
+      $a = "AXSERS"
+    condition:
+      $a
+}

--- a/lib/src/compiler/tests/testdata/warnings/38.out
+++ b/lib/src/compiler/tests/testdata/warnings/38.out
@@ -1,0 +1,6 @@
+warning[invalid_rule_name]: rule name does not meet requirements
+ --> line:2:6
+  |
+2 | rule test {
+  |      ---- name does not meet requirements
+  |

--- a/lib/src/compiler/warnings.rs
+++ b/lib/src/compiler/warnings.rs
@@ -31,6 +31,7 @@ pub enum Warning {
     TextPatternAsHex(Box<TextPatternAsHex>),
     IncorrectMetadataType(Box<IncorrectMetadataType>),
     MissingMetadata(Box<MissingMetadata>),
+    InvalidRuleName(Box<InvalidRuleName>),
 }
 
 /// A hex pattern contains two or more consecutive jumps.
@@ -480,7 +481,7 @@ pub struct TextPatternAsHex {
 #[associated_enum(Warning)]
 #[warning(
     code = "incorrect_metadata_type",
-    title = "incorrect metadata type"
+    title = "metadata has incorrect type"
 )]
 #[label(
     "expected type {expected} here",
@@ -509,7 +510,7 @@ pub struct IncorrectMetadataType {
 #[associated_enum(Warning)]
 #[warning(
     code = "missing_metadata",
-    title = "missing metadata"
+    title = "required metadata missing"
 )]
 #[label(
     "required metadata \"{name}\" ({expected_type}) not found",
@@ -520,4 +521,32 @@ pub struct MissingMetadata {
     rule_loc: CodeLoc,
     name: String,
     expected_type: String,
+}
+
+/// Rule name does not match regex. This is only used if the compiler is
+/// configured to check for it (see: [`crate::Compiler::rule_name_regexp`]).
+///
+/// ## Example
+///
+/// ```text
+/// warning[invalid_rule_name]: rule name does not meet requirements
+///  --> rules/test2.yara:13:6
+///    |
+/// 13 | rule pants {
+///    |      ----- name does not meet requirements
+///    |
+/// ```
+#[derive(ErrorStruct, Debug, PartialEq, Eq)]
+#[associated_enum(Warning)]
+#[warning(
+    code = "invalid_rule_name",
+    title = "rule name does not meet requirements"
+)]
+#[label(
+    "name does not meet requirements",
+   rule_loc
+)]
+pub struct InvalidRuleName {
+    report: Report,
+    rule_loc: CodeLoc,
 }

--- a/lib/src/compiler/warnings.rs
+++ b/lib/src/compiler/warnings.rs
@@ -29,6 +29,8 @@ pub enum Warning {
     RedundantCaseModifier(Box<RedundantCaseModifier>),
     SlowPattern(Box<SlowPattern>),
     TextPatternAsHex(Box<TextPatternAsHex>),
+    IncorrectMetadataType(Box<IncorrectMetadataType>),
+    MissingMetadata(Box<MissingMetadata>),
 }
 
 /// A hex pattern contains two or more consecutive jumps.
@@ -459,4 +461,63 @@ pub struct TextPatternAsHex {
     report: Report,
     text: String,
     pattern_loc: CodeLoc,
+}
+
+/// Metadata with an incorrect type. This is only used if the compiler is
+/// configured to check for required metadata (see: [`crate::Compiler::required_metadata`]).
+///
+/// ## Example
+///
+/// ```text
+/// warning[incorrect_metadata_type]: incorrect metadata type
+/// --> rules/test2.yara:4:5
+///   |
+/// 4 |     author = 1234
+///   |     ------ expected type string here
+///   |
+/// ```
+#[derive(ErrorStruct, Debug, PartialEq, Eq)]
+#[associated_enum(Warning)]
+#[warning(
+    code = "incorrect_metadata_type",
+    title = "incorrect metadata type"
+)]
+#[label(
+    "expected type {expected} here",
+    type_loc
+)]
+pub struct IncorrectMetadataType {
+    report: Report,
+    type_loc: CodeLoc,
+    expected: String,
+}
+
+/// Missing metadata. This is only used if the compiler is configured to check
+/// for required metadata (see: [`crate::Compiler::required_metadata`]).
+///
+/// ## Example
+///
+/// ```text
+/// warning[missing_metadata]: missing metadata
+///  --> rules/test2.yara:12:6
+///    |
+/// 12 | rule pants {
+///    |      ----- required metadata "date" (int) not found
+///    |
+/// ```
+#[derive(ErrorStruct, Debug, PartialEq, Eq)]
+#[associated_enum(Warning)]
+#[warning(
+    code = "missing_metadata",
+    title = "missing metadata"
+)]
+#[label(
+    "required metadata \"{name}\" ({expected_type}) not found",
+   rule_loc
+)]
+pub struct MissingMetadata {
+    report: Report,
+    rule_loc: CodeLoc,
+    name: String,
+    expected_type: String,
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -99,6 +99,51 @@ pub mod warnings {
     pub use crate::compiler::warnings::*;
 }
 
+/// Shared config types utilized by the compiler and CLI
+pub mod config {
+    use serde::Deserialize;
+    use serde::Serialize;
+    use strum_macros::Display;
+
+    /// Types allowed in the check.metadata table of the config file. Used to
+    /// require specific metadata identifiers have specific types by "yr check".
+    #[derive(Display, Deserialize, Serialize, Debug, Clone)]
+    pub enum MetaValueType {
+        /// Represents a String type
+        #[serde(rename = "string")]
+        #[strum(to_string = "string")]
+        String,
+        /// Represents an Integer type
+        #[serde(rename = "int")]
+        #[strum(to_string = "int")]
+        Integer,
+        /// Represents a Float type
+        #[serde(rename = "float")]
+        #[strum(to_string = "float")]
+        Float,
+        /// Represents a Boolean type
+        #[serde(rename = "bool")]
+        #[strum(to_string = "bool")]
+        Bool,
+        /// Represents a SHA256 (string) type
+        #[serde(rename = "sha256")]
+        #[strum(to_string = "sha256 (string)")]
+        SHA256,
+        /// Represents a SHA1 (string) type
+        #[serde(rename = "sha1")]
+        #[strum(to_string = "sha1 (string)")]
+        SHA1,
+        /// Represents a MD5 (string) type
+        #[serde(rename = "md5")]
+        #[strum(to_string = "md5 (string)")]
+        MD5,
+        /// Represents a generic hash (string) type. Can be MD5/SHA1/SHA256
+        #[serde(rename = "hash")]
+        #[strum(to_string = "hash (string)")]
+        HASH,
+    }
+}
+
 mod utils {
     /// Tries to match `target` as the enum variant `pat`. Returns the
     /// inner value contained in the variant, or panics if `target` does


### PR DESCRIPTION
Apologies as this PR is a little bigger than I wanted, partially due to fixing a bug in config file handling and partially because it implements two linter checks (required metadata and rule name regexp).

# Config file handling improvements

Prior to this change if you had an invalid config file in your home dir we would just silently replace it with the default config, which is unexpected from a user standpoint (invalid configs should produce an error and refuse to run). To deal with this we now pass errors back up in the main command instead of using `.unwrap_or_default()`.

Also, rather than have each sub-command implement config file handling I moved it into main, to remove duplicate code. Also, because we are now propagating errors if you have an invalid config in `${HOME}/.yara-x.toml` I improved error messages so it is clear what file failed to parse:

```
Error: Unable to parse /Users/wxs/.yara-x.toml: invalid type: found signed int `0`, expected a boolean for key "default.fmt.patterns.align_values" in TOML source string
```

# Linting checks

To implement linting checks for required metadata and rule name format I chose to implement them in the compiler directly. I initially had an implementation with a stand-alone Linter type that worked on the AST from the parser. While this worked it turned out that getting it to use the existing Report/ReportBuilder mechanism was exceedingly intrusive as reporting is coupled too closely to the compiler (or at least I couldn't figure out how to make it work easily). Because of this I just went with implementing it directly in the compiler, which I think is also a good idea because we now get warnings anywhere the compiler is used, which can be quite beneficial for enforcing standards.

To use these linting checks I added a section in the config file and exposed the options for it there. See the config guide changes for details, but the TLDR is you can now specify a table (TOML term for a dictionary) where the key is the metadata identifier that is required and the value is the type that is required. Any rule that does not meet these requirements will get warnings from the compiler.

The other check is a regex that must match the rule name. Again, this is specified in the config file and warnings are issued by the compiler for any rule that does not match this regex.

The default value for both of these options is off so by default the compiler does not enforce any particular standards but you can opt in to it for linting if you want. The only place that currently sets these options is the `yr check` command.

If you're happy with these changes I'd like to also expose them in the various bindings so users can get lint warnings in the language of their choice.