### PR TITLE
refactor: improve unary minus handling in the parser.

### DIFF
--- a/lib/src/compiler/ir/tests/testdata/1.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.cse.ir
@@ -33,9 +33,9 @@ RULE test_4
     5: CONST integer(2) -- parent: 6 
 
 RULE test_5
-  14: EQ -- hash: 0xce980a3b0dd2d7cf -- parent: None 
-    12: CONST integer(8) -- parent: 14 
-    13: CONST integer(8) -- parent: 14 
+  12: EQ -- hash: 0xce980a3b0dd2d7cf -- parent: None 
+    10: CONST integer(8) -- parent: 12 
+    11: CONST integer(8) -- parent: 12 
 
 RULE test_6
   18: EQ -- hash: 0x4a78a326637b7d9d -- parent: None 

--- a/lib/src/compiler/ir/tests/testdata/1.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.hoisting.ir
@@ -33,9 +33,9 @@ RULE test_4
     5: CONST integer(2) -- parent: 6 
 
 RULE test_5
-  14: EQ -- hash: 0xce980a3b0dd2d7cf -- parent: None 
-    12: CONST integer(8) -- parent: 14 
-    13: CONST integer(8) -- parent: 14 
+  12: EQ -- hash: 0xce980a3b0dd2d7cf -- parent: None 
+    10: CONST integer(8) -- parent: 12 
+    11: CONST integer(8) -- parent: 12 
 
 RULE test_6
   18: EQ -- hash: 0x4a78a326637b7d9d -- parent: None 

--- a/lib/src/compiler/ir/tests/testdata/1.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.ir
@@ -33,9 +33,9 @@ RULE test_4
     5: CONST integer(2) -- parent: 6 
 
 RULE test_5
-  14: EQ -- hash: 0xce980a3b0dd2d7cf -- parent: None 
-    12: CONST integer(8) -- parent: 14 
-    13: CONST integer(8) -- parent: 14 
+  12: EQ -- hash: 0xce980a3b0dd2d7cf -- parent: None 
+    10: CONST integer(8) -- parent: 12 
+    11: CONST integer(8) -- parent: 12 
 
 RULE test_6
   18: EQ -- hash: 0x4a78a326637b7d9d -- parent: None 

--- a/lib/src/compiler/ir/tests/testdata/1.no-folding.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.no-folding.ir
@@ -39,14 +39,13 @@ RULE test_4
     5: CONST integer(2) -- parent: 6 
 
 RULE test_5
-  14: EQ -- hash: 0xf53fe7e47dccd12 -- parent: None 
-    12: SUB -- hash: 0x2811d6a2057cdcd4 -- parent: 14 
-      7: CONST integer(4) -- parent: 12 
-      11: MUL -- hash: 0x732ef991cf2d1ca3 -- parent: 12 
-        9: MINUS -- hash: 0x250857ae282d75aa -- parent: 11 
-          8: CONST integer(2) -- parent: 9 
-        10: CONST integer(2) -- parent: 11 
-    13: CONST integer(8) -- parent: 14 
+  12: EQ -- hash: 0xeb353eeba0e329e3 -- parent: None 
+    10: SUB -- hash: 0x3e023f7bf097d869 -- parent: 12 
+      6: CONST integer(4) -- parent: 10 
+      9: MUL -- hash: 0x3eb7d1d11a0539b0 -- parent: 10 
+        7: CONST integer(-2) -- parent: 9 
+        8: CONST integer(2) -- parent: 9 
+    11: CONST integer(8) -- parent: 12 
 
 RULE test_6
   18: EQ -- hash: 0x4a78a326637b7d9d -- parent: None 

