### PR TITLE
docs: `slow_pattern` typo in doc and help

### DIFF
--- a/cli/src/help.rs
+++ b/cli/src/help.rs
@@ -67,7 +67,7 @@ list of with the names of the warnings to disable.
 Examples:
 
 --disable-warnings
---disable-warnings=slow_patterns
+--disable-warnings=slow_pattern
 --disable-warnings=slow_rules,redundant_modifier"
 --disable-warnings=slow_rules --disable-warnings=redundant_modifier"#;
 

--- a/site/content/docs/cli/commands.md
+++ b/site/content/docs/cli/commands.md
@@ -114,22 +114,22 @@ Disable all warnings:
 --disable-warnings
 ```
 
-Disable warning `slow_patterns`:
+Disable warning `slow_pattern`:
 
 ```
---disable-warnings=slow_patterns
+--disable-warnings=slow_pattern
 ```
 
-Disable warnings `slow_patterns` and `redundant_modifier`:
+Disable warnings `slow_pattern` and `redundant_modifier`:
 
 ```
---disable-warnings=slow_patterns,redundant_modifier
+--disable-warnings=slow_pattern,redundant_modifier
 ```
 
 Equivalent to the previous one, but using `--disable-warnings` multiple times:
 
 ```
---disable-warnings=slow_patterns --disable-warnings=redundant_modifier
+--disable-warnings=slow_pattern --disable-warnings=redundant_modifier
 ```
 
 ### --include-dir \<PATH\>, -I \<PATH\>


### PR DESCRIPTION
The docs and help `yr  scan --help` had a small typo for disabling the `slow_pattern` warning. Small change to fix the documentation.

```sh
kmsec@penguin:~$ yr scan b64.yara b64.js --disable-warnings=slow_patterns
error: `slow_patterns` is not a valid warning code
```
