### PR TITLE
feat: implement `len` method for arrays and maps.

### DIFF
--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -646,7 +646,7 @@ fn emit_expr(
                 emit_expr(ctx, ir, *expr, instr);
             }
 
-            if func_call.signature().result_may_be_undef {
+            if func_call.signature().result_may_be_undef() {
                 emit_call_and_handle_undef(
                     ctx,
                     instr,

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -359,7 +359,7 @@ fn emit_expr(
                             // root structure, we know that the stack already
                             // contains the object.
                             if let Some((_, true)) = ctx.lookup_list.first() {
-                                if func.method_of().is_some() {
+                                if func.is_method() {
                                     emit_lookup_object(ctx, instr);
                                 }
                             }

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1353,6 +1353,9 @@ fn with_expr_from_ast(
         let expr = expr_from_ast(ctx, &item.expression)?;
         let type_value = ctx.ir.get(expr).type_value();
 
+        // If some item in the `with` statement is a function, don't create
+        // a variable for it, but add it to the symbol table. Methods are not
+        // allowed though.
         if let TypeValue::Func(func) = &type_value {
             if func.is_method() {
                 return Err(MethodNotAllowedInWith::build(

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -820,6 +820,8 @@ fn expr_from_ast(
         ast::Expr::Lookup(expr) => {
             let primary = expr_from_ast(ctx, &expr.primary)?;
 
+            ctx.one_shot_symbol_table = None;
+
             match ctx.ir.get(primary).type_value() {
                 TypeValue::Array(array) => {
                     let index =
@@ -1180,10 +1182,8 @@ fn is_potentially_large_range(ctx: &CompileContext, range: &Range) -> bool {
             |node| matches!(node, Expr::Filesize | Expr::PatternCount { .. }),
             // Don't traverse the arguments of `math.min`.
             |node| {
-                if let Expr::FuncCall(f) = node {
-                    f.func.signatures().iter().any(|signature| {
-                        signature.mangled_name.as_str().eq("math.min@ii@i")
-                    })
+                if let Expr::FuncCall(func) = node {
+                    func.signature.mangled_name.as_str().eq("math.min@ii@i")
                 } else {
                     false
                 }
@@ -1353,9 +1353,6 @@ fn with_expr_from_ast(
         let expr = expr_from_ast(ctx, &item.expression)?;
         let type_value = ctx.ir.get(expr).type_value();
 
-        // If some item in the `with` statement is a function, don't create
-        // a variable for it, but add it to the symbol table. Methods are not
-        // allowed though.
         if let TypeValue::Func(func) = &type_value {
             if func.method_of().is_some() {
                 return Err(MethodNotAllowedInWith::build(
@@ -1656,12 +1653,6 @@ fn func_call_from_ast(
         }
     };
 
-    // The object is necessary only when this is a method call, if this
-    // is a function call no object is required.
-    if func.method_of().is_none() {
-        object = None
-    }
-
     let args = func_call
         .args
         .iter()
@@ -1676,19 +1667,21 @@ fn func_call_from_ast(
 
     // Determine if any of the signatures for the called function matches
     // the provided arguments.
-    for (i, signature) in func.signatures().iter().enumerate() {
+    for signature in func.signatures().iter() {
         // If the function is actually a method, the first argument is always
         // the type the method belongs to (i.e: the self pointer). This
         // argument appears in the function's signature, but is not expected
         // to appear among the arguments in the call statement.
-        let expected_arg_types: Vec<Type> = if func.method_of().is_some() {
+
+        let expected_arg_types: Vec<Type> = if signature.method_of().is_some()
+        {
             signature.args.iter().skip(1).map(|arg| arg.ty()).collect()
         } else {
             signature.args.iter().map(|arg| arg.ty()).collect()
         };
 
         if arg_types == expected_arg_types {
-            matching_signature = Some((i, signature.result.clone()));
+            matching_signature = Some(signature);
             break;
         }
 
@@ -1720,9 +1713,15 @@ fn func_call_from_ast(
         ));
     }
 
-    let (signature_index, type_value) = matching_signature.unwrap();
+    let matching_signature = matching_signature.unwrap();
 
-    Ok(ctx.ir.func_call(object, args, func, type_value, signature_index))
+    // The object is necessary only when this is a method call, if this
+    // is a function call no object is required.
+    if matching_signature.method_of().is_none() {
+        object = None
+    }
+
+    Ok(ctx.ir.func_call(object, args, matching_signature.clone()))
 }
 
 fn matches_expr_from_ast(

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1354,7 +1354,7 @@ fn with_expr_from_ast(
         let type_value = ctx.ir.get(expr).type_value();
 
         if let TypeValue::Func(func) = &type_value {
-            if func.method_of().is_some() {
+            if func.is_method() {
                 return Err(MethodNotAllowedInWith::build(
                     ctx.report_builder,
                     ctx.report_builder

--- a/lib/src/compiler/ir/tests/testdata/3.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.cse.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
-    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
-      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
+  22: OR -- hash: 0xb4a7a7f9c72710dc -- parent: None 
+    10: EQ -- hash: 0x1f83299ba01db9c1 -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
-      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
+    21: EQ -- hash: 0x6d626453d72bff2d -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/ir/tests/testdata/3.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.hoisting.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
-    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
-      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
+  22: OR -- hash: 0xb4a7a7f9c72710dc -- parent: None 
+    10: EQ -- hash: 0x1f83299ba01db9c1 -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
-      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
+    21: EQ -- hash: 0x6d626453d72bff2d -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/ir/tests/testdata/3.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
-    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
-      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
+  22: OR -- hash: 0xb4a7a7f9c72710dc -- parent: None 
+    10: EQ -- hash: 0x1f83299ba01db9c1 -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
-      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
+    21: EQ -- hash: 0x6d626453d72bff2d -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/ir/tests/testdata/3.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.no-folding.ir
@@ -1,12 +1,12 @@
 RULE test
-  22: OR -- hash: 0x919db2da0fc7c751 -- parent: None 
-    10: EQ -- hash: 0x789880c57de1743e -- parent: 22 
-      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 10 
+  22: OR -- hash: 0xb4a7a7f9c72710dc -- parent: None 
+    10: EQ -- hash: 0x1f83299ba01db9c1 -- parent: 22 
+      8: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 10 
         6: CONST integer(0) -- parent: 8 
         7: FILESIZE -- parent: 8 
       9: CONST string("feba6c919e3797e7778e8f2e85fa033d") -- parent: 10 
-    21: EQ -- hash: 0xc677bb7db0efb9aa -- parent: 22 
-      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xbe23bb6d9ec1165e -- parent: 21 
+    21: EQ -- hash: 0x6d626453d72bff2d -- parent: 22 
+      19: FN_CALL hash.md5@ii@s:N32:Lu -- hash: 0xca0c6432c29a02bd -- parent: 21 
         17: CONST integer(0) -- parent: 19 
         18: FILESIZE -- parent: 19 
       20: CONST string("275876e34cf609db118f3d84b799a790") -- parent: 21 

--- a/lib/src/compiler/ir/tests/testdata/4.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.cse.ir
@@ -1,18 +1,18 @@
 RULE test
-  77: WITH -- hash: 0x2aa6c1f669ae2520 -- parent: None 
+  77: WITH -- hash: 0x283b533258999e1f -- parent: None 
     2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20 -- parent: 77 
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None } -- parent: 2 
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None } -- parent: 2 
-    76: AND -- hash: 0xcce3785d10669f2b -- parent: 77 
-      35: FOR_IN -- hash: 0x68a46f0ab6ea3ad1 -- parent: 76 
+    76: AND -- hash: 0x9e9efd2440d620e9 -- parent: 77 
+      35: FOR_IN -- hash: 0xcaea1975f4072d2c -- parent: 76 
         3: CONST integer(0) -- parent: 35 
         4: CONST integer(1) -- parent: 35 
-        34: AND -- hash: 0xf391ff5ee74242c2 -- parent: 35 
+        34: AND -- hash: 0x907cdd1b66f5782f -- parent: 35 
           9: EQ -- hash: 0xa866a1c3637edc78 -- parent: 34 
             7: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 6 }, type_value: integer(unknown) } -- parent: 9 
             8: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) } -- parent: 9 
-          20: EQ -- hash: 0x2ca4ea101097f712 -- parent: 34 
-            18: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 20 
+          20: EQ -- hash: 0x7a40b810809fa2ee -- parent: 34 
+            18: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 20 
               16: CONST integer(1) -- parent: 18 
               17: CONST integer(2) -- parent: 18 
             19: CONST integer(3) -- parent: 20 
@@ -23,12 +23,12 @@ RULE test
                 28: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None } -- parent: 29 
               30: CONST integer(1) -- parent: 31 
             32: CONST float(1.0) -- parent: 33 
-      58: FOR_IN -- hash: 0x5acaec2ad2bd517e -- parent: 76 
+      58: FOR_IN -- hash: 0x2e5383fb72bed118 -- parent: 76 
         36: CONST integer(0) -- parent: 58 
         37: CONST integer(1) -- parent: 58 
-        57: OR -- hash: 0x7b70c4f8c0c56c1a -- parent: 58 
-          43: NE -- hash: 0x6c1a3099aa8575c5 -- parent: 57 
-            41: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 43 
+        57: OR -- hash: 0x932d031ba37e9e5d -- parent: 58 
+          43: NE -- hash: 0x2a6b1f8a4b38e719 -- parent: 57 
+            41: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 43 
               39: CONST integer(1) -- parent: 41 
               40: CONST integer(2) -- parent: 41 
             42: CONST integer(0) -- parent: 43 

--- a/lib/src/compiler/ir/tests/testdata/4.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.hoisting.ir
@@ -1,11 +1,11 @@
 RULE test
-  77: WITH -- hash: 0x60420e3edc4f5bfa -- parent: None 
+  77: WITH -- hash: 0xcb82265a8df56399 -- parent: None 
     2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20 -- parent: 77 
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None } -- parent: 2 
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None } -- parent: 2 
-    76: AND -- hash: 0xa167a07244034fdf -- parent: 77 
-      79: WITH -- hash: 0x5c886e5464d4e373 -- parent: 76 
-        78: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 79 
+    76: AND -- hash: 0x5e44474f35878564 -- parent: 77 
+      79: WITH -- hash: 0x7059c38b552dfd45 -- parent: 76 
+        78: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 79 
           16: CONST integer(1) -- parent: 78 
           17: CONST integer(2) -- parent: 78 
         81: WITH -- hash: 0xb10afbca5fb181c -- parent: 79 
@@ -33,8 +33,8 @@ RULE test
                       8: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) } -- parent: 9 
                     20: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 2 }, type_value: boolean(unknown) } -- parent: 34 
                     33: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 5 }, type_value: boolean(unknown) } -- parent: 34 
-      89: WITH -- hash: 0x25da1ee0e54b34e6 -- parent: 76 
-        88: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 89 
+      89: WITH -- hash: 0x93cca32615906008 -- parent: 76 
+        88: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 89 
           39: CONST integer(1) -- parent: 88 
           40: CONST integer(2) -- parent: 88 
         91: WITH -- hash: 0xfd27d080260fa211 -- parent: 89 

--- a/lib/src/compiler/ir/tests/testdata/4.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.ir
@@ -1,18 +1,18 @@
 RULE test
-  77: WITH -- hash: 0x2aa6c1f669ae2520 -- parent: None 
+  77: WITH -- hash: 0x283b533258999e1f -- parent: None 
     2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20 -- parent: 77 
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None } -- parent: 2 
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None } -- parent: 2 
-    76: AND -- hash: 0xcce3785d10669f2b -- parent: 77 
-      35: FOR_IN -- hash: 0x68a46f0ab6ea3ad1 -- parent: 76 
+    76: AND -- hash: 0x9e9efd2440d620e9 -- parent: 77 
+      35: FOR_IN -- hash: 0xcaea1975f4072d2c -- parent: 76 
         3: CONST integer(0) -- parent: 35 
         4: CONST integer(1) -- parent: 35 
-        34: AND -- hash: 0xf391ff5ee74242c2 -- parent: 35 
+        34: AND -- hash: 0x907cdd1b66f5782f -- parent: 35 
           9: EQ -- hash: 0xa866a1c3637edc78 -- parent: 34 
             7: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 6 }, type_value: integer(unknown) } -- parent: 9 
             8: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) } -- parent: 9 
-          20: EQ -- hash: 0x2ca4ea101097f712 -- parent: 34 
-            18: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 20 
+          20: EQ -- hash: 0x7a40b810809fa2ee -- parent: 34 
+            18: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 20 
               16: CONST integer(1) -- parent: 18 
               17: CONST integer(2) -- parent: 18 
             19: CONST integer(3) -- parent: 20 
@@ -23,12 +23,12 @@ RULE test
                 28: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None } -- parent: 29 
               30: CONST integer(1) -- parent: 31 
             32: CONST float(1.0) -- parent: 33 
-      58: FOR_IN -- hash: 0x5acaec2ad2bd517e -- parent: 76 
+      58: FOR_IN -- hash: 0x2e5383fb72bed118 -- parent: 76 
         36: CONST integer(0) -- parent: 58 
         37: CONST integer(1) -- parent: 58 
-        57: OR -- hash: 0x7b70c4f8c0c56c1a -- parent: 58 
-          43: NE -- hash: 0x6c1a3099aa8575c5 -- parent: 57 
-            41: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 43 
+        57: OR -- hash: 0x932d031ba37e9e5d -- parent: 58 
+          43: NE -- hash: 0x2a6b1f8a4b38e719 -- parent: 57 
+            41: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 43 
               39: CONST integer(1) -- parent: 41 
               40: CONST integer(2) -- parent: 41 
             42: CONST integer(0) -- parent: 43 

--- a/lib/src/compiler/ir/tests/testdata/4.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.no-folding.ir
@@ -1,18 +1,18 @@
 RULE test
-  77: WITH -- hash: 0x2aa6c1f669ae2520 -- parent: None 
+  77: WITH -- hash: 0x283b533258999e1f -- parent: None 
     2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20 -- parent: 77 
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None } -- parent: 2 
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None } -- parent: 2 
-    76: AND -- hash: 0xcce3785d10669f2b -- parent: 77 
-      35: FOR_IN -- hash: 0x68a46f0ab6ea3ad1 -- parent: 76 
+    76: AND -- hash: 0x9e9efd2440d620e9 -- parent: 77 
+      35: FOR_IN -- hash: 0xcaea1975f4072d2c -- parent: 76 
         3: CONST integer(0) -- parent: 35 
         4: CONST integer(1) -- parent: 35 
-        34: AND -- hash: 0xf391ff5ee74242c2 -- parent: 35 
+        34: AND -- hash: 0x907cdd1b66f5782f -- parent: 35 
           9: EQ -- hash: 0xa866a1c3637edc78 -- parent: 34 
             7: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 6 }, type_value: integer(unknown) } -- parent: 9 
             8: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) } -- parent: 9 
-          20: EQ -- hash: 0x2ca4ea101097f712 -- parent: 34 
-            18: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 20 
+          20: EQ -- hash: 0x7a40b810809fa2ee -- parent: 34 
+            18: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 20 
               16: CONST integer(1) -- parent: 18 
               17: CONST integer(2) -- parent: 18 
             19: CONST integer(3) -- parent: 20 
@@ -23,12 +23,12 @@ RULE test
                 28: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None } -- parent: 29 
               30: CONST integer(1) -- parent: 31 
             32: CONST float(1.0) -- parent: 33 
