### PR TITLE
feat: add support for parsing IEEE754 float/double 

### DIFF
--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -1528,6 +1528,6 @@ macro_rules! gen_xieee754_fn {
 }
 
 gen_xieee754_fn!(float32, f32, from_le_bytes);
-gen_xieee754_fn!(double64, f64, from_le_bytes);
+gen_xieee754_fn!(float64, f64, from_le_bytes);
 gen_xieee754_fn!(float32be, f32, from_be_bytes);
-gen_xieee754_fn!(double64be, f64, from_be_bytes);
+gen_xieee754_fn!(float64be, f64, from_be_bytes);

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -1507,3 +1507,27 @@ gen_xint_fn!(int32, i32, from_le_bytes, -2_147_483_648, 2_147_483_647);
 gen_xint_fn!(int8be, i8, from_be_bytes, -128, 127);
 gen_xint_fn!(int16be, i16, from_be_bytes, -32_768, 32_767);
 gen_xint_fn!(int32be, i32, from_be_bytes, -2_147_483_648, 2_147_483_647);
+
+macro_rules! gen_xieee754_fn {
+    ($name:ident, $return_type:ty, $from_fn:ident) => {
+        #[wasm_export(public = true)]
+        pub(crate) fn $name(
+            caller: &mut Caller<'_, ScanContext>,
+            offset: i64,
+        ) -> Option<f64> {
+            let offset = usize::try_from(offset).ok()?;
+            caller
+                .data()
+                .scanned_data()
+                .get(offset..offset + mem::size_of::<$return_type>())
+                .map(|bytes| {
+                    <$return_type>::$from_fn(bytes.try_into().unwrap()) as f64
+                })
+        }
+    };
+}
+
+gen_xieee754_fn!(float32, f32, from_le_bytes);
+gen_xieee754_fn!(double64, f64, from_le_bytes);
+gen_xieee754_fn!(float32be, f32, from_be_bytes);
+gen_xieee754_fn!(double64be, f64, from_be_bytes);

--- a/site/content/docs/writing_rules/conditions.md
+++ b/site/content/docs/writing_rules/conditions.md
@@ -229,11 +229,18 @@ int32be(<offset>)
 uint8be(<offset>)
 uint16be(<offset>)
 uint32be(<offset>)
+
+float32(<offset>)
+double64(<offset>)
+
+float32be(<offset>)
+double64be(<offset>)
 ```
 
 The `intXX` functions read 8, 16, and 32 bits signed integers from the given
-offset, while functions uintXX read unsigned integers. Both 16 and 32-bit
-integers are considered to be little-endian. If you want to read a big-endian
+offset, while functions `uintXX` read unsigned integers. IEEE 754 floating
+point numbers are read using `float32/double64`. The order in which multiple
+bytes are read defaults to little-endian. If you want to read a big-endian
 integer use the corresponding function ending in `be`. The offset parameter can
 be any expression returning an unsigned integer, including the return value of
 one the `uintXX` functions. Let's see a rule to distinguish PE files:

--- a/site/content/docs/writing_rules/conditions.md
+++ b/site/content/docs/writing_rules/conditions.md
@@ -231,19 +231,19 @@ uint16be(<offset>)
 uint32be(<offset>)
 
 float32(<offset>)
-double64(<offset>)
+float64(<offset>)
 
 float32be(<offset>)
-double64be(<offset>)
+float64be(<offset>)
 ```
 
 The `intXX` functions read 8, 16, and 32 bits signed integers from the given
 offset, while functions `uintXX` read unsigned integers. IEEE 754 floating
-point numbers are read using `float32/double64`. The order in which multiple
-bytes are read defaults to little-endian. If you want to read a big-endian
-integer use the corresponding function ending in `be`. The offset parameter can
-be any expression returning an unsigned integer, including the return value of
-one the `uintXX` functions. Let's see a rule to distinguish PE files:
+point numbers are read using `floatXX`. The order in which multiple bytes are
+read defaults to little-endian. If you want to read a big-endian number use the
+corresponding function ending in `be`. The offset parameter can be any
+expression returning an unsigned integer, including the return value of one the
+`uintXX` functions. Let's see a rule to distinguish PE files:
 
 ```yara
 rule IsPE {


### PR DESCRIPTION
Port of https://github.com/VirusTotal/yara/pull/2153 to Yara-X

Parse IEEE 754 float and double formats from any offset and to create signatures based on the interpreted floating point value.

Sample rule:
```
rule ieee754_test {
    condition:
        float32(0) == 1.0 and 
        float32be(4) == 1.0 and
        float32(8) > 0.74 and
        float32be(12) < 0.76 and
        float64(16) == 1.0 and
        float64be(24) == 1.0 and
        float64be(32) == 0.01171875
}
```

Sample file:
```
00000000: 0000 803f 3f80 0000  ...??...
00000008: 0000 403f 3f40 0000  ..@??@..
00000010: 0000 0000 0000 f03f  .......?
00000018: 3ff0 0000 0000 0000  ?.......
00000020: 3f88 0000 0000 0000  ?.......
```