### PR TITLE
fix: don't strip prefix if path is exactly "."

### DIFF
--- a/cli/src/tests/mod.rs
+++ b/cli/src/tests/mod.rs
@@ -284,4 +284,13 @@ fn cli_issue_280() {
         .arg("./src/tests/testdata/")
         .assert()
         .success();
+
+    // Handle special case of just . for path argument.
+    Command::cargo_bin("yr")
+        .unwrap()
+        .arg("scan")
+        .arg("src/tests/testdata/foo.yar")
+        .arg(".")
+        .assert()
+        .success();
 }


### PR DESCRIPTION
One of the things I often run is "yr scan -r rules.yara ." when I have a collection of samples and I want to scan all of them in the current directory.

With the fix in #280 the path was being stripped to an empty string which would result in an error when trying to scan. Fix it by only performing the strip if the path is not equal to ".".