-      58: FOR_IN -- hash: 0x5acaec2ad2bd517e -- parent: 76 
+      58: FOR_IN -- hash: 0x2e5383fb72bed118 -- parent: 76 
         36: CONST integer(0) -- parent: 58 
         37: CONST integer(1) -- parent: 58 
-        57: OR -- hash: 0x7b70c4f8c0c56c1a -- parent: 58 
-          43: NE -- hash: 0x6c1a3099aa8575c5 -- parent: 57 
-            41: FN_CALL test_proto2.add@ii@i -- hash: 0xe62f32868fcf8ebd -- parent: 43 
+        57: OR -- hash: 0x932d031ba37e9e5d -- parent: 58 
+          43: NE -- hash: 0x2a6b1f8a4b38e719 -- parent: 57 
+            41: FN_CALL test_proto2.add@ii@i -- hash: 0x3134dbc7cef85942 -- parent: 43 
               39: CONST integer(1) -- parent: 41 
               40: CONST integer(2) -- parent: 41 
             42: CONST integer(0) -- parent: 43 

--- a/lib/src/compiler/ir/tests/testdata/6.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.cse.ir
@@ -1,22 +1,22 @@
 RULE test
-  29: OR -- hash: 0xcd739dd2c39c446d -- parent: None 
-    16: AND -- hash: 0xd5c4987d90eaa4e0 -- parent: 29 
-      6: EQ -- hash: 0x3c39649c72d4a493 -- parent: 16 
-        4: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 6 
+  29: OR -- hash: 0xc8faf63e6fc4cd6e -- parent: None 
+    16: AND -- hash: 0x8dab579cf49b9cbe -- parent: 29 
+      6: EQ -- hash: 0x35c1df009eb1761a -- parent: 16 
+        4: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 6 
           3: CONST integer(0) -- parent: 4 
         5: CONST integer(23117) -- parent: 6 
