### PR TITLE
feat: implement regexp validation for metadata

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -138,6 +138,11 @@ jobs:
       env:
         RUSTFLAGS: ${{ matrix.rust_flags }}
 
+    - name: Run CLI tests
+      run: cargo test -p yara-x-cli --bin yr
+      env:
+        RUSTFLAGS: ${{ matrix.rust_flags }}
+
     - name: Run doc tests
       run: cargo test --doc
       env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -138,11 +138,6 @@ jobs:
       env:
         RUSTFLAGS: ${{ matrix.rust_flags }}
 
-    - name: Run CLI tests
-      run: cargo test -p yara-x-cli --bin yr
-      env:
-        RUSTFLAGS: ${{ matrix.rust_flags }}
-
     - name: Run doc tests
       run: cargo test --doc
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,6 +4836,7 @@ dependencies = [
  "log",
  "predicates",
  "protobuf",
+ "regex",
  "serde",
  "serde_json",
  "strum",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,6 +54,7 @@ enable-ansi-support = { workspace = true }
 env_logger = { workspace = true, optional = true, features = ["auto-color"] }
 log = { workspace = true, optional = true }
 protobuf = { workspace = true }
+regex = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde = { workspace = true, features = ["derive"] }
 strum = { workspace = true }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -118,6 +118,9 @@ pub struct RuleNameConfig {
 pub struct MetadataConfig {
     #[serde(rename = "type")]
     pub ty: MetaValueType,
+    /// A regular expression that the metadata value must match. Only
+    /// applies if type is MetaValueType::String.
+    pub regexp: Option<String>,
     /// Specifies whether the metadata is required or optional.
     #[serde(default)]
     pub required: bool,

--- a/cli/src/tests/check.rs
+++ b/cli/src/tests/check.rs
@@ -21,6 +21,7 @@ fn metadata() {
             sha256 = { type = "sha256" }
             required = { type = "string", required = true }
             optional = { type = "string" }
+            regexp = { type = "string", regexp = "(foo|bar)" }
             "#,
         )
         .unwrap();
@@ -42,14 +43,14 @@ fn metadata() {
   |      --- required metadata `required` not found
   |
 warning[text_as_hex]: hex pattern could be written as text literal
- --> src/tests/testdata/foo.yar:9:5
-  |
-9 |     $foo_hex = { 66 6f 6f }
-  |     ---------------------
-  |     |
-  |     this pattern can be written as a text literal
-  |     help: replace with "foo"
-  |
+  --> src/tests/testdata/foo.yar:10:5
+   |
+10 |     $foo_hex = { 66 6f 6f }
+   |     ---------------------
+   |     |
+   |     this pattern can be written as a text literal
+   |     help: replace with "foo"
+   |
 "#,
         );
 
@@ -66,6 +67,7 @@ warning[text_as_hex]: hex pattern could be written as text literal
                 int = 3.14
                 float = "not a float"
                 string = true
+                regexp = "baz"
               condition:
                 true
             }"#,
@@ -83,23 +85,36 @@ warning[text_as_hex]: hex pattern could be written as text literal
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `md5` is not valid",
         ))
+        .stderr(predicate::str::contains("`md5` must be a MD5"))
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `sha1` is not valid",
         ))
+        .stderr(predicate::str::contains("`sha1` must be a SHA-1"))
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `sha256` is not valid",
         ))
+        .stderr(predicate::str::contains("`sha256` must be a SHA-256"))
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `bool` is not valid",
         ))
+        .stderr(predicate::str::contains("`bool` must be a bool"))
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `int` is not valid",
         ))
+        .stderr(predicate::str::contains("`int` must be an int"))
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `float` is not valid",
         ))
+        .stderr(predicate::str::contains("`float` must be a float"))
         .stderr(predicate::str::contains(
             "warning[invalid_metadata]: metadata `string` is not valid",
+        ))
+        .stderr(predicate::str::contains("`string` must be a string"))
+        .stderr(predicate::str::contains(
+            "warning[invalid_metadata]: metadata `regexp` is not valid",
+        ))
+        .stderr(predicate::str::contains(
+            "`regexp` must be a string that matches `/(foo|bar)/`",
         ));
 }
 

--- a/cli/src/tests/scan.rs
+++ b/cli/src/tests/scan.rs
@@ -147,7 +147,7 @@ fn print_meta() {
         .arg("src/tests/testdata/dummy.file")
         .assert()
         .success()
-        .stdout("foo [string=\"foo\",bool=true,int=1,float=3.14] src/tests/testdata/dummy.file\n");
+        .stdout("foo [string=\"foo\",bool=true,int=1,float=3.14,regexp=\"foo\"] src/tests/testdata/dummy.file\n");
 }
 
 #[test]

