### PR TITLE
feat: implement transitive includes

### DIFF
--- a/lib/src/compiler/ir/tests/mod.rs
+++ b/lib/src/compiler/ir/tests/mod.rs
@@ -2,6 +2,7 @@ use std::mem::size_of;
 
 use crate::compiler::{Expr, IR};
 use crate::types::TypeValue;
+use crate::SourceCode;
 
 #[test]
 fn expr_size() {
@@ -91,7 +92,10 @@ fn ir() {
             path.with_extension("no-folding.ir")
         };
 
-        let source = fs::read_to_string(path).unwrap();
+        let source = fs::read_to_string(&path).unwrap();
+        let source_code = SourceCode::from(source.as_str()).with_origin(
+            &path.as_os_str().to_str().expect("Path should be valid UTF-8"),
+        );
 
         let output_file = mint.new_goldenfile(&output_path).unwrap();
         let mut compiler = Compiler::new();
@@ -100,7 +104,7 @@ fn ir() {
         compiler
             .hoisting(false)
             .set_ir_writer(w)
-            .add_source(source.as_str())
+            .add_source(source_code.clone())
             .unwrap();
 
         #[cfg(feature = "constant-folding")]
@@ -113,7 +117,7 @@ fn ir() {
             compiler
                 .hoisting(false)
                 .set_ir_writer(w)
-                .add_source(source.as_str())
+                .add_source(source_code.clone())
                 .unwrap();
 
             let hoisting_output = output_path.with_extension("hoisting.ir");
@@ -124,7 +128,7 @@ fn ir() {
             compiler
                 .hoisting(true)
                 .set_ir_writer(w)
-                .add_source(source.as_str())
+                .add_source(source_code.clone())
                 .unwrap();
         }
     });

--- a/lib/src/compiler/ir/tests/testdata/10-dependency.yar
+++ b/lib/src/compiler/ir/tests/testdata/10-dependency.yar
@@ -1,0 +1,4 @@
+rule test_10_dep {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/10.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/10.cse.ir
@@ -1,0 +1,6 @@
+RULE test_10_dep
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  0: SYMBOL Rule(RuleId(0)) -- parent: None 
+

--- a/lib/src/compiler/ir/tests/testdata/10.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/10.hoisting.ir
@@ -1,0 +1,6 @@
+RULE test_10_dep
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  0: SYMBOL Rule(RuleId(0)) -- parent: None 
+

--- a/lib/src/compiler/ir/tests/testdata/10.in
+++ b/lib/src/compiler/ir/tests/testdata/10.in
@@ -1,0 +1,8 @@
+// simple include test
+
+include "10-dependency.yar"
+
+rule test {
+  condition:
+    test_10_dep
+}

--- a/lib/src/compiler/ir/tests/testdata/10.ir
+++ b/lib/src/compiler/ir/tests/testdata/10.ir
@@ -1,0 +1,6 @@
+RULE test_10_dep
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  0: SYMBOL Rule(RuleId(0)) -- parent: None 
+

--- a/lib/src/compiler/ir/tests/testdata/11-dependency-a.yar
+++ b/lib/src/compiler/ir/tests/testdata/11-dependency-a.yar
@@ -1,0 +1,4 @@
+rule test_11_dep_a {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/11-dependency-b.yar
+++ b/lib/src/compiler/ir/tests/testdata/11-dependency-b.yar
@@ -1,0 +1,4 @@
+rule test_11_dep_b {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/11.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/11.cse.ir
@@ -1,0 +1,11 @@
+RULE test_11_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_11_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  2: AND -- hash: 0xcef175606325cfd1 -- parent: None 
+    0: SYMBOL Rule(RuleId(0)) -- parent: 2 
+    1: SYMBOL Rule(RuleId(1)) -- parent: 2 
+

--- a/lib/src/compiler/ir/tests/testdata/11.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/11.hoisting.ir
@@ -1,0 +1,11 @@
+RULE test_11_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_11_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  2: AND -- hash: 0xcef175606325cfd1 -- parent: None 
+    0: SYMBOL Rule(RuleId(0)) -- parent: 2 
+    1: SYMBOL Rule(RuleId(1)) -- parent: 2 
+

--- a/lib/src/compiler/ir/tests/testdata/11.in
+++ b/lib/src/compiler/ir/tests/testdata/11.in
@@ -1,0 +1,9 @@
+// multiple include test
+
+include "11-dependency-a.yar"
+include "11-dependency-b.yar"
+
+rule test {
+  condition:
+    test_11_dep_a and test_11_dep_b
+}

--- a/lib/src/compiler/ir/tests/testdata/11.ir
+++ b/lib/src/compiler/ir/tests/testdata/11.ir
@@ -1,0 +1,11 @@
+RULE test_11_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_11_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  2: AND -- hash: 0xcef175606325cfd1 -- parent: None 
+    0: SYMBOL Rule(RuleId(0)) -- parent: 2 
+    1: SYMBOL Rule(RuleId(1)) -- parent: 2 
+

--- a/lib/src/compiler/ir/tests/testdata/12-dependency-a.yar
+++ b/lib/src/compiler/ir/tests/testdata/12-dependency-a.yar
@@ -1,0 +1,6 @@
+include "12-dependency-b.yar"
+
+rule test_12_dep_a {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/12-dependency-b.yar
+++ b/lib/src/compiler/ir/tests/testdata/12-dependency-b.yar
@@ -1,0 +1,4 @@
+rule test_12_dep_b {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/12.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/12.cse.ir
@@ -1,0 +1,11 @@
+RULE test_12_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_12_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  2: AND -- hash: 0x19dac66f1335e415 -- parent: None 
+    0: SYMBOL Rule(RuleId(1)) -- parent: 2 
+    1: SYMBOL Rule(RuleId(0)) -- parent: 2 
+

--- a/lib/src/compiler/ir/tests/testdata/12.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/12.hoisting.ir
@@ -1,0 +1,11 @@
+RULE test_12_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_12_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  2: AND -- hash: 0x19dac66f1335e415 -- parent: None 
+    0: SYMBOL Rule(RuleId(1)) -- parent: 2 
+    1: SYMBOL Rule(RuleId(0)) -- parent: 2 
+

--- a/lib/src/compiler/ir/tests/testdata/12.in
+++ b/lib/src/compiler/ir/tests/testdata/12.in
@@ -1,0 +1,8 @@
+// chain include test
+
+include "12-dependency-a.yar"
+
+rule test {
+  condition:
+    test_12_dep_a and test_12_dep_b
+}

--- a/lib/src/compiler/ir/tests/testdata/12.ir
+++ b/lib/src/compiler/ir/tests/testdata/12.ir
@@ -1,0 +1,11 @@
+RULE test_12_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_12_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  2: AND -- hash: 0x19dac66f1335e415 -- parent: None 
+    0: SYMBOL Rule(RuleId(1)) -- parent: 2 
+    1: SYMBOL Rule(RuleId(0)) -- parent: 2 
+

--- a/lib/src/compiler/ir/tests/testdata/13-dependency-a.yar
+++ b/lib/src/compiler/ir/tests/testdata/13-dependency-a.yar
@@ -1,0 +1,6 @@
+include "13-dependency-c.yar"
+
+rule test_13_dep_a {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/13-dependency-b.yar
+++ b/lib/src/compiler/ir/tests/testdata/13-dependency-b.yar
@@ -1,0 +1,6 @@
+include "13-dependency-c.yar"
+
+rule test_13_dep_b {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/13-dependency-c.yar
+++ b/lib/src/compiler/ir/tests/testdata/13-dependency-c.yar
@@ -1,0 +1,4 @@
+rule test_13_dep_c {
+  condition:
+    true
+}

--- a/lib/src/compiler/ir/tests/testdata/13.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.cse.ir
@@ -1,0 +1,15 @@
+RULE test_13_dep_c
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_13_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_13_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  3: AND -- hash: 0x50a68ffd40424bc1 -- parent: None 
+    0: SYMBOL Rule(RuleId(1)) -- parent: 3 
+    1: SYMBOL Rule(RuleId(2)) -- parent: 3 
+    2: SYMBOL Rule(RuleId(0)) -- parent: 3 
+

--- a/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
@@ -1,0 +1,15 @@
+RULE test_13_dep_c
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_13_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_13_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  3: AND -- hash: 0x50a68ffd40424bc1 -- parent: None 
+    0: SYMBOL Rule(RuleId(1)) -- parent: 3 
+    1: SYMBOL Rule(RuleId(2)) -- parent: 3 
+    2: SYMBOL Rule(RuleId(0)) -- parent: 3 
+

--- a/lib/src/compiler/ir/tests/testdata/13.in
+++ b/lib/src/compiler/ir/tests/testdata/13.in
@@ -1,0 +1,9 @@
+// diamond include test
+
+include "13-dependency-a.yar"
+include "13-dependency-b.yar"
+
+rule test {
+  condition:
+    test_13_dep_a and test_13_dep_b and test_13_dep_c
+}

--- a/lib/src/compiler/ir/tests/testdata/13.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.ir
@@ -1,0 +1,15 @@
+RULE test_13_dep_c
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_13_dep_a
+  0: CONST boolean(true) -- parent: None 
+
+RULE test_13_dep_b
+  0: CONST boolean(true) -- parent: None 
+
+RULE test
+  3: AND -- hash: 0x50a68ffd40424bc1 -- parent: None 
+    0: SYMBOL Rule(RuleId(1)) -- parent: 3 
+    1: SYMBOL Rule(RuleId(2)) -- parent: 3 
+    2: SYMBOL Rule(RuleId(0)) -- parent: 3 
+

--- a/lib/src/compiler/tests/testdata/errors/143.out
+++ b/lib/src/compiler/tests/testdata/errors/143.out
@@ -1,5 +1,5 @@
 error[E001]: syntax error
- --> src/compiler/tests/testdata/includes/included_error.yar:1:15
+ --> ./src/compiler/tests/testdata/includes/included_error.yar:1:15
   |
 1 | rule included {
   |               ^ expecting `condition`, found end of file

--- a/lib/src/compiler/tests/testdata/errors/146.in
+++ b/lib/src/compiler/tests/testdata/errors/146.in
@@ -1,0 +1,8 @@
+// source origin required
+
+include "146.in"
+
+rule test {
+  condition:
+    false
+}

--- a/lib/src/compiler/tests/testdata/errors/146.out
+++ b/lib/src/compiler/tests/testdata/errors/146.out
@@ -1,0 +1,8 @@
+error[E042]: error including file
+ --> ./src/compiler/tests/testdata/errors/146.in:3:1
+  |
+3 | include "146.in"
+  | ^^^^^^^^^^^^^^^^ failed with error: File was already included.
+Full include stack:
+↳ <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/146.in
+  |

--- a/lib/src/compiler/tests/testdata/errors/147-dependency.yar
+++ b/lib/src/compiler/tests/testdata/errors/147-dependency.yar
@@ -1,0 +1,1 @@
+include "147.in"

--- a/lib/src/compiler/tests/testdata/errors/147.in
+++ b/lib/src/compiler/tests/testdata/errors/147.in
@@ -1,0 +1,3 @@
+// source origin required
+
+include "147-dependency.yar"

--- a/lib/src/compiler/tests/testdata/errors/147.out
+++ b/lib/src/compiler/tests/testdata/errors/147.out
@@ -1,0 +1,9 @@
+error[E042]: error including file
+ --> <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/147-dependency.yar:1:1
+  |
+1 | include "147.in"
+  | ^^^^^^^^^^^^^^^^ failed with error: File was already included.
+Full include stack:
+↳ <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/147.in
+  ↳ <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/147-dependency.yar
+  |

--- a/lib/src/compiler/tests/testdata/errors/148-dependency-a.yar
+++ b/lib/src/compiler/tests/testdata/errors/148-dependency-a.yar
@@ -1,0 +1,1 @@
+include "148-dependency-b.yar"

--- a/lib/src/compiler/tests/testdata/errors/148-dependency-b.yar
+++ b/lib/src/compiler/tests/testdata/errors/148-dependency-b.yar
@@ -1,0 +1,1 @@
+include "148.in"

--- a/lib/src/compiler/tests/testdata/errors/148.in
+++ b/lib/src/compiler/tests/testdata/errors/148.in
@@ -1,0 +1,3 @@
+// source origin required
+
+include "148-dependency-a.yar"

--- a/lib/src/compiler/tests/testdata/errors/148.out
+++ b/lib/src/compiler/tests/testdata/errors/148.out
@@ -1,0 +1,10 @@
+error[E042]: error including file
+ --> <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/148-dependency-b.yar:1:1
+  |
+1 | include "148.in"
+  | ^^^^^^^^^^^^^^^^ failed with error: File was already included.
+Full include stack:
+↳ <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/148.in
+  ↳ <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/148-dependency-a.yar
+    ↳ <CARGO_MANIFEST_DIR>/src/compiler/tests/testdata/errors/148-dependency-b.yar
+  |


### PR DESCRIPTION
The `include` implementation introduced to YARA-X is not the same as in YARA. The most notable difference is that it does not support transitive includes. I.e. if file `A` includes `B`, `B` cannot then include more files relative to its location (I'm not sure if absolute includes work in such a case). We need this transitive behavior in order to migrate to YARA-X in Gen Digital (Avast).

This PR attempts to add this functionality, related changes, improvements, and tests. However, I'm not 100% sure what is the best way to introduce this stuff, so this is kind of a draft. I fully expect you might have some notes or reservations. I kindly ask you to have a look and point me to an acceptable solution. I will try to accommodate the best I can. I believe the newly introduced tests demonstrate what I try to achieve.