-      15: EQ -- hash: 0x69851164e47029d9 -- parent: 16 
-        13: FN_CALL uint32@i@iu -- hash: 0x3018868b5ef5e28d -- parent: 15 
-          12: FN_CALL uint32@i@iu -- hash: 0x11ebe7bfd2692abe -- parent: 13 
+      15: EQ -- hash: 0x2f88edef3d55b4cd -- parent: 16 
+        13: FN_CALL uint32@i@iu -- hash: 0x9e0677dad441cbf6 -- parent: 15 
+          12: FN_CALL uint32@i@iu -- hash: 0xa3bce9990eee53a7 -- parent: 13 
             11: CONST integer(60) -- parent: 12 
         14: CONST integer(17744) -- parent: 15 
-    28: AND -- hash: 0xd00d540b210159e3 -- parent: 29 
-      23: EQ -- hash: 0x5a99f0157644314c -- parent: 28 
-        21: FN_CALL uint32@i@iu -- hash: 0x866f689720470782 -- parent: 23 
+    28: AND -- hash: 0x196e381f9886fb00 -- parent: 29 
+      23: EQ -- hash: 0xc814a73c034c440e -- parent: 28 
+        21: FN_CALL uint32@i@iu -- hash: 0x18406a705ccc306c -- parent: 23 
           20: CONST integer(0) -- parent: 21 
         22: CONST integer(1179403647) -- parent: 23 
