### PR TITLE
fix: clear module outputs when resetting scan context

### DIFF
--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -502,7 +502,6 @@ impl ScanContext<'_, '_> {
 
         // Clear module outputs from previous scans.
         self.module_outputs.clear();
-        self.user_provided_module_outputs.clear();
 
         // Move the matching rules to the `matching_rules` vector, leaving the
         // `matching_rules_per_ns` map empty.

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -593,6 +593,12 @@ impl<'r> Scanner<'r> {
                 .add_field(module_name, TypeValue::Struct(module_struct));
         }
 
+        // The user provided module outputs are not needed anymore. Let's
+        // clear any remaining entry in the hash map (which can happen if
+        // the user has set outputs for modules that are not even imported
+        // by the rules.
+        ctx.user_provided_module_outputs.clear();
+
         // Evaluate the conditions of every rule, this will call
         // `ScanContext::search_for_patterns` if necessary.
         ctx.eval_conditions()?;


### PR DESCRIPTION
Anecdotally, I've noticed that memory usage tends to grow over time when scanning large numbers of files with the same scanner instance (Go, specifically). Memory usage for scans with the same scanner on the order of hundreds to thousands of files are mostly fine, but increasing the order of magnitude once or twice or more is problematic. 

Using a fresh scanner for each file is fine, but can also be slow with the overhead involved in creating a fresh scanner for large numbers of files, even when reusing the same, pre-compiled rules object.

After digging around, I saw that the module outputs aren't cleared when the scan context is reset. Based on that, it seems likely that all of the protobuf messages from each scan accrue over the course of the scanner's lifecycle which can add up quickly depending on how many files are scanned and the size of the messages (please correct me if I'm wrong here).

To that end, this PR clears both the `module_outputs` and the `user_provided_module_outputs` when the scan context is reset so that each subsequent scan does not continuously add module outputs to the hash map.