### PR TITLE
perf: memoized some module functions

### DIFF
--- a/lib/src/modules/macho/mod.rs
+++ b/lib/src/modules/macho/mod.rs
@@ -5,9 +5,7 @@
 //! both protobuf structure fields and constants. This together with
 //! also exported functions can be later used in YARA rules.
 
-
 use std::cell::RefCell;
-
 
 use crate::modules::prelude::*;
 use crate::modules::protos::macho::*;
@@ -20,18 +18,17 @@ mod parser;
 mod tests;
 
 thread_local!(
-    static MEMOIZED_DYLIB_MD5: RefCell<Option<String>> =
-        RefCell::new(None);
-    static MEMOIZED_ENTITLEMENT_MD5: RefCell<Option<String>> =
-        RefCell::new(None);
-    static MEMOIZED_EXPORT_MD5: RefCell<Option<String>> =
-        RefCell::new(None);
-    static MEMOIZED_IMPORT_MD5: RefCell<Option<String>> =
-        RefCell::new(None);
-    static MEMOIZED_SYM_MD5: RefCell<Option<String>> =
-        RefCell::new(None);
+    static DYLIB_MD5_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+    static ENTITLEMENT_MD5_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+    static EXPORT_MD5_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+    static IMPORT_MD5_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+    static SYM_MD5_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
 );
-
 
 /// Get the index of a Mach-O file within a fat binary based on CPU type.
 ///
@@ -338,17 +335,16 @@ fn has_export(ctx: &ScanContext, export: RuntimeString) -> Option<bool> {
 /// Returns a md5 hash of the dylibs designated in the mach-o binary
 #[module_export]
 fn dylib_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
-    let cached = MEMOIZED_DYLIB_MD5.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
-            ctx,
-            cache.borrow().as_deref()?.as_bytes(),
-        ))
+    let cached = DYLIB_MD5_CACHE.with(|cache| -> Option<RuntimeString> {
+        cache
+            .borrow()
+            .as_deref()
+            .map(|s| RuntimeString::from_slice(ctx, s.as_bytes()))
     });
 
     if cached.is_some() {
         return cached;
     }
-
 
     let macho = ctx.module_output::<Macho>()?;
     let mut dylibs_to_hash = &macho.dylibs;
@@ -381,10 +377,10 @@ fn dylib_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     md5_hash.update(dylibs_to_hash.as_bytes());
 
     let digest = format!("{:x}", md5_hash.finalize());
-    MEMOIZED_DYLIB_MD5.with(|cache| {
+
+    DYLIB_MD5_CACHE.with(|cache| {
         *cache.borrow_mut() = Some(digest.clone());
     });
-
 
     Some(RuntimeString::new(digest))
 }
@@ -392,17 +388,17 @@ fn dylib_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 /// Returns a md5 hash of the entitlements designated in the mach-o binary
 #[module_export]
 fn entitlement_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
-    let cached = MEMOIZED_ENTITLEMENT_MD5.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
-            ctx,
-            cache.borrow().as_deref()?.as_bytes(),
-        ))
-    });
+    let cached =
+        ENTITLEMENT_MD5_CACHE.with(|cache| -> Option<RuntimeString> {
+            cache
+                .borrow()
+                .as_deref()
+                .map(|s| RuntimeString::from_slice(ctx, s.as_bytes()))
+        });
 
     if cached.is_some() {
         return cached;
     }
-
 
     let macho = ctx.module_output::<Macho>()?;
     let mut entitlements_to_hash = &macho.entitlements;
@@ -430,7 +426,8 @@ fn entitlement_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     md5_hash.update(entitlements_str.as_bytes());
 
     let digest = format!("{:x}", md5_hash.finalize());
-    MEMOIZED_ENTITLEMENT_MD5.with(|cache| {
+
+    ENTITLEMENT_MD5_CACHE.with(|cache| {
         *cache.borrow_mut() = Some(digest.clone());
     });
 
@@ -440,17 +437,16 @@ fn entitlement_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 /// Returns a md5 hash of the export symbols in the mach-o binary
 #[module_export]
 fn export_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
-    let cached = MEMOIZED_EXPORT_MD5.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
-            ctx,
-            cache.borrow().as_deref()?.as_bytes(),
-        ))
+    let cached = EXPORT_MD5_CACHE.with(|cache| -> Option<RuntimeString> {
+        cache
+            .borrow()
+            .as_deref()
+            .map(|s| RuntimeString::from_slice(ctx, s.as_bytes()))
     });
 
     if cached.is_some() {
         return cached;
     }
-
 
     let macho = ctx.module_output::<Macho>()?;
     let mut exports_to_hash = &macho.exports;
@@ -478,7 +474,8 @@ fn export_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     md5_hash.update(exports_str.as_bytes());
 
     let digest = format!("{:x}", md5_hash.finalize());
