### PR TITLE
refactor: prepare TypeValue enum for admitting constraints.

### DIFF
--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -31,7 +31,8 @@ use crate::compiler::{
 use crate::scanner::RuntimeObjectHandle;
 use crate::string_pool::{BStringPool, StringPool};
 use crate::symbols::Symbol;
-use crate::types::{Array, Map, Type, TypeValue, Value};
+use crate::types::Value::Const;
+use crate::types::{Array, Map, Type, TypeValue};
 use crate::utils::cast;
 use crate::wasm;
 use crate::wasm::builder::WasmModuleBuilder;
@@ -271,16 +272,16 @@ fn emit_expr(
 ) {
     match ir.get(expr) {
         Expr::Const(type_value) => match type_value {
-            TypeValue::Integer(Value::Const(value)) => {
+            TypeValue::Integer { value: Const(value) } => {
                 instr.i64_const(*value);
             }
-            TypeValue::Float(Value::Const(value)) => {
+            TypeValue::Float { value: Const(value) } => {
                 instr.f64_const(*value);
             }
-            TypeValue::Bool(Value::Const(value)) => {
+            TypeValue::Bool { value: Const(value) } => {
                 instr.i32_const((*value).into());
             }
-            TypeValue::String(Value::Const(value)) => {
+            TypeValue::String { value: Const(value) } => {
                 // Put the literal string in the pool, or get its ID if it was
                 // already there.
                 let literal_id = ctx.lit_pool.get_or_intern(value.as_bstr());
@@ -318,22 +319,22 @@ fn emit_expr(
                     let index: i32 = (*index).try_into().unwrap();
 
                     match type_value {
-                        TypeValue::Integer(_) => {
+                        TypeValue::Integer { .. } => {
                             ctx.lookup_list.push((index, *is_root));
                             emit_lookup_integer(ctx, instr);
                             assert!(ctx.lookup_list.is_empty());
                         }
-                        TypeValue::Float(_) => {
+                        TypeValue::Float { .. } => {
                             ctx.lookup_list.push((index, *is_root));
                             emit_lookup_float(ctx, instr);
                             assert!(ctx.lookup_list.is_empty());
                         }
-                        TypeValue::Bool(_) => {
+                        TypeValue::Bool { .. } => {
                             ctx.lookup_list.push((index, *is_root));
                             emit_lookup_bool(ctx, instr);
                             assert!(ctx.lookup_list.is_empty());
                         }
-                        TypeValue::String(_) => {
+                        TypeValue::String { .. } => {
                             ctx.lookup_list.push((index, *is_root));
                             emit_lookup_string(ctx, instr);
                             assert!(ctx.lookup_list.is_empty());

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -281,7 +281,7 @@ fn emit_expr(
             TypeValue::Bool { value: Const(value) } => {
                 instr.i32_const((*value).into());
             }
-            TypeValue::String { value: Const(value) } => {
+            TypeValue::String { value: Const(value), .. } => {
                 // Put the literal string in the pool, or get its ID if it was
                 // already there.
                 let literal_id = ctx.lit_pool.get_or_intern(value.as_bstr());

--- a/lib/src/compiler/ir/tests/mod.rs
+++ b/lib/src/compiler/ir/tests/mod.rs
@@ -5,13 +5,13 @@ use crate::types::TypeValue;
 
 #[test]
 fn expr_size() {
-    // Sentinel test for making sure tha Expr doesn't grow in future
+    // Sentinel test for making sure the Expr doesn't grow in future
     // changes.
     #[cfg(target_pointer_width = "32")]
-    assert_eq!(size_of::<Expr>(), 20);
+    assert_eq!(size_of::<Expr>(), 24);
 
     #[cfg(target_pointer_width = "64")]
-    assert_eq!(size_of::<Expr>(), 32);
+    assert_eq!(size_of::<Expr>(), 40);
 }
 
 #[test]

--- a/lib/src/compiler/ir/tests/testdata/3.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.cse.ir
@@ -1,6 +1,6 @@
 RULE test
-  24: WITH -- hash: 0x7297a63875ac564a -- parent: None 
-    23: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 24 
+  24: WITH -- hash: 0x825ac1d62451ffe1 -- parent: None 
+    23: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 24 
       6: CONST integer(0) -- parent: 23 
       7: FILESIZE -- parent: 23 
     22: OR -- hash: 0x9c37eeec72832c3 -- parent: 24 

--- a/lib/src/compiler/ir/tests/testdata/3.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.hoisting.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x1c627bcc6ff91868 -- parent: None 
-    10: EQ -- hash: 0xb9ba03404f01eba5 -- parent: 22 
-      8: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 10 
+  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
+    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0x7993df882103112 -- parent: 22 
-      19: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 21 
+    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/ir/tests/testdata/3.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x1c627bcc6ff91868 -- parent: None 
-    10: EQ -- hash: 0xb9ba03404f01eba5 -- parent: 22 
-      8: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 10 
+  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
+    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0x7993df882103112 -- parent: 22 
-      19: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 21 
+    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/ir/tests/testdata/3.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.no-folding.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x1c627bcc6ff91868 -- parent: None 
-    10: EQ -- hash: 0xb9ba03404f01eba5 -- parent: 22 
-      8: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 10 
+  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
+    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0x7993df882103112 -- parent: 22 
-      19: FN_CALL hash.md5@ii@su -- hash: 0xaacae1fb2d94c8fe -- parent: 21 
+    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/tests/testdata/warnings/37.in
+++ b/lib/src/compiler/tests/testdata/warnings/37.in
@@ -1,0 +1,6 @@
+import "hash"
+
+rule test_1 { condition: hash.md5(0, filesize) == "AAB" }
+
+
+rule test_2 { condition: "AD" == hash.sha256(0,filesize) }

--- a/lib/src/compiler/tests/testdata/warnings/37.out
+++ b/lib/src/compiler/tests/testdata/warnings/37.out
@@ -1,0 +1,18 @@
+warning[unsatisfiable_expr]: unsatisfiable expression
+ --> line:3:31
+  |
+3 | rule test_1 { condition: hash.md5(0, filesize) == "AAB" }
+  |                               ----------------    ----- this contains uppercase characters
+  |                               |
+  |                               this is a lowercase string
+  |
+  = note: a lowercase string can't be equal to a string containing uppercase characters
+warning[unsatisfiable_expr]: unsatisfiable expression
+ --> line:6:39
+  |
+6 | rule test_2 { condition: "AD" == hash.sha256(0,filesize) }
+  |                          ----         ------------------ this is a lowercase string
+  |                          |
+  |                          this contains uppercase characters
+  |
+  = note: a lowercase string can't be equal to a string containing uppercase characters

--- a/lib/src/compiler/tests/testdata/warnings/37.out
+++ b/lib/src/compiler/tests/testdata/warnings/37.out
@@ -2,11 +2,27 @@ warning[unsatisfiable_expr]: unsatisfiable expression
  --> line:3:31
   |
 3 | rule test_1 { condition: hash.md5(0, filesize) == "AAB" }
+  |                               ----------------    ----- the length of this string is 3
+  |                               |
+  |                               the length of this string is 32
+  |
+warning[unsatisfiable_expr]: unsatisfiable expression
+ --> line:3:31
+  |
+3 | rule test_1 { condition: hash.md5(0, filesize) == "AAB" }
   |                               ----------------    ----- this contains uppercase characters
   |                               |
   |                               this is a lowercase string
   |
   = note: a lowercase string can't be equal to a string containing uppercase characters
+warning[unsatisfiable_expr]: unsatisfiable expression
+ --> line:6:39
+  |
+6 | rule test_2 { condition: "AD" == hash.sha256(0,filesize) }
+  |                          ----         ------------------ the length of this string is 64
+  |                          |
+  |                          the length of this string is 2
+  |
 warning[unsatisfiable_expr]: unsatisfiable expression
  --> line:6:39
   |

--- a/lib/src/compiler/tests/testdata/warnings/38.in
+++ b/lib/src/compiler/tests/testdata/warnings/38.in
@@ -1,0 +1,8 @@
+import "test_proto2"
+
+rule test {
+    condition:
+        test_proto2.string_foo == "FOO"
+}
+
+

--- a/lib/src/compiler/tests/testdata/warnings/38.out
+++ b/lib/src/compiler/tests/testdata/warnings/38.out
@@ -1,0 +1,9 @@
+warning[unsatisfiable_expr]: unsatisfiable expression
+ --> line:5:9
+  |
+5 |         test_proto2.string_foo == "FOO"
+  |         ----------------------    ----- this contains uppercase characters
+  |         |
+  |         this is a lowercase string
+  |
+  = note: a lowercase string can't be equal to a string containing uppercase characters

--- a/lib/src/compiler/warnings.rs
+++ b/lib/src/compiler/warnings.rs
@@ -35,6 +35,7 @@ pub enum Warning {
     SlowPattern(Box<SlowPattern>),
     TextPatternAsHex(Box<TextPatternAsHex>),
     TooManyIterations(Box<TooManyIterations>),
+    UnsatisfiableExpression(Box<UnsatisfiableExpression>),
     UnknownTag(Box<UnknownTag>),
 }
 
@@ -148,6 +149,44 @@ pub struct PotentiallyUnsatisfiableExpression {
     report: Report,
     quantifier_loc: CodeLoc,
     at_loc: CodeLoc,
+}
+
+/// A boolean expression can't be satisfied.
+///
+/// ## Example
+///
+/// ```text
+/// warning[unsatisfiable_expr]: unsatisfiable expression
+/// --> test.yar:6:34
+/// |
+/// 6 | rule x { condition: "AD" == hash.sha256(0,filesize) }
+/// |                     ----         ------------------ this is a lowercase string
+/// |                     |
+/// |                     this contains uppercase characters
+/// |
+/// = note: a lowercase strings can't be equal to a string containing uppercase characters
+#[derive(ErrorStruct, Debug, PartialEq, Eq)]
+#[associated_enum(Warning)]
+#[warning(
+    code = "unsatisfiable_expr",
+    title = "unsatisfiable expression"
+)]
+#[label(
+    "{label_1}",
+    loc_1
+)]
+#[label(
+    "{label_2}",
+    loc_2
+)]
+#[footer(note)]
+pub struct UnsatisfiableExpression {
+    report: Report,
+    label_1: String,
+    label_2: String,
+    loc_1: CodeLoc,
+    loc_2: CodeLoc,
+    note: Option<String>,
 }
 
 

--- a/lib/src/modules/elf/mod.rs
+++ b/lib/src/modules/elf/mod.rs
@@ -79,18 +79,19 @@ fn import_md5(ctx: &mut ScanContext) -> Option<RuntimeString> {
 /// Function names excluded while computing the telfhash. These exclusions
 /// are based on the original implementation:
 /// https://github.com/trendmicro/telfhash/blob/master/telfhash/telfhash.py
-pub(crate) static TELFHASH_EXCLUSIONS: LazyLock<FxHashSet<&'static str>> = LazyLock::new(|| {
-    let mut exclusions = FxHashSet::default();
-    exclusions.insert("__libc_start_main");
-    exclusions.insert("main");
-    exclusions.insert("abort");
-    exclusions.insert("cachectl");
-    exclusions.insert("cacheflush");
-    exclusions.insert("puts");
-    exclusions.insert("atol");
-    exclusions.insert("malloc_trim");
-    exclusions
-});
+pub(crate) static TELFHASH_EXCLUSIONS: LazyLock<FxHashSet<&'static str>> =
+    LazyLock::new(|| {
+        let mut exclusions = FxHashSet::default();
+        exclusions.insert("__libc_start_main");
+        exclusions.insert("main");
+        exclusions.insert("abort");
+        exclusions.insert("cachectl");
+        exclusions.insert("cacheflush");
+        exclusions.insert("puts");
+        exclusions.insert("atol");
+        exclusions.insert("malloc_trim");
+        exclusions
+    });
 
 /// Function that returns the [`telfhash`][1] for the current ELF file.
 ///

--- a/lib/src/modules/hash/mod.rs
+++ b/lib/src/modules/hash/mod.rs
@@ -45,9 +45,9 @@ fn md5_data(
     ctx: &mut ScanContext,
     offset: i64,
     size: i64,
-) -> Option<RuntimeString> {
-    let cached = MD5_CACHE.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
+) -> Option<Lowercase<FixedLenString<32>>> {
+    let cached = MD5_CACHE.with(|cache| {
+        Some(Lowercase::<FixedLenString<32>>::from_slice(
             ctx,
             cache.borrow().get(&(offset, size))?.as_bytes(),
         ))
@@ -69,15 +69,21 @@ fn md5_data(
         cache.borrow_mut().insert((offset, size), digest.clone());
     });
 
-    Some(RuntimeString::new(digest))
+    Some(Lowercase::<FixedLenString<32>>::new(digest))
 }
 
 #[module_export(name = "md5")]
-fn md5_str(ctx: &mut ScanContext, s: RuntimeString) -> Option<RuntimeString> {
+fn md5_str(
+    ctx: &mut ScanContext,
+    s: RuntimeString,
+) -> Option<Lowercase<FixedLenString<32>>> {
     let mut hasher = Md5::new();
     hasher.update(s.as_bstr(ctx));
 
-    Some(RuntimeString::new(format!("{:x}", hasher.finalize())))
+    Some(Lowercase::<FixedLenString<32>>::new(format!(
+        "{:x}",
+        hasher.finalize()
+    )))
 }
 
 #[module_export(name = "sha1")]
@@ -85,9 +91,9 @@ fn sha1_data(
     ctx: &mut ScanContext,
     offset: i64,
     size: i64,
-) -> Option<RuntimeString> {
-    let cached = SHA1_CACHE.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
+) -> Option<Lowercase<FixedLenString<40>>> {
+    let cached = SHA1_CACHE.with(|cache| {
+        Some(Lowercase::<FixedLenString<40>>::from_slice(
             ctx,
             cache.borrow().get(&(offset, size))?.as_bytes(),
         ))
@@ -109,15 +115,21 @@ fn sha1_data(
         cache.borrow_mut().insert((offset, size), digest.clone());
     });
 
-    Some(RuntimeString::new(digest))
+    Some(Lowercase::<FixedLenString<40>>::new(digest))
 }
 
 #[module_export(name = "sha1")]
-fn sha1_str(ctx: &mut ScanContext, s: RuntimeString) -> Option<RuntimeString> {
+fn sha1_str(
+    ctx: &mut ScanContext,
+    s: RuntimeString,
+) -> Option<Lowercase<FixedLenString<40>>> {
     let mut hasher = Sha1::new();
     hasher.update(s.as_bstr(ctx));
 
-    Some(RuntimeString::new(format!("{:x}", hasher.finalize())))
+    Some(Lowercase::<FixedLenString<40>>::new(format!(
+        "{:x}",
+        hasher.finalize()
+    )))
 }
 
 #[module_export(name = "sha256")]
@@ -125,9 +137,9 @@ fn sha256_data(
     ctx: &mut ScanContext,
     offset: i64,
     size: i64,
-) -> Option<RuntimeString> {
-    let cached = SHA256_CACHE.with(|cache| -> Option<RuntimeString> {
-        Some(RuntimeString::from_slice(
+) -> Option<Lowercase<FixedLenString<64>>> {
+    let cached = SHA256_CACHE.with(|cache| {
+        Some(Lowercase::<FixedLenString<64>>::from_slice(
             ctx,
             cache.borrow().get(&(offset, size))?.as_bytes(),
         ))
@@ -149,18 +161,21 @@ fn sha256_data(
         cache.borrow_mut().insert((offset, size), digest.clone());
     });
 
-    Some(RuntimeString::new(digest))
+    Some(Lowercase::<FixedLenString<64>>::new(digest))
 }
 
 #[module_export(name = "sha256")]
 fn sha256_str(
     ctx: &mut ScanContext,
     s: RuntimeString,
-) -> Option<RuntimeString> {
+) -> Option<Lowercase<FixedLenString<64>>> {
     let mut hasher = Sha256::new();
     hasher.update(s.as_bstr(ctx));
 
-    Some(RuntimeString::new(format!("{:x}", hasher.finalize())))
+    Some(Lowercase::<FixedLenString<64>>::new(format!(
+        "{:x}",
+        hasher.finalize()
+    )))
 }
 
 #[module_export(name = "crc32")]

--- a/lib/src/modules/mod.rs
+++ b/lib/src/modules/mod.rs
@@ -13,7 +13,10 @@ mod tests;
 #[allow(unused_imports)]
 pub(crate) mod prelude {
     pub(crate) use crate::scanner::ScanContext;
-    pub(crate) use crate::wasm::string::*;
+    pub(crate) use crate::wasm::string::FixedLenString;
+    pub(crate) use crate::wasm::string::Lowercase;
+    pub(crate) use crate::wasm::string::RuntimeString;
+    pub(crate) use crate::wasm::string::String as _;
     pub(crate) use crate::wasm::*;
     pub(crate) use bstr::ByteSlice;
     pub(crate) use linkme::distributed_slice;

--- a/lib/src/modules/protos/test_proto2.proto
+++ b/lib/src/modules/protos/test_proto2.proto
@@ -136,7 +136,7 @@ message TestProto2 {
 
   // String values.
 
-  required string             string_foo = 61;
+  required string             string_foo = 61 [(yara.field_options).lowercase = true];
   required string             string_bar = 62;
   optional string             string_undef = 63;
 

--- a/lib/src/modules/protos/vt/titan.proto
+++ b/lib/src/modules/protos/vt/titan.proto
@@ -74,9 +74,9 @@ message GoReSym {
 }
 
 message FileMetadata {
-  string sha256 = 1;
-  string sha1 = 2;
-  string md5 = 3;
+  string sha256 = 1 [(yara.field_options).lowercase = true ];
+  string sha1 = 2 [(yara.field_options).lowercase = true ];
+  string md5 = 3 [(yara.field_options).lowercase = true ];
   string ssdeep = 4;
   string imphash = 5;
   string vhash = 6;

--- a/lib/src/modules/protos/yara.proto
+++ b/lib/src/modules/protos/yara.proto
@@ -83,6 +83,14 @@ message FieldOptions {
   // Also, keep in mind that ACL entries are evaluated sequentially. The first
   // entry that fails will trigger the corresponding error message.
   repeated AclEntry acl = 3;
+
+  // Indicates that a string field is always lowercase.
+  //
+  // This option can be used only with fields of type string. If used with some
+  // other type YARA will panic.
+  //
+  // string some_lowercase_string = 32 [(yara.field_options).lowercase = true];
+  optional bool lowercase = 4;
 }
 
 // An entry in a field's ACL.

--- a/lib/src/symbols/mod.rs
+++ b/lib/src/symbols/mod.rs
@@ -135,7 +135,7 @@ impl Symbol {
 
     #[cfg(test)]
     fn as_string(&self) -> Option<BString> {
-        if let TypeValue::String { value } = self.type_value() {
+        if let TypeValue::String { value, .. } = self.type_value() {
             value.extract().map(|s| BString::from(s.as_slice()))
         } else {
             None

--- a/lib/src/symbols/mod.rs
+++ b/lib/src/symbols/mod.rs
@@ -8,7 +8,7 @@ use std::{mem, ptr};
 use bstr::BString;
 
 use crate::compiler::{RuleId, Var};
-use crate::types::{AclEntry, Func, Type, TypeValue, Value};
+use crate::types::{AclEntry, Func, Type, TypeValue};
 
 /// Trait implemented by types that allow looking up for a symbol.
 pub(crate) trait SymbolLookup {
@@ -119,14 +119,14 @@ impl Symbol {
         match &self {
             Symbol::Var { type_value, .. } => type_value.clone(),
             Symbol::Field { type_value, .. } => type_value.clone(),
-            Symbol::Rule(_) => TypeValue::Bool(Value::Unknown),
+            Symbol::Rule(_) => TypeValue::unknown_bool(),
             Symbol::Func(func) => TypeValue::Func(func.clone()),
         }
     }
 
     #[cfg(test)]
     fn as_integer(&self) -> Option<i64> {
-        if let TypeValue::Integer(value) = self.type_value() {
+        if let TypeValue::Integer { value } = self.type_value() {
             value.extract().cloned()
         } else {
             None
@@ -135,7 +135,7 @@ impl Symbol {
 
     #[cfg(test)]
     fn as_string(&self) -> Option<BString> {
-        if let TypeValue::String(value) = self.type_value() {
+        if let TypeValue::String { value } = self.type_value() {
             value.extract().map(|s| BString::from(s.as_slice()))
         } else {
             None

--- a/lib/src/types/array.rs
+++ b/lib/src/types/array.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use bstr::BString;
 use serde::{Deserialize, Serialize};
 
-use crate::types::{Struct, TypeValue, Value};
+use crate::types::{Struct, TypeValue};
 
 #[derive(Serialize, Deserialize)]
 pub(crate) enum Array {
@@ -17,10 +17,10 @@ pub(crate) enum Array {
 impl Array {
     pub fn deputy(&self) -> TypeValue {
         match self {
-            Array::Integers(_) => TypeValue::Integer(Value::Unknown),
-            Array::Floats(_) => TypeValue::Float(Value::Unknown),
-            Array::Bools(_) => TypeValue::Bool(Value::Unknown),
-            Array::Strings(_) => TypeValue::String(Value::Unknown),
+            Array::Integers(_) => TypeValue::unknown_integer(),
+            Array::Floats(_) => TypeValue::unknown_float(),
+            Array::Bools(_) => TypeValue::unknown_bool(),
+            Array::Strings(_) => TypeValue::unknown_string(),
             Array::Structs(s) => TypeValue::Struct(s.first().unwrap().clone()),
         }
     }

--- a/lib/src/types/func.rs
+++ b/lib/src/types/func.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
-use crate::types::{TypeValue, Value};
+use crate::types::TypeValue;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Represents a mangled function name.
@@ -69,10 +69,10 @@ impl MangledFnName {
 
         for t in arg_types.chars() {
             match t {
-                'i' => args.push(TypeValue::Integer(Value::Unknown)),
-                'f' => args.push(TypeValue::Float(Value::Unknown)),
-                'b' => args.push(TypeValue::Bool(Value::Unknown)),
-                's' => args.push(TypeValue::String(Value::Unknown)),
+                'i' => args.push(TypeValue::unknown_integer()),
+                'f' => args.push(TypeValue::unknown_float()),
+                'b' => args.push(TypeValue::unknown_bool()),
+                's' => args.push(TypeValue::unknown_string()),
                 'r' => args.push(TypeValue::Regexp(None)),
                 _ => panic!("unexpected argument type: `{}`", t),
             }
@@ -80,10 +80,10 @@ impl MangledFnName {
 
         let result = if let Some(ret) = ret.get(0..1) {
             match ret.get(0..1).unwrap() {
-                "i" => TypeValue::Integer(Value::Unknown),
-                "f" => TypeValue::Float(Value::Unknown),
-                "b" => TypeValue::Bool(Value::Unknown),
-                "s" => TypeValue::String(Value::Unknown),
+                "i" => TypeValue::unknown_integer(),
+                "f" => TypeValue::unknown_float(),
+                "b" => TypeValue::unknown_bool(),
+                "s" => TypeValue::unknown_string(),
                 "u" => TypeValue::Unknown,
                 _ => panic!("unexpected return type: `{}`", ret),
             }
@@ -217,46 +217,34 @@ impl Func {
 
 #[cfg(test)]
 mod test {
-    use crate::types::{MangledFnName, TypeValue, Value};
+    use crate::types::{MangledFnName, TypeValue};
     use pretty_assertions::assert_eq;
 
     #[test]
     fn mangled_name() {
         assert_eq!(
             MangledFnName::from("foo@@i").unmangle(),
-            (vec![], TypeValue::Integer(Value::Unknown))
+            (vec![], TypeValue::unknown_integer())
         );
 
         assert_eq!(
             MangledFnName::from("foo@i@i").unmangle(),
-            (
-                vec![TypeValue::Integer(Value::Unknown)],
-                TypeValue::Integer(Value::Unknown)
-            )
+            (vec![TypeValue::unknown_integer()], TypeValue::unknown_integer())
         );
 
         assert_eq!(
             MangledFnName::from("foo@f@f").unmangle(),
-            (
-                vec![TypeValue::Float(Value::Unknown)],
-                TypeValue::Float(Value::Unknown)
-            )
+            (vec![TypeValue::unknown_float()], TypeValue::unknown_float())
         );
 
         assert_eq!(
             MangledFnName::from("foo@b@b").unmangle(),
-            (
-                vec![TypeValue::Bool(Value::Unknown)],
-                TypeValue::Bool(Value::Unknown)
-            )
+            (vec![TypeValue::unknown_bool()], TypeValue::unknown_bool())
         );
 
         assert_eq!(
             MangledFnName::from("foo@s@s").unmangle(),
-            (
-                vec![TypeValue::String(Value::Unknown)],
-                TypeValue::String(Value::Unknown)
-            )
+            (vec![TypeValue::unknown_string()], TypeValue::unknown_string())
         );
 
         assert!(!MangledFnName::from("foo@i@i").result_may_be_undef());

--- a/lib/src/variables.rs
+++ b/lib/src/variables.rs
@@ -14,7 +14,7 @@ use bstr::BString;
 use thiserror::Error;
 
 use crate::types;
-use crate::types::{Array, TypeValue, Value};
+use crate::types::{Array, TypeValue};
 
 /// Represents a YARA variable.
 ///
@@ -174,14 +174,14 @@ impl TryFrom<&serde_json::Value> for Variable {
         match value {
             serde_json::Value::Null => Err(VariableError::UnexpectedNull),
             serde_json::Value::Bool(b) => {
-                Ok(Variable(TypeValue::Bool(Value::Var(*b))))
+                Ok(Variable(TypeValue::var_bool_from(*b)))
             }
             serde_json::Value::Number(n) => {
                 if let Some(n) = n.as_u64() {
-                    Ok(Variable(TypeValue::Integer(Value::Var(
-                        n.try_into()
-                            .map_err(|_| VariableError::IntegerOutOfRange)?,
-                    ))))
+                    let n: i64 = n
+                        .try_into()
+                        .map_err(|_| VariableError::IntegerOutOfRange)?;
+                    Ok(Variable(TypeValue::var_integer_from(n)))
                 } else if let Some(n) = n.as_i64() {
                     Ok(Variable(TypeValue::var_integer_from(n)))
                 } else if let Some(n) = n.as_f64() {

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -98,7 +98,9 @@ use crate::scanner::{RuntimeObjectHandle, ScanContext, ScanError};
 use crate::types::{
     Array, Func, FuncSignature, Map, Struct, TypeValue, Value,
 };
+use crate::wasm;
 use crate::wasm::string::RuntimeString;
+use crate::wasm::string::String as _;
 
 pub(crate) mod builder;
 pub(crate) mod string;
@@ -464,7 +466,7 @@ impl WasmResult for bool {
     }
 }
 
-impl WasmResult for RuntimeString {
+impl<S: wasm::string::String> WasmResult for S {
     fn values(self, ctx: &mut ScanContext) -> WasmResultArray<ValRaw> {
         smallvec![ValRaw::i64(self.into_wasm_with_ctx(ctx))]
     }
@@ -1034,13 +1036,13 @@ pub(crate) fn lookup_string(
     num_lookup_indexes: i32,
 ) -> Option<RuntimeString> {
     match lookup_field(caller, structure, num_lookup_indexes) {
-        TypeValue::String { value: Value::Var(s) } => {
+        TypeValue::String { value: Value::Var(s), .. } => {
             Some(RuntimeString::Rc(s))
         }
-        TypeValue::String { value: Value::Const(s) } => {
+        TypeValue::String { value: Value::Const(s), .. } => {
             Some(RuntimeString::Rc(s))
         }
-        TypeValue::String { value: Value::Unknown } => None,
+        TypeValue::String { value: Value::Unknown, .. } => None,
         _ => unreachable!(),
     }
 }

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -1034,9 +1034,13 @@ pub(crate) fn lookup_string(
     num_lookup_indexes: i32,
 ) -> Option<RuntimeString> {
     match lookup_field(caller, structure, num_lookup_indexes) {
-        TypeValue::String(Value::Var(s)) => Some(RuntimeString::Rc(s)),
-        TypeValue::String(Value::Const(s)) => Some(RuntimeString::Rc(s)),
-        TypeValue::String(Value::Unknown) => None,
+        TypeValue::String { value: Value::Var(s) } => {
+            Some(RuntimeString::Rc(s))
+        }
+        TypeValue::String { value: Value::Const(s) } => {
+            Some(RuntimeString::Rc(s))
+        }
+        TypeValue::String { value: Value::Unknown } => None,
         _ => unreachable!(),
     }
 }
@@ -1068,7 +1072,7 @@ macro_rules! gen_lookup_fn {
             structure: Option<Rc<Struct>>,
             num_lookup_indexes: i32,
         ) -> Option<$return_type> {
-            if let $type(value) =
+            if let $type { value } =
                 lookup_field(caller, structure, num_lookup_indexes)
             {
                 value.extract().cloned()

--- a/lib/src/wasm/string.rs
+++ b/lib/src/wasm/string.rs
@@ -298,6 +298,8 @@ impl RuntimeString {
 
 /// Special kind of [RuntimeString] that has a fixed length.
 ///
+/// The specified length is in bytes, not characters.
+///
 /// Trying to create a [FixedLenString] with some length that is not the one
 /// specified by the `LEN` parameter will cause a panic.
 #[derive(Debug, Default)]

--- a/parser/src/ast/cst2ast.rs
+++ b/parser/src/ast/cst2ast.rs
@@ -1284,7 +1284,7 @@ impl<'src> Builder<'src> {
         let r_paren_span = self.expect(R_PAREN)?;
 
         let expr = Expr::FuncCall(Box::new(FuncCall {
-            span: identifier.span(),
+            span: identifier.span().combine(&r_paren_span),
             args_span: l_paren_span.combine(&r_paren_span),
             object,
             identifier,

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -857,7 +857,8 @@ impl FuncCall<'_> {
     /// Span covered by the function's arguments in the source code.
     ///
     /// [`FuncCall::span`] covers the whole function call, including the
-    /// function identifier, while this covers only the arguments.
+    /// function identifier and the arguments, while this covers only the
+    /// arguments.
     pub fn args_span(&self) -> Span {
         self.args_span.clone()
     }

--- a/proto/src/yara.proto
+++ b/proto/src/yara.proto
@@ -83,6 +83,14 @@ message FieldOptions {
   // Also, keep in mind that ACL entries are evaluated sequentially. The first
   // entry that fails will trigger the corresponding error message.
   repeated AclEntry acl = 3;
+
+  // Indicates that a string field is always lowercase.
+  //
+  // This option can be used only with fields of type string. If used with some
+  // other type YARA will panic.
+  //
+  // string some_lowercase_string = 32 [(yara.field_options).lowercase = true];
+  optional bool lowercase = 4;
 }
 
 // An entry in a field's ACL.

--- a/test.yar
+++ b/test.yar
@@ -1,5 +1,6 @@
-include "test3"
-rule test3 {
-condition:
-  true }
+import "hash"
 
+rule t { condition: hash.md5(0, filesize) == "AAB" }
+
+
+rule x { condition: "AD" == hash.sha256(0,filesize) }


### PR DESCRIPTION
Adds a warning that is emitted when a boolean expression can't be satisfied, for example, when comparing a lowercase string with a string containing uppercase characters. One common case is comparing the result of the hashing functions in the `hash` module (which return lowercase strings) with an upper case hash. These comparisons can't never succeed.