-      27: NE -- hash: 0x5225c2aaa0128b80 -- parent: 28 
-        25: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 27 
+      27: NE -- hash: 0x5f9a9964dcff1dc0 -- parent: 28 
+        25: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 27 
           24: CONST integer(0) -- parent: 25 
         26: CONST integer(0) -- parent: 27 
 

--- a/lib/src/compiler/ir/tests/testdata/6.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.hoisting.ir
@@ -1,22 +1,22 @@
 RULE test
-  29: OR -- hash: 0xcd739dd2c39c446d -- parent: None 
-    16: AND -- hash: 0xd5c4987d90eaa4e0 -- parent: 29 
-      6: EQ -- hash: 0x3c39649c72d4a493 -- parent: 16 
-        4: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 6 
+  29: OR -- hash: 0xc8faf63e6fc4cd6e -- parent: None 
+    16: AND -- hash: 0x8dab579cf49b9cbe -- parent: 29 
+      6: EQ -- hash: 0x35c1df009eb1761a -- parent: 16 
+        4: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 6 
           3: CONST integer(0) -- parent: 4 
         5: CONST integer(23117) -- parent: 6 
-      15: EQ -- hash: 0x69851164e47029d9 -- parent: 16 
-        13: FN_CALL uint32@i@iu -- hash: 0x3018868b5ef5e28d -- parent: 15 
-          12: FN_CALL uint32@i@iu -- hash: 0x11ebe7bfd2692abe -- parent: 13 
+      15: EQ -- hash: 0x2f88edef3d55b4cd -- parent: 16 
+        13: FN_CALL uint32@i@iu -- hash: 0x9e0677dad441cbf6 -- parent: 15 
+          12: FN_CALL uint32@i@iu -- hash: 0xa3bce9990eee53a7 -- parent: 13 
             11: CONST integer(60) -- parent: 12 
         14: CONST integer(17744) -- parent: 15 