--- a/cli/src/tests/testdata/foo.yar
+++ b/cli/src/tests/testdata/foo.yar
@@ -4,6 +4,7 @@ rule foo : bar baz {
     bool = true
     int = 1
     float = 3.14
+    regexp = "foo"
   strings:
     $foo = "foo"
     $foo_hex = { 66 6f 6f }

--- a/lib/src/compiler/linters.rs
+++ b/lib/src/compiler/linters.rs
@@ -139,7 +139,7 @@ type Predicate<'a> = dyn Fn(&Meta) -> bool + 'a;
 ///   |
 ///   = note: allowed tags: foo, bar"#);
 pub struct Tags {
-    allow_list: Vec<String>,
+    allowed: Vec<String>,
     regex: Option<String>,
     compiled_regex: Option<Regex>,
     error: bool,
@@ -148,12 +148,7 @@ pub struct Tags {
 impl Tags {
     /// A list of strings that tags for each rule must match one of.
     pub(crate) fn from_list(list: Vec<String>) -> Self {
-        Self {
-            allow_list: list,
-            regex: None,
-            compiled_regex: None,
-            error: false,
-        }
+        Self { allowed: list, regex: None, compiled_regex: None, error: false }
     }
 
     /// Regular expression that tags for each rule must match.
@@ -163,7 +158,7 @@ impl Tags {
         let regex = regex.into();
         let compiled_regex = Some(Regex::new(regex.as_str())?);
         let tags = Self {
-            allow_list: Vec::new(),
+            allowed: Vec::new(),
             regex: Some(regex),
             compiled_regex,
             error: false,
@@ -195,9 +190,9 @@ impl LinterInternal for Tags {
 
         let mut results: Vec<Warning> = Vec::new();
         let tags = rule.tags.as_ref().unwrap();
-        if !self.allow_list.is_empty() {
+        if !self.allowed.is_empty() {
             for tag in tags.iter() {
-                if !self.allow_list.contains(&tag.name.to_string()) {
+                if !self.allowed.contains(&tag.name.to_string()) {
                     if self.error {
                         return LinterResult::Err(errors::UnknownTag::build(
                             report_builder,
@@ -205,7 +200,7 @@ impl LinterInternal for Tags {
                             tag.name.to_string(),
                             Some(format!(
                                 "allowed tags: {}",
-                                self.allow_list.join(", ")
+                                self.allowed.join(", ")
                             )),
                         ));
                     } else {
@@ -215,7 +210,7 @@ impl LinterInternal for Tags {
                             tag.name.to_string(),
                             Some(format!(
                                 "allowed tags: {}",
-                                self.allow_list.join(", ")
+                                self.allowed.join(", ")
                             )),
                         ));
                     }

--- a/site/content/docs/cli/config.md
+++ b/site/content/docs/cli/config.md
@@ -224,6 +224,7 @@ metadata field.
 author = { type = "string", required = true }
 date = { type = "integer" }
 file = { type = "hash", required = true, error = true }
+severity = { type = "string", regexp = "(LOW|HIGH)" }
 ```
 
 {{< callout title="Warning">}}
@@ -239,6 +240,7 @@ allowed.
   and is required. If the field is not present or has the wrong type it will
   cause
   an error instead of a warning.
+- The `severity` field must be a string that matches the regexp `(LOW|HIGH)`.
 
 Supported metadata types are `"string"`, `"integer"`, `"float"`, `"bool"`,
 `"md5"`, `"sha1"`, `"sha256"`, or `"hash"`. The `"md5"`, `"sha1"` and `"sha256"`
@@ -249,6 +251,10 @@ The `"hash"` type is another convenience type that checks for any of the valid
 hashes mentioned above. It is meant to be more flexible than requiring a
 specific hash type in every rule.
 
+Metadata entries of type `"string"` can be accompanied by a `regexp` field that
+contains a regular expression that must be matched by the metadata value. This
+field is ignored if the type is other than `"string"`.
+
 The default values for `required` and `error` are both `false`. This means that
 metadata fields are optional by default, and if they don't comply with the
 requirements established in the configuration file YARA-X will raise a warning.
@@ -258,7 +264,7 @@ By setting `error` to `true` these warnings are turned into errors.
 
 ```toml
 [check.tags]
-allow_list = ["APT", "CRIME"]
+allowed = ["APT", "CRIME"]
 regexp = "^(APT|CRIME)_"
 error = false
 ```
@@ -337,7 +343,7 @@ author = { type = "string", required = true }
 date = { type = "integer" }
 
 [check.tags]
-allow_list = ["APT", "CRIME"]
+allowed = ["APT", "CRIME"]
 error = true
 
 [warnings]


### PR DESCRIPTION
The config file now accepts the following:

```
[check.metadata]
my_meta = { type = "string", regexp = "(foo|bar)" }
```

In this case the metadata `my_meta` must be of type string and match the regexp `(foo|bar)`.