### PR TITLE
feat: Add support for scanning with modules to c-api

### DIFF
--- a/capi/include/yara_x.h
+++ b/capi/include/yara_x.h
@@ -693,6 +693,22 @@ enum YRX_RESULT yrx_scanner_set_module_output(struct YRX_SCANNER *scanner,
                                               const uint8_t *data,
                                               size_t len);
 
+// Specifies metadata for a module.
+//
+// Since the module's output typically varies with each scanned file, you need to
+// call [yrx_scanner_set_module_data] prior to each invocation of
+// [yrx_scanner_scan]. Once [yrx_scanner_scan] is executed, the module's metadata
+// is consumed and will be empty unless set again before the subsequent call.
+//
+// The `name` argument is the name of a YARA module. It must be a valid UTF-8 string.
+//
+// The `name` as well as `data` must be valid from the time they are used as arguments
+// of this function until the scan is executed.
+enum YRX_RESULT yrx_scanner_set_module_data(struct YRX_SCANNER *scanner,
+                                            const char *name,
+                                            const uint8_t *data,
+                                            size_t len);
+
 // Sets the value of a global variable of type string.
 enum YRX_RESULT yrx_scanner_set_global_str(struct YRX_SCANNER *scanner,
                                            const char *ident,

--- a/capi/src/tests.rs
+++ b/capi/src/tests.rs
@@ -13,8 +13,9 @@ use crate::{
     yrx_scanner_create, yrx_scanner_destroy, yrx_scanner_on_matching_rule,
     yrx_scanner_scan, yrx_scanner_set_global_bool,
     yrx_scanner_set_global_float, yrx_scanner_set_global_int,
-    yrx_scanner_set_global_str, yrx_scanner_set_timeout, YRX_BUFFER,
-    YRX_METADATA, YRX_PATTERN, YRX_RESULT, YRX_RULE,
+    yrx_scanner_set_global_str, yrx_scanner_set_timeout,
+    yrx_scanner_set_module_data, YRX_BUFFER, YRX_METADATA, YRX_PATTERN,
+    YRX_RESULT, YRX_RULE,
 };
 
 use std::ffi::{c_char, c_void, CStr};
@@ -91,6 +92,15 @@ extern "C" fn on_rule_match(rule: *const YRX_RULE, user_data: *mut c_void) {
         assert_eq!(count, 2);
     }
 
+    let ptr = user_data as *mut i32;
+    let matches = unsafe { ptr.as_mut().unwrap() };
+    *matches += 1;
+}
+
+extern "C" fn on_rule_match_increase_counter(
+    _rule: *const YRX_RULE,
+    user_data: *mut c_void,
+) {
     let ptr = user_data as *mut i32;
     let matches = unsafe { ptr.as_mut().unwrap() };
     *matches += 1;
@@ -207,6 +217,105 @@ fn capi() {
 
         yrx_scanner_destroy(scanner);
         yrx_rules_destroy(rules);
+    }
+}
+
+#[test]
+fn capi_modules() {
+    unsafe {
+        let mut compiler = std::ptr::null_mut();
+        yrx_compiler_create(0, &mut compiler);
+
+        let src = cr#"
+        import "cuckoo"
+
+        rule test {
+            condition:
+                cuckoo.network.tcp(/192\.168\.1\.1/, 443)
+        }
+        "#;
+
+        let module_name = c"cuckoo";
+        let module_metadata = cr#"
+        {
+            "network": {
+                "tcp": [{ "dport": 443, "dst": "192.168.1.1" }]
+            },
+            "behavior": {
+                "summary": {}
+            }
+        }
+        "#;
+
+        let module_metadata2 = cr#"
+        {
+            "network": {
+                "tcp": [{ "dport": 443, "dst": "192.168.1.2" }]
+            },
+            "behavior": {
+                "summary": {}
+            }
+        }
+        "#;
+
+        yrx_compiler_add_source(compiler, src.as_ptr());
+        let rules = yrx_compiler_build(compiler);
+
+        let mut scanner = std::ptr::null_mut();
+        yrx_scanner_create(rules, &mut scanner);
+
+        let mut matches = 0;
+        yrx_scanner_on_matching_rule(
+            scanner,
+            on_rule_match_increase_counter,
+            &mut matches as *mut i32 as *mut c_void,
+        );
+        yrx_scanner_scan(scanner, std::ptr::null(), 0);
+        assert_eq!(matches, 0);
+        assert_eq!(yrx_last_error(), std::ptr::null());
+
+        yrx_scanner_set_module_data(
+            scanner,
+            module_name.as_ptr(),
+            module_metadata.as_ptr() as *const u8,
+            module_metadata.to_bytes().len(),
+        );
+        yrx_scanner_scan(scanner, std::ptr::null(), 0);
+        assert_eq!(matches, 1);
+        assert_eq!(yrx_last_error(), std::ptr::null());
+
+        // Module data are cleaned after scanning
+        matches = 0;
+        yrx_scanner_scan(scanner, std::ptr::null(), 0);
+        assert_eq!(matches, 0);
+        assert_eq!(yrx_last_error(), std::ptr::null());
+
+        // Scanning with two different module data, first is matched, second is not
+        yrx_scanner_set_module_data(
+            scanner,
+            module_name.as_ptr(),
+            module_metadata.as_ptr() as *const u8,
+            module_metadata.to_bytes().len(),
+        );
+        yrx_scanner_scan(scanner, std::ptr::null(), 0);
+        assert_eq!(matches, 1);
+        assert_eq!(yrx_last_error(), std::ptr::null());
+
+        matches = 0;
+
+        yrx_scanner_set_module_data(
+            scanner,
+            module_name.as_ptr(),
+            module_metadata2.as_ptr() as *const u8,
+            module_metadata2.to_bytes().len(),
+        );
+        yrx_scanner_scan(scanner, std::ptr::null(), 0);
+        assert_eq!(matches, 0);
+        assert_eq!(yrx_last_error(), std::ptr::null());
+
+        yrx_rules_destroy(rules);
+        yrx_scanner_destroy(scanner);
+        yrx_compiler_destroy(compiler);
     }
 }
 