-    28: AND -- hash: 0xd00d540b210159e3 -- parent: 29 
-      23: EQ -- hash: 0x5a99f0157644314c -- parent: 28 
-        21: FN_CALL uint32@i@iu -- hash: 0x866f689720470782 -- parent: 23 
+    28: AND -- hash: 0x196e381f9886fb00 -- parent: 29 
+      23: EQ -- hash: 0xc814a73c034c440e -- parent: 28 
+        21: FN_CALL uint32@i@iu -- hash: 0x18406a705ccc306c -- parent: 23 
           20: CONST integer(0) -- parent: 21 
         22: CONST integer(1179403647) -- parent: 23 
-      27: NE -- hash: 0x5225c2aaa0128b80 -- parent: 28 
-        25: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 27 
+      27: NE -- hash: 0x5f9a9964dcff1dc0 -- parent: 28 
+        25: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 27 
           24: CONST integer(0) -- parent: 25 
         26: CONST integer(0) -- parent: 27 
 

--- a/lib/src/compiler/ir/tests/testdata/6.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.ir
@@ -1,22 +1,22 @@
 RULE test
-  29: OR -- hash: 0xcd739dd2c39c446d -- parent: None 
-    16: AND -- hash: 0xd5c4987d90eaa4e0 -- parent: 29 
-      6: EQ -- hash: 0x3c39649c72d4a493 -- parent: 16 
-        4: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 6 
+  29: OR -- hash: 0xc8faf63e6fc4cd6e -- parent: None 
+    16: AND -- hash: 0x8dab579cf49b9cbe -- parent: 29 
+      6: EQ -- hash: 0x35c1df009eb1761a -- parent: 16 
+        4: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 6 
           3: CONST integer(0) -- parent: 4 
         5: CONST integer(23117) -- parent: 6 
-      15: EQ -- hash: 0x69851164e47029d9 -- parent: 16 
-        13: FN_CALL uint32@i@iu -- hash: 0x3018868b5ef5e28d -- parent: 15 
-          12: FN_CALL uint32@i@iu -- hash: 0x11ebe7bfd2692abe -- parent: 13 
+      15: EQ -- hash: 0x2f88edef3d55b4cd -- parent: 16 
+        13: FN_CALL uint32@i@iu -- hash: 0x9e0677dad441cbf6 -- parent: 15 
+          12: FN_CALL uint32@i@iu -- hash: 0xa3bce9990eee53a7 -- parent: 13 
             11: CONST integer(60) -- parent: 12 
         14: CONST integer(17744) -- parent: 15 
