### PR TITLE
feat: support of "max-matches-per-pattern" parameter in CLI and Python API

### DIFF
--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -122,6 +122,12 @@ pub fn scan() -> Command {
                 .long_help(help::NO_MMAP_LONG_HELP)
         )
         .arg(
+            arg!(--"max-matches-per-pattern" <MATCHES>)
+                .help("Maximum number of matches per pattern")
+                .long_help(help::MAX_MATCHES_PER_PATTERN_LONG_HELP)
+                .value_parser(value_parser!(usize))
+        )
+        .arg(
             arg!(-o --"output-format" <FORMAT>)
                 .help("Output format for results")
                 .long_help(help::OUTPUT_FORMAT_LONG_HELP)
@@ -256,6 +262,7 @@ pub fn exec_scan(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
     let scan_list = args.get_flag("scan-list");
     let recursive = args.get_one::<usize>("recursive");
     let no_mmap = args.get_flag("no-mmap");
+    let max_matches_per_pattern = args.get_one::<usize>("max-matches-per-pattern");
 
     let timeout =
         args.get_one::<u64>("timeout").map(|t| Duration::from_secs(*t));
@@ -394,6 +401,10 @@ pub fn exec_scan(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
 
             if no_mmap {
                 scanner.use_mmap(false);
+            }
+
+            if let Some(max_matches_per_pattern) = max_matches_per_pattern {
+                scanner.max_matches_per_pattern(*max_matches_per_pattern);
             }
 
             scanner

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -262,7 +262,8 @@ pub fn exec_scan(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
     let scan_list = args.get_flag("scan-list");
     let recursive = args.get_one::<usize>("recursive");
     let no_mmap = args.get_flag("no-mmap");
-    let max_matches_per_pattern = args.get_one::<usize>("max-matches-per-pattern");
+    let max_matches_per_pattern =
+        args.get_one::<usize>("max-matches-per-pattern");
 
     let timeout =
         args.get_one::<u64>("timeout").map(|t| Duration::from_secs(*t));

--- a/cli/src/help.rs
+++ b/cli/src/help.rs
@@ -97,8 +97,8 @@ be converted. This behavior can be changed by using the `--filter` option."#;
 
 pub const INCLUDE_DIR_LONG_HELP: &str = r#"Directory in which to search for included files
 
-If not given, the current working directory is used. May be specified multiple times;
-directories will be searched in order."#;
+If not given, the current working directory is used. May be specified multiple 
+times; directories will be searched in order."#;
 
 pub const IGNORE_MODULE_LONG_HELP: &str = r#"Ignore rules that use the specified module
 
@@ -109,17 +109,20 @@ This option can be used more than once for ignored different modules."#;
 
 pub const NO_MMAP_LONG_HELP: &str = r#"Don't use memory-mapped files
 
-By default, large files are memory-mapped as this is typically faster than copying
-file contents into memory. However, this approach has a drawback: if another process
-truncates the file during scanning, a `SIGBUS` signal may occur and the YARA-X process
-will crash.
+By default, large files are memory-mapped as this is typically faster than 
+copying file contents into memory. However, this approach has a drawback: if 
+another process truncates the file during scanning, a `SIGBUS` signal may 
+occur and the YARA-X process will crash.
    
-This option disables memory mapping and forces the scanner to always read files into
-an in-memory buffer instead."#;
+This option disables memory mapping and forces the scanner to always read files
+into an in-memory buffer instead."#;
 
 pub const MAX_MATCHES_PER_PATTERN_LONG_HELP: &str = r#"Maximum number of matches per pattern
 
-When some pattern reaches the maximum number of patterns it won't produce more matches."#;
+When some pattern reaches the maximum number of occurrences it won't produce
+more matches. This can affect rules that rely on the number of occurrences of
+some pattern. For instance, the expression `#a > 100` will be false if this 
+limit is set to 100 or less."#;
 
 pub const MODULE_DATA_LONG_HELP: &str = r#"Pass FILE's content as extra data to MODULE
 
@@ -190,8 +193,8 @@ yr scan namespace:rules_dir scanned_file"#;
 
 pub const SCAN_PRINT_STRING_LONG_HELP: &str = r#"Print matching patterns
 
-The printed patterns can be optionally limited to <N> characters. By default they are limited
-to 120 characters.
+The printed patterns can be optionally limited to <N> characters. By default 
+they are limited to 120 characters.
 
 Examples:
 
@@ -200,14 +203,15 @@ Examples:
 
 pub const SCAN_RECURSIVE_LONG_HELP: &str = r#"Scan directories recursively
 
-When <TARGET_PATH> is a directory, this option enables recursive scanning of its contents.
-You can optionally specify a <MAX_DEPTH> to limit how deep the scan goes:
+When <TARGET_PATH> is a directory, this option enables recursive scanning
+of its contents. You can optionally specify a <MAX_DEPTH> to limit how deep
+the scan goes:
 
 --recursive     scan nested subdirectories with no depth limit.
 --recursive=0   scan only the files in <TARGET_PATH> (no subdirectories)
 --recursive=3   scan up to 3 levels deep, including nested subdirectories
 
-If --recursive is not specified, the default behavior is equivalent to --recursive=0.
+If --recursive is not specified, the default behavior is --recursive=0.
 
 Examples:
 

--- a/cli/src/help.rs
+++ b/cli/src/help.rs
@@ -117,6 +117,10 @@ will crash.
 This option disables memory mapping and forces the scanner to always read files into
 an in-memory buffer instead."#;
 
+pub const MAX_MATCHES_PER_PATTERN_LONG_HELP: &str = r#"Maximum number of matches per pattern
+
+When some pattern reaches the maximum number of patterns it won't produce more matches."#;
+
 pub const MODULE_DATA_LONG_HELP: &str = r#"Pass FILE's content as extra data to MODULE
 
 Some modules require supplementary data to work, in addition to the scanned

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -536,6 +536,13 @@ impl Scanner {
         self.inner.set_timeout(Duration::from_secs(seconds));
     }
 
+    /// Sets the maximum number of matches per pattern.
+    ///
+    /// When some pattern reaches the specified number of `matches` it won't produce more matches.
+    fn max_matches_per_pattern(&mut self, matches: usize) {
+        self.inner.max_matches_per_pattern(matches);
+    }
+
     /// Sets a callback that is invoked every time a YARA rule calls the
     /// `console` module.
     ///

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -218,6 +218,18 @@ def test_scanner_timeout():
   with pytest.raises(yara_x.TimeoutError):
     scanner.scan(b'foobar')
 
+def test_scanner_max_matches_per_pattern():
+  compiler = yara_x.Compiler()
+  compiler.add_source('rule test {strings: $a = "." condition: #a > 1}')
+
+  scanner.max_matches_per_pattern(1)
+  matching_rules = scanner.scan(b'..').matching_rules
+  assert len(matching_rules) == 0
+
+  scanner.max_matches_per_pattern(2)
+  matching_rules = scanner.scan(b'..').matching_rules
+  assert len(matching_rules) == 1
+
 
 def test_module_outputs():
   import datetime

--- a/py/yara_x.pyi
+++ b/py/yara_x.pyi
@@ -221,6 +221,14 @@ class Scanner:
         """
         ...
 
+    def max_matches_per_pattern(self, matches: int) -> None:
+        r"""
+        Sets the maximum number of matches per pattern.
+
+        When some pattern reaches the specified number of `matches` it won't produce more matches.
+        """
+        ...
+
     def console_log(self, callback: collections.abc.Callable[[str], Any]) -> None:
         r"""
         Sets a callback that is invoked every time a YARA rule calls the

--- a/site/content/docs/api/python.md
+++ b/site/content/docs/api/python.md
@@ -95,6 +95,7 @@ rules = compiler.build()
 # Pass the rules to a scanner, and set a scan timeout.
 scanner = yara_x.Scanner(rules)
 scanner.set_timeout(60)
+scanner.max_matches_per_pattern(1000)
 # Scan some data.
 result = scanner.scan(b"foo")
 ```

--- a/site/content/docs/cli/commands.md
+++ b/site/content/docs/cli/commands.md
@@ -178,6 +178,15 @@ will crash.
 This option disables memory mapping and forces the scanner to always read files into
 an in-memory buffer instead.
 
+### --max-matches-per-pattern \<MATCHES\>
+
+Maximum number of matches per pattern
+
+When some pattern reaches the maximum number of occurrences it won't produce
+more matches. This can affect rules that rely on the number of occurrences of
+some pattern. For instance, the expression `#a > 100` will be false if this
+limit is set to 100 or less.
+
 ### --output-format \<FORMAT\>
 
 Specify the output format. Available options are `text`, `ndjson` and `json`.


### PR DESCRIPTION
New parameter in CLI tested locally.

New parameter in Python code not tested, as I didn't find any usage of `test_api.py`, so I just compiled **yara-x-py**.