### PR TITLE
Add module invoke support to python bindings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,6 +4660,7 @@ dependencies = [
  "bitflags 2.9.0",
  "bitvec",
  "bstr",
+ "clap",
  "const-oid",
  "crc32fast",
  "der-parser",
@@ -4706,6 +4707,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.8",
  "smallvec",
+ "strum",
  "strum_macros",
  "thiserror 2.0.12",
  "tlsh-fixed",
@@ -4845,6 +4847,7 @@ dependencies = [
 name = "yara-x-py"
 version = "0.14.0"
 dependencies = [
+ "protobuf",
  "protobuf-json-mapping",
  "pyo3",
  "pyo3-build-config",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -225,6 +225,7 @@ bincode = { workspace = true }
 bitflags = { workspace = true, features = ["serde"] }
 bitvec = { workspace = true }
 bstr = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["cargo", "derive"] }
 const-oid = { workspace = true, optional = true, features = ["db"] }
 crc32fast = { workspace = true, optional = true }
 der-parser = { workspace = true, optional = true, features = ["bigint"] }
@@ -263,6 +264,7 @@ rsa = { workspace = true, optional = true }
 smallvec = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
+strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tlsh-fixed = { workspace = true, optional = true }

--- a/lib/src/modules/mod.rs
+++ b/lib/src/modules/mod.rs
@@ -136,7 +136,25 @@ pub mod mods {
     # use yara_x;
     let pe_info = yara_x::mods::invoke::<yara_x::mods::PE>(&[]);
     ```
-     */
+    */
+
+    use clap::ValueEnum;
+    use strum_macros::{Display, EnumString};
+    #[derive(Debug, Clone, ValueEnum, Display, EnumString, PartialEq)]
+    #[strum(ascii_case_insensitive)]
+    /// Modules supported by the "dump" command and language bindings.
+    pub enum SupportedDumpModules {
+        /// LNK module for parsing lnk files.
+        Lnk,
+        /// Macho module for parsing macho files.
+        Macho,
+        /// Elf module for parsing elf files.
+        Elf,
+        /// PE module for parsing pe files.
+        Pe,
+        /// Dotnet module for parsing dotnet files.
+        Dotnet,
+    }
 
     /// Data structures defined by the `dotnet` module.
     ///

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -23,7 +23,7 @@ pyo3 = { version = "0.24.1", features = [
 ] }
 pyo3-file = "0.12.0"
 serde_json = { workspace = true }
-
+protobuf = { workspace = true }
 protobuf-json-mapping = { workspace = true }
 yara-x = { workspace = true, features = ["parallel-compilation"] }
 yara-x-fmt = { workspace = true }

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -294,3 +294,14 @@ def test_format():
   fmt.format(inp, output)
   result = output.getvalue()
   assert result == expected_output
+
+
+def test_module():
+  with pytest.raises(ValueError):
+    yara_x.Module('AXS')
+
+  # We aren't interested in testing the actual parsing functionality of the
+  # module as that is covered in module tests. Instead we just want to make sure
+  # we get a dict object back, and we can do that by passing non-PE data.
+  result = yara_x.Module('PE').invoke(b'ERS')
+  assert isinstance(result, dict)

--- a/py/yara_x.pyi
+++ b/py/yara_x.pyi
@@ -286,7 +286,7 @@ class ScanResults:
 
     def module_outputs(self) -> dict:
         r"""
-        Rules that matched during the scan.
+        Module output from the scan.
         """
         ...
 
@@ -298,3 +298,12 @@ def compile(src: str) -> Rules:
     variables. For more complex use cases you will need to use a [`Compiler`].
     """
     ...
+
+class Module:
+    r"""A YARA-X module."""
+    def new(self, name: str) -> Module:
+        ...
+
+    def invoke(data: str) -> dict:
+        r"""Parse the data and collect module metadata."""
+        ...


### PR DESCRIPTION
This commit adds the ability to dump module output from python bindings. The API is roughly:

yara_x.Module('pe').invoke(data)

I chose to use an API that requires you instantiate a new Module object because it will allow us to put other things as methods on it. I'm thinking we will want to support things like invoke a module on a path or file object. This sets us up to have a cleaner API in the future.

I also moved and renamed the SupportedModules enum out of the dump command so it is now in a better place to be shared by the bindings and dump command.  This allows us to raise a ValueError if you try to instantiate a new module with an unsupported dump module.

As part of this I also realized that when using "dump" and outputting YAML (the default) the keys would be different from outputting in JSON. For example, in YAML a PDB path would be "pdb_path" while in JSON it was "pdbPath". To better align these I made the JSON output use proto_field_true when serializing the protobuf to JSON.