-    28: AND -- hash: 0xd00d540b210159e3 -- parent: 29 
-      23: EQ -- hash: 0x5a99f0157644314c -- parent: 28 
-        21: FN_CALL uint32@i@iu -- hash: 0x866f689720470782 -- parent: 23 
+    28: AND -- hash: 0x196e381f9886fb00 -- parent: 29 
+      23: EQ -- hash: 0xc814a73c034c440e -- parent: 28 
+        21: FN_CALL uint32@i@iu -- hash: 0x18406a705ccc306c -- parent: 23 
           20: CONST integer(0) -- parent: 21 
         22: CONST integer(1179403647) -- parent: 23 
-      27: NE -- hash: 0x5225c2aaa0128b80 -- parent: 28 
-        25: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 27 
+      27: NE -- hash: 0x5f9a9964dcff1dc0 -- parent: 28 
+        25: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 27 
           24: CONST integer(0) -- parent: 25 
         26: CONST integer(0) -- parent: 27 
 

--- a/lib/src/compiler/ir/tests/testdata/6.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.no-folding.ir
@@ -1,22 +1,22 @@
 RULE test
-  29: OR -- hash: 0xcd739dd2c39c446d -- parent: None 
-    16: AND -- hash: 0xd5c4987d90eaa4e0 -- parent: 29 
-      6: EQ -- hash: 0x3c39649c72d4a493 -- parent: 16 
-        4: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 6 
+  29: OR -- hash: 0xc8faf63e6fc4cd6e -- parent: None 
+    16: AND -- hash: 0x8dab579cf49b9cbe -- parent: 29 
+      6: EQ -- hash: 0x35c1df009eb1761a -- parent: 16 
+        4: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 6 
           3: CONST integer(0) -- parent: 4 
         5: CONST integer(23117) -- parent: 6 
-      15: EQ -- hash: 0x69851164e47029d9 -- parent: 16 
-        13: FN_CALL uint32@i@iu -- hash: 0x3018868b5ef5e28d -- parent: 15 
-          12: FN_CALL uint32@i@iu -- hash: 0x11ebe7bfd2692abe -- parent: 13 
+      15: EQ -- hash: 0x2f88edef3d55b4cd -- parent: 16 
+        13: FN_CALL uint32@i@iu -- hash: 0x9e0677dad441cbf6 -- parent: 15 
+          12: FN_CALL uint32@i@iu -- hash: 0xa3bce9990eee53a7 -- parent: 13 
             11: CONST integer(60) -- parent: 12 
         14: CONST integer(17744) -- parent: 15 
-    28: AND -- hash: 0xd00d540b210159e3 -- parent: 29 
-      23: EQ -- hash: 0x5a99f0157644314c -- parent: 28 
-        21: FN_CALL uint32@i@iu -- hash: 0x866f689720470782 -- parent: 23 
+    28: AND -- hash: 0x196e381f9886fb00 -- parent: 29 
+      23: EQ -- hash: 0xc814a73c034c440e -- parent: 28 
+        21: FN_CALL uint32@i@iu -- hash: 0x18406a705ccc306c -- parent: 23 
           20: CONST integer(0) -- parent: 21 
         22: CONST integer(1179403647) -- parent: 23 
-      27: NE -- hash: 0x5225c2aaa0128b80 -- parent: 28 
-        25: FN_CALL uint16@i@iu -- hash: 0x8388494845bae8f6 -- parent: 27 
+      27: NE -- hash: 0x5f9a9964dcff1dc0 -- parent: 28 
+        25: FN_CALL uint16@i@iu -- hash: 0x7091e7e92285116b -- parent: 27 
           24: CONST integer(0) -- parent: 25 
         26: CONST integer(0) -- parent: 27 
 

--- a/lib/src/compiler/ir/tests/testdata/7.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.cse.ir
@@ -15,12 +15,12 @@ RULE test_1
       21: CONST integer(0) -- parent: 22 
 
 RULE test_2
-  10: DEFINED -- hash: 0x724d354d07744a2a -- parent: None 
-    9: FOR_IN -- hash: 0xebd1cf9739bb7d11 -- parent: 10 
+  10: DEFINED -- hash: 0xc0679a26d09a412e -- parent: None 
+    9: FOR_IN -- hash: 0x7c23aa43148905e5 -- parent: 10 
       0: CONST integer(0) -- parent: 9 
       1: CONST integer(10) -- parent: 9 
-      8: EQ -- hash: 0x417da33c44558cf1 -- parent: 9 
-        6: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xe9bfe015cdc995a -- parent: 8 
+      8: EQ -- hash: 0x3811592712be149d -- parent: 9 
+        6: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee -- parent: 8 
         7: CONST integer(0) -- parent: 8 
 
 RULE test_3

--- a/lib/src/compiler/ir/tests/testdata/7.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.hoisting.ir
@@ -17,9 +17,9 @@ RULE test_1
         21: CONST integer(0) -- parent: 22 
 
 RULE test_2
