### PR TITLE
refactor: safer addition for offsets within superblobs

### DIFF
--- a/lib/src/modules/macho/parser.rs
+++ b/lib/src/modules/macho/parser.rs
@@ -894,7 +894,7 @@ impl<'a> MachOFile<'a> {
                 match blob.magic {
                     CS_MAGIC_EMBEDDED_ENTITLEMENTS => {
                         let xml_data = match super_data
-                            .get(offset + size_of_blob..offset + length)
+                            .get(offset.saturating_add(size_of_blob) .. offset.saturating_add(length))
                         {
                             Some(data) => data,
                             None => continue,
@@ -938,7 +938,7 @@ impl<'a> MachOFile<'a> {
                     }
                     CS_MAGIC_BLOBWRAPPER => {
                         if let Some(ber_blob) = super_data.get(
-                            offset + size_of_blob
+                            offset.saturating_add(size_of_blob)
                                 ..offset.saturating_add(length),
                         ) {
                             if let Ok((_remainder, certs)) =


### PR DESCRIPTION
Found a few instances that need to be using `.saturating_add` for safer addition of the offsets parsed from the file or with struct sizes

Unlikely the binary blob is big enough to encounter the overflow, but better safe than sorry 😄 