### PR TITLE
fix: reduce consumption of virtual address space.

### DIFF
--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -262,7 +262,7 @@ impl<'r> Scanner<'r> {
         // Create module's main memory.
         let main_memory = wasmtime::Memory::new(
             wasm_store.as_context_mut(),
-            MemoryType::new(mem_size, None),
+            MemoryType::new(mem_size, Some(mem_size)),
         )
         .unwrap();
 

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -720,7 +720,8 @@ lazy_static! {
         config.native_unwind_info(false);
 
         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
-        config.memory_reservation(0x80000000); // 2GB
+        config.memory_reservation(0x10000000); // 256MB
+        config.memory_reservation_for_growth(0);
         config.guard_before_linear_memory(false);
         config.memory_may_move(false);
         config.epoch_interruption(true);

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -720,7 +720,7 @@ lazy_static! {
         config.native_unwind_info(false);
 
         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
-        config.memory_reservation(0x10000000); // 256MB
+        config.memory_reservation(0x1000000); // 16MB
         config.memory_reservation_for_growth(0);
         config.guard_before_linear_memory(false);
         config.memory_may_move(false);

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -720,6 +720,7 @@ lazy_static! {
         config.native_unwind_info(false);
 
         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
+        config.memory_reservation(0x80000000); // 2GB
         config.epoch_interruption(true);
         config
     };

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -720,11 +720,29 @@ lazy_static! {
         config.native_unwind_info(false);
 
         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
-        config.memory_reservation(0x1000000); // 16MB
-        config.memory_reservation_for_growth(0);
-        config.guard_before_linear_memory(false);
-        config.memory_may_move(false);
         config.epoch_interruption(true);
+
+        // 16MB should be enough for each WASM module. Each module needs a
+        // fixed amount of memory that is only a few KB long, plus a variable
+        // amount that depends on the number of rules and patterns (1 bit per
+        // rule and 1 bit per pattern). With 16MB there's enough space for
+        // millions of rules and patterns. By default, this is 4GB in 64-bits
+        // systems, which causes a reservation of 4GB of virtual address space
+        // (not physical RAM) per module (and therefore per Scanner). In some
+        // scenarios where virtual address space is limited (i.e: Docker
+        // instances) this is problematic. See:
+        // https://github.com/VirusTotal/yara-x/issues/292
+        config.memory_reservation(0x1000000);
+
+        // WASM memory won't grow, there's no need to allocate space for
+        // future grow.
+        config.memory_reservation_for_growth(0);
+
+        // As the memory can't grow, it won't move. By explicitly indicating
+        // this, modules can be compiled with static knowledge the base pointer
+        // of linear memory never changes to enable optimizations.
+        config.memory_may_move(false);
+
         config
     };
     pub(crate) static ref ENGINE: Engine = Engine::new(&CONFIG).unwrap();

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -721,6 +721,8 @@ lazy_static! {
 
         config.cranelift_opt_level(wasmtime::OptLevel::SpeedAndSize);
         config.memory_reservation(0x80000000); // 2GB
+        config.guard_before_linear_memory(false);
+        config.memory_may_move(false);
         config.epoch_interruption(true);
         config
     };


### PR DESCRIPTION
Each WASM module tries to reserve a large amount of virtual address space (4GB in 64-bits systems). This doesn't means that they actually needs this amount of RAM, it only means that it reserves address space in case the memory required by the module grows dynamically. As each YARA-X scanner needs one of these WASM modules, this implies that YARA-X ends up reserving a very large amount of virtual address space. This is problematic in some environments where the amount of virtual address space per process is limited (in Docker containers, for instance). 

This PR reduces the amount of virtual address space reserved by each WASM module, mainly by limiting the amount of memory of each WASM module to 16MB. This is enough to accommodate very large sets of rules, with millions of rules and patterns.

Closes #292.