### PR TITLE
fix: Add warning for invariant in "for of" expressions.

### DIFF
--- a/lib/src/compiler/tests/testdata/warnings/44.in
+++ b/lib/src/compiler/tests/testdata/warnings/44.in
@@ -1,0 +1,8 @@
+rule a {
+  strings:
+    $a0 = "foo"
+    $a1 = "pants"
+    $b = "bar"
+  condition:
+    for 4 of ($a*, $b): ($ at 1)
+}

--- a/lib/src/compiler/tests/testdata/warnings/44.out
+++ b/lib/src/compiler/tests/testdata/warnings/44.out
@@ -1,0 +1,7 @@
+warning[invariant_expr]: invariant boolean expression
+ --> line:7:5
+  |
+7 |     for 4 of ($a*, $b): ($ at 1)
+  |     ---------------------------- this expression is always false
+  |
+  = note: the expression requires 4 matching patterns out of 3


### PR DESCRIPTION
If you have an expression that is "for 3 of ($a, $b): (! == 6)" it will always be false because the quantifier is more than the length of the pattern set. This commit makes this a warning.