### PR TITLE
fix(capi): export and do not mangle yrx_finalize

### DIFF
--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -262,6 +262,7 @@ pub unsafe extern "C" fn yrx_compile(
 ///   to undefined behavior.
 ///
 /// [wasmtime]: https://wasmtime.dev/
+#[no_mangle]
 pub unsafe extern "C" fn yrx_finalize() {
     yara_x::finalize();
 }


### PR DESCRIPTION
It seems like unless `#[no_mangle]` is specified, the symbol is not exported (or is exported absolutely mangled, that I wasn't even able to locate it in the list of exported symbols).