-    MEMOIZED_EXPORT_MD5.with(|cache| {
+
+    EXPORT_MD5_CACHE.with(|cache| {
         *cache.borrow_mut() = Some(digest.clone());
     });
 
@@ -488,18 +485,16 @@ fn export_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
 /// Returns a md5 hash of the imported symbols in the mach-o binary
 #[module_export]
 fn import_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
-    let cached = MEMOIZED_IMPORT_MD5.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
-            ctx,
-            cache.borrow().as_deref()?.as_bytes(),
-        ))
+    let cached = IMPORT_MD5_CACHE.with(|cache| -> Option<RuntimeString> {
+        cache
+            .borrow()
+            .as_deref()
+            .map(|s| RuntimeString::from_slice(ctx, s.as_bytes()))
     });
 
     if cached.is_some() {
         return cached;
     }
-
-
 
     let macho = ctx.module_output::<Macho>()?;
     let mut imports_to_hash = &macho.imports;
@@ -527,26 +522,27 @@ fn import_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     md5_hash.update(imports_str.as_bytes());
 
     let digest = format!("{:x}", md5_hash.finalize());
-    MEMOIZED_IMPORT_MD5.with(|cache| {
+
+    IMPORT_MD5_CACHE.with(|cache| {
         *cache.borrow_mut() = Some(digest.clone());
     });
+
     Some(RuntimeString::new(digest))
 }
 
 /// Returns a md5 hash of the symbol table in the mach-o binary
 #[module_export]
 fn sym_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
-    let cached = MEMOIZED_SYM_MD5.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
-            ctx,
-            cache.borrow().as_deref()?.as_bytes(),
-        ))
+    let cached = SYM_MD5_CACHE.with(|cache| -> Option<RuntimeString> {
+        cache
+            .borrow()
+            .as_deref()
+            .map(|s| RuntimeString::from_slice(ctx, s.as_bytes()))
     });
 
     if cached.is_some() {
         return cached;
     }
-
 
     let macho = ctx.module_output::<Macho>()?;
     let mut symtab_to_hash = &macho.symtab.entries;
@@ -574,19 +570,22 @@ fn sym_hash(ctx: &mut ScanContext) -> Option<RuntimeString> {
     md5_hash.update(symtab_hash_entries);
 
     let digest = format!("{:x}", md5_hash.finalize());
-    MEMOIZED_SYM_MD5.with(|cache| {
+
+    SYM_MD5_CACHE.with(|cache| {
         *cache.borrow_mut() = Some(digest.clone());
     });
+
     Some(RuntimeString::new(digest))
 }
 
 #[module_main]
 fn main(data: &[u8], _meta: Option<&[u8]>) -> Macho {
-    MEMOIZED_DYLIB_MD5.with(|cache| *cache.borrow_mut() = None);
-    MEMOIZED_ENTITLEMENT_MD5.with(|cache| *cache.borrow_mut() = None);
-    MEMOIZED_EXPORT_MD5.with(|cache| *cache.borrow_mut() = None);
-    MEMOIZED_IMPORT_MD5.with(|cache| *cache.borrow_mut() = None);
-    MEMOIZED_SYM_MD5.with(|cache| *cache.borrow_mut() = None);
+    DYLIB_MD5_CACHE.with(|cache| *cache.borrow_mut() = None);
+    ENTITLEMENT_MD5_CACHE.with(|cache| *cache.borrow_mut() = None);
+    EXPORT_MD5_CACHE.with(|cache| *cache.borrow_mut() = None);
+    IMPORT_MD5_CACHE.with(|cache| *cache.borrow_mut() = None);
+    SYM_MD5_CACHE.with(|cache| *cache.borrow_mut() = None);
+
     match parser::MachO::parse(data) {
         Ok(macho) => macho.into(),
         Err(_) => Macho::new(),


### PR DESCRIPTION
There are a bunch of functions in the `elf`, `pe`, and `macho` modules who's results can be memoized (imphash, import_md5, etc).
This can result in a significant performance boost in cases where a large number of calls to these functions are made (usually because a large number of rules are used in a single scanner).
This is very similar to what is done in the hash module.
I'm not very experienced with rust so apologies if I've missed anything obvious.

A simple example to demonstrate the benefits is to run the following rule on any sort of `pe` file:
```yar
rule memoize_example {
    import "pe"
    condition:
        pe.calculate_checksum() == 0 or 
        pe.calculate_checksum() == 1 or 
        pe.calculate_checksum() == 2 or 
        pe.calculate_checksum() == 3 or 
        ...
        pe.calculate_checksum() == 100
}
```
This is obviously a very contrived example but a similar thing can happen if there are lots of different rules compiled together which each use these functions.