--- a/lib/src/compiler/tests/testdata/warnings/40.in
+++ b/lib/src/compiler/tests/testdata/warnings/40.in
@@ -1,5 +1,3 @@
-// constant-folding required
-
 rule test_1 {
     condition:
         uint8(0) == 0x1FF

--- a/lib/src/compiler/tests/testdata/warnings/40.out
+++ b/lib/src/compiler/tests/testdata/warnings/40.out
@@ -1,95 +1,95 @@
 warning[unsatisfiable_expr]: unsatisfiable expression
- --> line:5:9
+ --> line:3:9
   |
-5 |         uint8(0) == 0x1FF
+3 |         uint8(0) == 0x1FF
   |         --------    ----- this integer is outside the range [0,255]
   |         |
   |         this expression is an integer in the range [0,255]
   |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:10:9
-   |
-10 |         int8(0) == -129
-   |         -------    ---- this integer is outside the range [-128,127]
-   |         |
-   |         this expression is an integer in the range [-128,127]
-   |
+ --> line:8:9
+  |
+8 |         int8(0) == -129
+  |         -------    ---- this integer is outside the range [-128,127]
+  |         |
+  |         this expression is an integer in the range [-128,127]
+  |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:15:9
+  --> line:13:9
    |
-15 |         uint16(0) == 0x1FFFF
+13 |         uint16(0) == 0x1FFFF
    |         ---------    ------- this integer is outside the range [0,65535]
    |         |
    |         this expression is an integer in the range [0,65535]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:20:9
+  --> line:18:9
    |
-20 |         int16(0) == -32769
+18 |         int16(0) == -32769
    |         --------    ------ this integer is outside the range [-32768,32767]
    |         |
    |         this expression is an integer in the range [-32768,32767]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:25:9
+  --> line:23:9
    |
-25 |         uint32(0) == 0x1FFFFFFFF
+23 |         uint32(0) == 0x1FFFFFFFF
    |         ---------    ----------- this integer is outside the range [0,4294967295]
    |         |
    |         this expression is an integer in the range [0,4294967295]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:30:9
+  --> line:28:9
    |
-30 |         int32(0) == -2147483649
+28 |         int32(0) == -2147483649
    |         --------    ----------- this integer is outside the range [-2147483648,2147483647]
    |         |
    |         this expression is an integer in the range [-2147483648,2147483647]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:35:9
+  --> line:33:9
    |
-35 |         uint8be(0) == 0x1FF
+33 |         uint8be(0) == 0x1FF
    |         ----------    ----- this integer is outside the range [0,255]
    |         |
    |         this expression is an integer in the range [0,255]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:40:9
+  --> line:38:9
    |
-40 |         int8be(0) == -129
+38 |         int8be(0) == -129
    |         ---------    ---- this integer is outside the range [-128,127]
    |         |
    |         this expression is an integer in the range [-128,127]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:45:9
+  --> line:43:9
    |
-45 |         uint16be(0) == 0x1FFFF
+43 |         uint16be(0) == 0x1FFFF
    |         -----------    ------- this integer is outside the range [0,65535]
    |         |
    |         this expression is an integer in the range [0,65535]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:50:9
+  --> line:48:9
    |
-50 |         int16be(0) == -32769
+48 |         int16be(0) == -32769
    |         ----------    ------ this integer is outside the range [-32768,32767]
    |         |
    |         this expression is an integer in the range [-32768,32767]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:55:9
+  --> line:53:9
    |
-55 |         uint32be(0) == 0x1FFFFFFFF
+53 |         uint32be(0) == 0x1FFFFFFFF
    |         -----------    ----------- this integer is outside the range [0,4294967295]
    |         |
    |         this expression is an integer in the range [0,4294967295]
    |
 warning[unsatisfiable_expr]: unsatisfiable expression
-  --> line:60:9
+  --> line:58:9
    |
-60 |         int32be(0) == -2147483649
+58 |         int32be(0) == -2147483649
    |         ----------    ----------- this integer is outside the range [-2147483648,2147483647]
    |         |
    |         this expression is an integer in the range [-2147483648,2147483647]

--- a/parser/src/parser/tests/testdata/arithmetic-ops.ast
+++ b/parser/src/parser/tests/testdata/arithmetic-ops.ast
@@ -5,8 +5,7 @@
        │  ├─ 1
        │  └─ mul
        │     ├─ 2.5
-       │     ├─ minus
-       │     │  └─ 2
+       │     ├─ -2
        │     └─ minus
        │        └─ 1.0
        └─ add
@@ -14,8 +13,7 @@
           │  ├─ 10.0
           │  └─ 2
           └─ minus
-             └─ minus
-                └─ 1
+             └─ -1
 
  rule test_2
  └─ condition
@@ -24,8 +22,7 @@
        │  ├─ add
        │  │  ├─ 1
        │  │  └─ 2.5
-       │  ├─ minus
-       │  │  └─ 2
+       │  ├─ -2
        │  └─ minus
        │     └─ 1.0
        └─ div
@@ -33,8 +30,7 @@
           └─ add
              ├─ 2
              └─ minus
-                └─ minus
-                   └─ 1
+                └─ -1
 
  rule test_3
  └─ condition
@@ -55,4 +51,12 @@
        └─ sub
           ├─ 6
           └─ 3
+
+ rule test_5
+ └─ condition
+    └─ eq
+       ├─ minus
+       │  └─ minus
+       │     └─ -1
+       └─ -1
 

--- a/parser/src/parser/tests/testdata/arithmetic-ops.cst
+++ b/parser/src/parser/tests/testdata/arithmetic-ops.cst
@@ -1,4 +1,4 @@
-SOURCE_FILE@0..250
+SOURCE_FILE@0..295
   RULE_DECL@0..72
     RULE_KW@0..4 "rule"
     WHITESPACE@4..5 " "
@@ -247,3 +247,45 @@ SOURCE_FILE@0..250
                 INTEGER_LIT@247..248 "3"
     NEWLINE@248..249 "\n"
     R_BRACE@249..250 "}"
+  NEWLINE@250..251 "\n"
+  NEWLINE@251..252 "\n"
+  RULE_DECL@252..295
+    RULE_KW@252..256 "rule"
+    WHITESPACE@256..257 " "
+    IDENT@257..263 "test_5"
+    WHITESPACE@263..264 " "
+    L_BRACE@264..265 "{"
+    NEWLINE@265..266 "\n"
+    WHITESPACE@266..268 "  "
+    CONDITION_BLK@268..293
+      CONDITION_KW@268..277 "condition"
+      COLON@277..278 ":"
+      NEWLINE@278..279 "\n"
+      WHITESPACE@279..283 "    "
+      BOOLEAN_EXPR@283..293
+        BOOLEAN_TERM@283..293
+          EXPR@283..287
+            TERM@283..287
+              PRIMARY_EXPR@283..287
+                MINUS@283..284 "-"
+                TERM@284..287
+                  PRIMARY_EXPR@284..287
+                    MINUS@284..285 "-"
+                    TERM@285..287
+                      PRIMARY_EXPR@285..287
+                        MINUS@285..286 "-"
+                        TERM@286..287
+                          PRIMARY_EXPR@286..287
+                            INTEGER_LIT@286..287 "1"
+          WHITESPACE@287..288 " "
+          EQ@288..290 "=="
+          WHITESPACE@290..291 " "
+          EXPR@291..293
+            TERM@291..293
+              PRIMARY_EXPR@291..293
+                MINUS@291..292 "-"
+                TERM@292..293
+                  PRIMARY_EXPR@292..293
+                    INTEGER_LIT@292..293 "1"
+    NEWLINE@293..294 "\n"
+    R_BRACE@294..295 "}"

--- a/parser/src/parser/tests/testdata/arithmetic-ops.in
+++ b/parser/src/parser/tests/testdata/arithmetic-ops.in
@@ -19,3 +19,8 @@ rule test_4 {
   condition:
     5 - 2 != 6 - 3
 }
+
+rule test_5 {
+  condition:
+    ---1 == -1
+}

--- a/parser/src/parser/tests/testdata/expr-1.ast
+++ b/parser/src/parser/tests/testdata/expr-1.ast
@@ -53,10 +53,8 @@
  └─ condition
     └─ eq
        ├─ add
-       │  ├─ minus
-       │  │  └─ 1
-       │  └─ minus
-       │     └─ 1
+       │  ├─ -1
+       │  └─ -1
        └─ 0
 
  rule test_5


### PR DESCRIPTION
Optimizes the handling of unary minus operators in the parser by merging a minus sign immediately followed by a positive literal integer into a single literal with a negative value. This prevents the creation of unnecessary intermediate `Expr::Minus` nodes and simplifies the AST.