-  10: DEFINED -- hash: 0xf7eed6b2a095c2be -- parent: None 
-    12: WITH -- hash: 0x6399cde916bd6d36 -- parent: 10 
-      11: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xe9bfe015cdc995a -- parent: 12 
+  10: DEFINED -- hash: 0xd8cb367ced48a495 -- parent: None 
+    12: WITH -- hash: 0xb7f6e9da70521817 -- parent: 10 
+      11: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee -- parent: 12 
       14: WITH -- hash: 0x3fd4d8a8a7b3def1 -- parent: 12 
         13: EQ -- hash: 0xfaee69d45c264d0d -- parent: 14 
           6: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 0 }, type_value: integer(unknown) } -- parent: 13 

--- a/lib/src/compiler/ir/tests/testdata/7.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.ir
@@ -15,12 +15,12 @@ RULE test_1
       21: CONST integer(0) -- parent: 22 
 
 RULE test_2
-  10: DEFINED -- hash: 0x724d354d07744a2a -- parent: None 
-    9: FOR_IN -- hash: 0xebd1cf9739bb7d11 -- parent: 10 
+  10: DEFINED -- hash: 0xc0679a26d09a412e -- parent: None 
+    9: FOR_IN -- hash: 0x7c23aa43148905e5 -- parent: 10 
       0: CONST integer(0) -- parent: 9 
       1: CONST integer(10) -- parent: 9 
-      8: EQ -- hash: 0x417da33c44558cf1 -- parent: 9 
-        6: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xe9bfe015cdc995a -- parent: 8 
+      8: EQ -- hash: 0x3811592712be149d -- parent: 9 
+        6: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee -- parent: 8 
         7: CONST integer(0) -- parent: 8 
 
 RULE test_3

--- a/lib/src/compiler/ir/tests/testdata/7.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.no-folding.ir
@@ -15,12 +15,12 @@ RULE test_1
       21: CONST integer(0) -- parent: 22 
 
 RULE test_2
-  10: DEFINED -- hash: 0x724d354d07744a2a -- parent: None 
-    9: FOR_IN -- hash: 0xebd1cf9739bb7d11 -- parent: 10 
+  10: DEFINED -- hash: 0xc0679a26d09a412e -- parent: None 
+    9: FOR_IN -- hash: 0x7c23aa43148905e5 -- parent: 10 
       0: CONST integer(0) -- parent: 9 
       1: CONST integer(10) -- parent: 9 
-      8: EQ -- hash: 0x417da33c44558cf1 -- parent: 9 
-        6: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xe9bfe015cdc995a -- parent: 8 
+      8: EQ -- hash: 0x3811592712be149d -- parent: 9 
+        6: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee -- parent: 8 
         7: CONST integer(0) -- parent: 8 
 
 RULE test_3

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -694,6 +694,16 @@ fn with() {
 }
 
 #[test]