--- a/lib/src/modules/cuckoo/mod.rs
+++ b/lib/src/modules/cuckoo/mod.rs
@@ -27,8 +27,10 @@ fn set_local(value: schema::CuckooJson) {
 
 #[module_main]
 fn main(_data: &[u8], meta: Option<&[u8]>) -> Cuckoo {
-    let parsed =
-        serde_json::from_slice::<schema::CuckooJson>(meta.unwrap_or_default());
+    let parsed = match meta {
+        None => Ok(schema::CuckooJson::default()),
+        Some(m) => serde_json::from_slice::<schema::CuckooJson>(m)
+    };
 
     match parsed {
         Ok(parsed) => {
@@ -39,7 +41,9 @@ fn main(_data: &[u8], meta: Option<&[u8]>) -> Cuckoo {
             error!("can't parse cuckoo report: {}", e);
         }
         #[cfg(not(feature = "logging"))]
-        Err(_) => {}
+        Err(_) => {
+            set_local(schema::CuckooJson::default());
+        }
     };
 
     Cuckoo::new()

--- a/lib/src/modules/cuckoo/schema.rs
+++ b/lib/src/modules/cuckoo/schema.rs
@@ -30,7 +30,7 @@ pub(super) struct UdpJson {
     pub dport: u64,
 }
 
-#[derive(/* serde::Deserialize, - custom */ Debug)]
+#[derive(/* serde::Deserialize, - custom */ Debug, Default)]
 pub(super) struct NetworkJson {
     pub domains: Option<Vec<DomainJson>>,
     pub http: Option<Vec<HttpJson>>,
@@ -39,19 +39,19 @@ pub(super) struct NetworkJson {
     pub hosts: Option<Vec<String>>,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
 pub(super) struct SummaryJson {
     pub mutexes: Option<Vec<String>>,
     pub files: Option<Vec<String>>,
     pub keys: Option<Vec<String>>,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
 pub(super) struct BehaviorJson {
     pub summary: SummaryJson,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
 pub(super) struct CuckooJson {
     pub network: NetworkJson,
     pub behavior: BehaviorJson,


### PR DESCRIPTION
Added `yrx_scanner_set_module_data` to C-api to allow scanning with modules that require some additional (meta)data.