### PR TITLE
feat: limit function and DLL names for exports in PE module

### DIFF
--- a/lib/src/modules/pe/parser.rs
+++ b/lib/src/modules/pe/parser.rs
@@ -2219,10 +2219,8 @@ impl<'a> PE<'a> {
     }
 
     fn str_at_rva(&self, rva: u32, max_len: usize) -> Option<&'a str> {
-        from_utf8(
-            self.parse_at_rva(rva, take_while_m_n(0, max_len, |c| c != 0))?,
-        )
-        .ok()
+        self.parse_at_rva(rva, take_while_m_n(0, max_len, |c| c != 0))
+            .map(|s| from_utf8(s).ok())?
     }
 
     fn dll_name_at_rva(&self, rva: u32) -> Option<&'a str> {


### PR DESCRIPTION
I encountered samples with huge names of exports causing very high memory consumption (similar to[ the case with imports that was solved recently](https://github.com/VirusTotal/yara-x/commit/af18dbc9e0f3962b19306570a75b88c0ec8d3755)). Therefore I would like to add limits for them.