### PR TITLE
feat: implement warning suppression comments.

### DIFF
--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -6,7 +6,7 @@ module implements the YARA compiler.
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -55,9 +55,9 @@ pub(crate) use crate::compiler::context::*;
 pub(crate) use crate::compiler::ir::*;
 #[doc(inline)]
 pub use crate::compiler::rules::*;
-
 #[doc(inline)]
 pub use crate::compiler::warnings::*;
+use crate::compiler::wsh::WarningSuppressionHook;
 use crate::errors::{IncludeError, IncludeNotAllowed, IncludeNotFound};
 use crate::linters::LinterResult;
 use crate::models::PatternKind;
@@ -76,6 +76,7 @@ pub mod base64;
 pub mod errors;
 pub mod linters;
 pub mod warnings;
+pub mod wsh;
 
 /// A structure that describes some YARA source code.
 ///
@@ -560,9 +561,13 @@ impl<'a> Compiler<'a> {
         let ast = match src.as_str() {
             Ok(src) => {
                 // Parse the source code and build the Abstract Syntax Tree.
-                let cst = CSTStream::from(Parser::new(src.as_bytes()));
+                let cst = Parser::new(src.as_bytes());
+                let cst =
+                    WarningSuppressionHook::from(cst).hook(|warning, span| {
+                        self.warnings.suppress(warning, span);
+                    });
 
-                AST::from(cst)
+                AST::from(CSTStream::new(src.as_bytes(), cst))
             }
             Err(err) => {
                 let span_start = err.valid_up_to();
@@ -595,6 +600,8 @@ impl<'a> Compiler<'a> {
         let existing_errors = self.errors.len();
 
         self.c_items(ast.items());
+
+        self.warnings.clear_suppressed();
 
         self.errors.extend(
             ast.into_errors()
@@ -2783,8 +2790,14 @@ pub struct InvalidWarningCode(String);
 /// warnings types.
 pub(crate) struct Warnings {
     warnings: Vec<Warning>,
+    /// Maximum number of warnings that will be stored in `warnings`.
     max_warnings: usize,
+    /// Warnings that are globally disabled.
     disabled_warnings: HashSet<String>,
+    /// Warnings that are suppressed for a specific code span. Keys are
+    /// warning identifiers, and values are the code spans in which the
+    /// warning is disabled.
+    suppressed_warnings: HashMap<String, Vec<Span>>,
 }
 
 impl Default for Warnings {
@@ -2793,6 +2806,7 @@ impl Default for Warnings {
             warnings: Vec::new(),
             max_warnings: 100,
             disabled_warnings: HashSet::default(),
+            suppressed_warnings: HashMap::default(),
         }
     }
 }
@@ -2806,7 +2820,24 @@ impl Warnings {
     pub fn add(&mut self, f: impl FnOnce() -> Warning) {
         if self.warnings.len() < self.max_warnings {
             let warning = f();
-            if !self.disabled_warnings.contains(warning.code()) {
+            let mut warn = !self.disabled_warnings.contains(warning.code());
+
+            if warn {
+                if let Some(spans) =
+                    self.suppressed_warnings.get(warning.code())
+                {
+                    'l: for disabled_span in spans {
+                        for label in warning.labels() {
+                            if disabled_span.contains(label.span()) {
+                                warn = false;
+                                break 'l;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if warn {
                 self.warnings.push(warning);
             }
         }
@@ -2847,6 +2878,18 @@ impl Warnings {
                 self.disabled_warnings.insert(c.to_string());
             }
         }
+    }
+
+    /// Clear suppressed warnings.
+    pub fn clear_suppressed(&mut self) {
+        self.suppressed_warnings.clear();
+    }
+
+    pub fn suppress(&mut self, code: &str, span: Span) {
+        self.suppressed_warnings
+            .entry(code.to_string())
+            .or_default()
+            .push(span);
     }
 
     #[inline]

--- a/lib/src/compiler/report.rs
+++ b/lib/src/compiler/report.rs
@@ -248,6 +248,13 @@ pub struct Label<'a> {
     text: &'a str,
 }
 
+impl Label<'_> {
+    #[inline]
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
 /// Represents a footer in an error or warning report.
 #[derive(Serialize)]
 pub struct Footer<'a> {

--- a/lib/src/compiler/tests/testdata/warnings/no_warnings.in
+++ b/lib/src/compiler/tests/testdata/warnings/no_warnings.in
@@ -65,3 +65,22 @@ rule test_9 {
         uint16(0) == 0 or uint16(0) == 0xFFFF or
         uint32(0) == 0 or uint32(0) == 0xFFFFFFFF
 }
+
+rule test_10 {
+  strings:
+    // suppress: text_as_hex
+    $a = { 61 62 63 64 }
+    $b = { 61 62 63 64 } // suppress: text_as_hex
+  condition:
+    $a and $b or true // suppress: invariant_expr
+}
+
+// suppress: text_as_hex
+// suppress: invariant_expr
+rule test_11 {
+  strings:
+    $a = { 61 62 63 64 }
+    $b = { 61 62 63 64 }
+  condition:
+    $a and $b or true
+}

--- a/lib/src/compiler/wsh.rs
+++ b/lib/src/compiler/wsh.rs
@@ -1,0 +1,205 @@
+use std::str::from_utf8;
+
+use regex::bytes::Regex;
+
+use yara_x_parser::cst::{CSTStream, Event, SyntaxKind};
+use yara_x_parser::Span;
+
+/// This type hooks into a stream of [`cst::Event`] and invokes a callback for
+/// each comment that suppresses a warning.
+///
+/// YARA users can suppress specific warnings by adding specially formatted
+/// comments in rules' code. For example:
+///
+/// ```text
+/// // suppress: text_as_hex
+/// rule dummy {
+///   ...
+/// }
+/// ```
+///
+/// In the example above, the `text_as_hex` warning will be suppressed for the
+/// entire `dummy` rule. Similarly, in the following example, the `invariant_expr`
+/// warning will be suppressed for the expression `true`:
+///
+/// ```text
+/// rule dummy {
+///   condition:
+///      // suppress: invariant_expr
+///      true
+/// }
+/// ```
+///
+/// The purpose of [`WarningSuppressionHook`] is to detect these suppression
+/// comments and call a user-provided function with the corresponding warning
+/// identifier and the span of code where the suppression applies. This mechanism
+/// allows determining whether a warning should be emitted.
+///
+pub(crate) struct WarningSuppressionHook<'src, I, F>
+where
+    I: Iterator<Item = Event>,
+    F: FnMut(&'src str, Span),
+{
+    /// Input stream.
+    cst_stream: CSTStream<'src, I>,
+    /// Hook function.
+    f: Option<F>,
+    /// Regex used for finding warning suppression comments.
+    suppress_re: Regex,
+    /// The starting and ending offsets of the line of code being processed.
+    /// This is set to `None` after every line break.
+    line_span: Option<Span>,
+    /// Comments already seen in the stream of CST events that may not a have
+    /// a code span assigned yet.
+    pending_comments: Vec<PendingComment<'src>>,
+}
+
+#[derive(Debug)]
+struct PendingComment<'src> {
+    /// Comment's text.
+    text: &'src [u8],
+    /// Span of code that the comment refers to.
+    code_span: Option<Span>,
+}
+
+impl<'src, I, F> WarningSuppressionHook<'src, I, F>
+where
+    I: Iterator<Item = Event>,
+    F: FnMut(&'src str, Span),
+{
+    /// Sets the hook function to `f`.
+    ///
+    /// The function receives two arguments, the warning identifier and the
+    /// span of code for which the warning must be suppressed.
+    pub fn hook(mut self, f: F) -> Self {
+        self.f = Some(f);
+        self
+    }
+}
+
+impl<'src, I, F, C> From<C> for WarningSuppressionHook<'src, I, F>
+where
+    C: Into<CSTStream<'src, I>>,
+    I: Iterator<Item = Event>,
+    F: FnMut(&'src str, Span),
+{
+    fn from(cst_events: C) -> Self {
+        Self {
+            f: None,
+            line_span: None,
+            cst_stream: cst_events.into(),
+            suppress_re: Regex::new(r"suppress: (\w+)").unwrap(),
+            pending_comments: vec![],
+        }
+    }
+}
+
+impl<'src, I, F> Iterator for WarningSuppressionHook<'src, I, F>
+where
+    I: Iterator<Item = Event>,
+    F: FnMut(&'src str, Span),
+{
+    type Item = Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let event = self.cst_stream.next()?;
+
+        match event {
+            Event::Token { kind: SyntaxKind::WHITESPACE, .. } => {
+                // do nothing
+            }
+            Event::Token { kind: SyntaxKind::NEWLINE, .. }
+            | Event::End { kind: SyntaxKind::SOURCE_FILE, .. } => {
+                self.pending_comments.retain_mut(|comment| {
+                    if comment.code_span.is_none() {
+                        comment.code_span = self.line_span.clone();
+                    }
+                    if let Some(code_span) = &comment.code_span {
+                        if let Some(hook) = &mut self.f {
+                            if let Some(warning_id) = self
+                                .suppress_re
+                                .captures(comment.text)
+                                .and_then(|captures| captures.get(1))
+                                .map(|m| m.as_bytes())
+                                .and_then(|m| from_utf8(m).ok())
+                            {
+                                hook(warning_id, code_span.clone());
+                            }
+                        }
+                    }
+                    comment.code_span.is_none()
+                });
+                self.line_span = None;
+            }
+            Event::Token { kind: SyntaxKind::COMMENT, ref span } => {
+                self.pending_comments.push(PendingComment {
+                    text: self.cst_stream.source().get(span.range()).unwrap(),
+                    code_span: self.line_span.clone(),
+                });
+            }
+            Event::Token { ref span, .. } => {
+                if let Some(current_span) = &mut self.line_span {
+                    self.line_span = Some(current_span.combine(span));
+                } else {
+                    self.line_span = Some(span.clone())
+                };
+            }
+            Event::Begin { kind, ref span }
+                if kind == SyntaxKind::RULE_DECL
+                    || kind == SyntaxKind::PATTERN_DEF =>
+            {
+                for comment in self.pending_comments.iter_mut() {
+                    comment.code_span = Some(span.clone());
+                }
+            }
+            _ => {}
+        }
+
+        Some(event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use yara_x_parser::cst::Event;
+    use yara_x_parser::{Parser, Span};
+
+    use crate::compiler::wsh::WarningSuppressionHook;
+
+    #[test]
+    fn warning_suppression() {
+        let parser = Parser::new(
+            b"
+// suppress: foo
+rule test { // suppress: bar
+    // suppress: baz
+    condition: true
+}
+        ",
+        );
+
+        let mut map: HashMap<&str, Vec<Span>> = HashMap::new();
+
+        let cst =
+            WarningSuppressionHook::from(parser).hook(|warning, span| {
+                map.entry(warning).or_default().push(span);
+            });
+
+        let _ = cst.collect::<Vec<Event>>();
+
+        let expected: HashMap<_, _> = vec![
+            // foo is suppressed for the whole rule
+            ("foo", vec![Span(18..89)]),
+            // bar is suppressed for "rule test {"
+            ("bar", vec![Span(18..29)]),
+            // baz is suppressed for "condition: true"
+            ("baz", vec![Span(72..87)]),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(map, expected);
+    }
+}

--- a/parser/src/cst/mod.rs
+++ b/parser/src/cst/mod.rs
@@ -92,7 +92,14 @@ impl<'src, I> CSTStream<'src, I>
 where
     I: Iterator<Item = Event>,
 {
-    pub(crate) fn new(source: &'src [u8], events: I) -> Self {
+    /// Creates a new [`CSTStream`] from source code and some iterator
+    /// that returns the parsed source code in the form of a sequence
+    /// of [`Event`].
+    ///
+    /// This API is not meant to be public, but it is used by the
+    /// compiler in the yara_x crate.
+    #[doc(hidden)]
+    pub fn new(source: &'src [u8], events: I) -> Self {
         Self {
             source,
             events,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -80,6 +80,24 @@ impl Span {
         Self(self.0.start..other.0.end)
     }
 
+    /// Returns true if this span completely contains `other`.
+    ///
+    /// Both the start and end of the `other` span must be within the limits of
+    /// this span.
+    ///
+    /// ```
+    /// # use yara_x_parser::Span;
+    /// assert!(Span(0..3).contains(&Span(0..2)));
+    /// assert!(Span(0..3).contains(&Span(1..3)));
+    /// assert!(Span(0..3).contains(&Span(0..3)));
+    /// assert!(!Span(0..3).contains(&Span(0..4)));
+    /// assert!(!Span(0..3).contains(&Span(3..4)));
+    /// ```
+    pub fn contains(&self, other: &Self) -> bool {
+        self.0.contains(&other.0.start)
+            && self.0.contains(&other.0.end.saturating_sub(1))
+    }
+
     /// Returns a new [`Span`] that is a subspan of the original one.
     ///
     /// `start` and `end` are the starting and ending offset of the subspan,

--- a/site/content/docs/writing_rules/differences.md
+++ b/site/content/docs/writing_rules/differences.md
@@ -9,7 +9,7 @@ menu:
   docs:
     parent: ""
     identifier: "differences"
-weight: 300
+weight: 310
 toc: true
 seo:
   title: "" # custom title (optional)

--- a/site/content/docs/writing_rules/disabling_warnings.md
+++ b/site/content/docs/writing_rules/disabling_warnings.md
@@ -1,0 +1,90 @@
+---
+title: "Disabling warnings"
+description: "Explains how to use comments for disabling warnings"
+summary: ""
+date: 2023-09-07T16:13:18+02:00
+lastmod: 2023-09-07T16:13:18+02:00
+draft: false
+menu:
+  docs:
+    parent: ""
+    identifier: "undefined"
+weight: 300
+toc: true
+seo:
+  title: "Disabling warnings"
+  description: "Explains how to use comments for disabling warnings"
+  noindex: false # false (default) or true
+---
+
+One of the key strengths of YARA-X is its improved feedback system. It provides 
+more comprehensive and informative warnings during rule compilation, helping 
+users catch issues early and write better rules. However, there are situations 
+where not all warnings are helpful, especially when you're dealing with edge 
+cases or legacy patterns.
+
+You can disable specific kinds of warnings using the `--disable-warnings=<WARNING_ID>` 
+command-line option, or through the configuration file. But these methods apply
+globally, they affect the entire rule set, offering little flexibility when you
+want to silence a specific warning in just one location.
+
+Individual warnings at specific locations of your code can be disabled by using 
+a comment of the form: `// suppress: <WARNING_ID>`.
+
+This allows you to disable a warning only for a specific rule, pattern, or line, 
+depending on the comment's position.
+
+#### Examples
+
+```
+rule example_1
+{
+    condition:
+        true // suppress: invariant_expr
+}
+
+rule example_2
+{
+    condition:
+        // suppress: invariant_expr
+        true 
+}
+
+// suppress: invariant_expr
+rule example_2
+{
+    condition:
+        true 
+}
+```
+
+The effect of a `// suppress:` comment depends on where it appears in the code:
+
+* Before a rule declaration: applies to the entire rule.
+
+  ```
+  // suppress: some_warning
+  rule my_rule { ... }
+  ```
+
+* Before a pattern declaration: applies to the entire pattern.
+
+  ```
+  // suppress: text_as_hex
+  $a = { 61 61 61 61 }
+  ```
+
+* At the end of a non-empty line: applies to the code that precedes it on the same line.
+
+
+  ```
+  condition: true // suppress: invariant_expr
+  ```
+
+* At the start of a line (on its own line): applies to the code on the line immediately following.
+
+  ```
+  condition: 
+     // suppress: invariant_expr
+     true 
+  ```


### PR DESCRIPTION
Now you can use `// suppress: some_warning_id` comments for disabling specific warnings.