### PR TITLE
docs: Disable Goldmark's Typographer `--` substitution

### DIFF
--- a/site/config/_default/markup.toml
+++ b/site/config/_default/markup.toml
@@ -3,6 +3,8 @@ defaultMarkdownHandler = "goldmark"
 [goldmark]
   [goldmark.extensions]
     linkify = false
+    [goldmark.extensions.typographer]
+      enDash = '--'
   [goldmark.parser]
     autoHeadingID = true
     autoHeadingIDType = "github"


### PR DESCRIPTION
Goldmark's Typographer by default substitutes `--` with `&ndash`.

This commit disables the default substitution ensuring command line arguments remain accurate. As such, titles on [YARA-X's CLI Commands docs](https://virustotal.github.io/yara-x/docs/cli/commands/) would become accurate again (e.g., `–profiling` needs to be `--profiling`).