### PR TITLE
feat: Support boolean in console.log()

### DIFF
--- a/lib/src/modules/console.rs
+++ b/lib/src/modules/console.rs
@@ -28,6 +28,22 @@ fn log_msg_str(
 }
 
 #[module_export(name = "log")]
+fn log_bool(ctx: &mut ScanContext, b: bool) -> bool {
+    ctx.console_log(format!("{b}"));
+    true
+}
+
+#[module_export(name = "log")]
+fn log_msg_bool(
+    ctx: &mut ScanContext,
+    message: RuntimeString,
+    b: bool,
+) -> bool {
+    ctx.console_log(format!("{}{}", message.as_bstr(ctx), b));
+    true
+}
+
+#[module_export(name = "log")]
 fn log_int(ctx: &mut ScanContext, i: i64) -> bool {
     ctx.console_log(format!("{i}"));
     true

--- a/site/content/docs/modules/console.md
+++ b/site/content/docs/modules/console.md
@@ -74,6 +74,18 @@ Logs the given message and float number.
 
 Example: `console.log("Entropy: ", math.entropy(0, filesize))`
 
+### log(boolean)
+
+Logs the given boolean value.
+
+Example: `console.log(pe.is_32bit())`
+
+### log(message, boolean)
+
+Logs the given message and boolean value.
+
+Example: `console.log("32 bit PE: ", pe.is_32bit())`
+
 ### hex(integer)
 
 Logs the given number as hex.


### PR DESCRIPTION
Add support for handling boolean arguments in console.log, so you can now do things like "console.log(pe.is_32bit())" since that returns a boolean in YARA-X but an integer in original YARA.