+fn len_methods() {
+    #[cfg(feature = "test_proto2-module")]
+    condition_true!(r#"test_proto2.array_bool.len() == 2"#);
+    condition_true!(r#"test_proto2.array_int64.len() == 3"#);
+    condition_true!(r#"test_proto2.array_string.len() == 3"#);
+
+    condition_true!(r#"test_proto2.map_int64_int64.len() == 1"#);
+}
+
+#[test]
 fn text_patterns() {
     pattern_true!(r#""issi""#, b"mississippi");
     pattern_true!(r#""issi" ascii"#, b"mississippi");

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -699,7 +699,6 @@ fn len_methods() {
     condition_true!(r#"test_proto2.array_bool.len() == 2"#);
     condition_true!(r#"test_proto2.array_int64.len() == 3"#);
     condition_true!(r#"test_proto2.array_string.len() == 3"#);
-
     condition_true!(r#"test_proto2.map_int64_int64.len() == 1"#);
 }
 

--- a/lib/src/types/array.rs
+++ b/lib/src/types/array.rs
@@ -18,8 +18,11 @@ pub(crate) enum Array {
 }
 
 impl Array {
+    #[allow(clippy::declare_interior_mutable_const)]
     const BUILTIN_METHODS: OnceCell<Rc<SymbolTable>> = OnceCell::new();
+
     pub fn builtin_methods(&self) -> Rc<SymbolTable> {
+        #[allow(clippy::borrow_interior_mutable_const)]
         Self::BUILTIN_METHODS
             .get_or_init(|| {
                 let mut s = SymbolTable::new();

--- a/lib/src/types/map.rs
+++ b/lib/src/types/map.rs
@@ -31,8 +31,11 @@ pub(crate) enum Map {
 }
 
 impl Map {
+    #[allow(clippy::declare_interior_mutable_const)]
     const BUILTIN_METHODS: OnceCell<Rc<SymbolTable>> = OnceCell::new();
+
     pub fn builtin_methods(&self) -> Rc<SymbolTable> {
+        #[allow(clippy::borrow_interior_mutable_const)]
         Self::BUILTIN_METHODS
             .get_or_init(|| {
                 let mut s = SymbolTable::new();

--- a/lib/src/types/mod.rs
+++ b/lib/src/types/mod.rs
@@ -301,12 +301,12 @@ impl TypeValue {
     /// Returns the symbol table associated to this [`TypeValue`].
     ///
     /// The symbol table contains the methods and/or fields associated to the
-    /// type. This only returns some value for [`TypeValue::Struct`] for any
-    /// other type it returns [`None`].
+    /// type.
     pub fn symbol_table(&self) -> Option<Rc<dyn SymbolLookup>> {
         match self {
             Self::Struct(s) => Some(s.clone()),
             Self::Array(a) => Some(a.builtin_methods()),
+            Self::Map(m) => Some(m.builtin_methods()),
             _ => None,
         }
     }

--- a/lib/src/types/mod.rs
+++ b/lib/src/types/mod.rs
@@ -306,6 +306,7 @@ impl TypeValue {
     pub fn symbol_table(&self) -> Option<Rc<dyn SymbolLookup>> {
         match self {
             Self::Struct(s) => Some(s.clone()),
+            Self::Array(a) => Some(a.builtin_methods()),
             _ => None,
         }
     }

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -749,7 +749,6 @@ pub(crate) static ENGINE: LazyLock<Engine> =
 pub(crate) fn new_linker<'r>() -> Linker<ScanContext<'r>> {
     let mut linker = Linker::<ScanContext<'r>>::new(&ENGINE);
     for export in WASM_EXPORTS {
-        println!("{}", export.mangled_name);
         let func_type = FuncType::new(
             &ENGINE,
             export.func.wasmtime_args(),

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -225,13 +225,9 @@ impl WasmExport {
     /// fn some_method(...) { ... }
     /// ```
     pub fn get_methods(type_name: &str) -> FxHashMap<&'static str, Func> {
-        let mut methods = WasmExport::get_functions(|export| {
+        WasmExport::get_functions(|export| {
             export.method_of.is_some_and(|name| name == type_name)
-        });
-        for (_, func) in methods.iter_mut() {
-            func.make_method_of(type_name)
-        }
-        methods
+        })
     }
 }
 
@@ -753,6 +749,7 @@ pub(crate) static ENGINE: LazyLock<Engine> =
 pub(crate) fn new_linker<'r>() -> Linker<ScanContext<'r>> {
     let mut linker = Linker::<ScanContext<'r>>::new(&ENGINE);
     for export in WASM_EXPORTS {
+        println!("{}", export.mangled_name);
         let func_type = FuncType::new(
             &ENGINE,
             export.func.wasmtime_args(),
@@ -925,7 +922,7 @@ pub(crate) fn pat_offset(
 }
 
 /// Called from WASM to obtain the length of an array.
-#[wasm_export]
+#[wasm_export(name = "len", method_of = "Array")]
 pub(crate) fn array_len(
     _: &mut Caller<'_, ScanContext>,
     array: Rc<Array>,
@@ -934,7 +931,7 @@ pub(crate) fn array_len(
 }
 
 /// Called from WASM to obtain the length of a map.
-#[wasm_export]
+#[wasm_export(name = "len", method_of = "Map")]
 pub(crate) fn map_len(_: &mut Caller<'_, ScanContext>, map: Rc<Map>) -> i64 {
     map.len() as i64
 }

--- a/macros/src/wasm_export.rs
+++ b/macros/src/wasm_export.rs
@@ -258,12 +258,18 @@ pub(crate) fn impl_wasm_export_macro(
     let public = attr_args.public;
     let export_ident = format_ident!("export__{}", rust_fn_name);
     let exported_fn_ident = format_ident!("WasmExportedFn{}", num_args);
+    let args_signature = FuncSignatureParser::new().parse(&func)?;
+
     let method_of = attr_args
         .method_of
+        .as_ref()
         .map_or_else(|| quote! { None}, |m| quote! { Some(#m) });
 
-    let mangled_fn_name =
-        format!("{}{}", fn_name, FuncSignatureParser::new().parse(&func)?);
+    let mangled_fn_name = if let Some(ty_name) = attr_args.method_of {
+        format!("{ty_name}::{fn_name}{args_signature}")
+    } else {
+        format!("{fn_name}{args_signature}")
+    };
 
     let fn_descriptor = quote! {
         #[allow(non_upper_case_globals)]

--- a/test.yar
+++ b/test.yar
@@ -1,0 +1,1 @@
+import "test_proto2"import "test_proto3"rule t {condition: with foo = test_proto2.uppercase("foo"): (foo == "FOO" ) }


### PR DESCRIPTION
With this change every array and map now has a built-in method `len()` which returns the number of items in the array or map.