### PR TITLE
ci: Add musllinux Python wheels for Alpine Linux support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -176,7 +176,7 @@ jobs:
         CIBW_ARCHS: ${{ matrix.arch || 'auto' }}
 
         CIBW_BEFORE_BUILD_LINUX: |
-          if [ $CIBW_BUILD == *-musllinux* ]; then
+          if [[ $CIBW_BUILD == *-musllinux* ]]; then
             export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="gcc"
             export CARGO_ENCODED_RUSTFLAGS=""
           fi


### PR DESCRIPTION
Enables musllinux wheel builds to support Alpine Linux

```shell
FROM python:3.12-alpine
RUN pip install --no-cache-dir yara-x==1.10.0
```
```shell
docker build --progress=plain .
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 166B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/python:3.12-alpine
#2 DONE 0.3s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.1s

#4 [1/2] FROM docker.io/library/python:3.12-alpine@sha256:d82291d418d5c47f267708393e40599ae836f2260b0519dd38670e9d281657f5
#4 CACHED

#5 [2/2] RUN pip install --no-cache-dir yara-x==1.10.0
#5 2.275 ERROR: Could not find a version that satisfies the requirement yara-x==1.10.0 (from versions: 0.2.0, 0.2.1, 0.3.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.11.1, 0.12.0, 0.13.0, 0.14.0, 0.15.0, 1.0.0, 1.0.1)
#5 2.407
#5 2.407 [notice] A new release of pip is available: 25.0.1 -> 25.3
#5 2.407 [notice] To update, run: pip install --upgrade pip
#5 2.408 ERROR: No matching distribution found for yara-x==1.10.0
#5 ERROR: process "/bin/sh -c pip install --no-cache-dir yara-x==1.10.0" did not complete successfully: exit code: 1
------
 > [2/2] RUN pip install --no-cache-dir yara-x==1.10.0:
2.275 ERROR: Could not find a version that satisfies the requirement yara-x==1.10.0 (from versions: 0.2.0, 0.2.1, 0.3.0, 0.4.0, 0.5.0, 0.6.0, 0.7.0, 0.8.0, 0.9.0, 0.10.0, 0.11.0, 0.11.1, 0.12.0, 0.13.0, 0.14.0, 0.15.0, 1.0.0, 1.0.1)
2.407
2.407 [notice] A new release of pip is available: 25.0.1 -> 25.3
2.407 [notice] To update, run: pip install --upgrade pip
2.408 ERROR: No matching distribution found for yara-x==1.10.0
------
Dockerfile:2
--------------------
   1 |     FROM python:3.12-alpine
   2 | >>> RUN pip install --no-cache-dir yara-x==1.10.0
   3 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pip install --no-cache-dir yara-x==1.10.0" did not complete successfully: exit code: 1
```

### Testing
---

```shell
CIBW_BUILD="cp312-musllinux_x86_64" cibuildwheel --platform linux py
```
```shell
     _ _       _ _   _       _           _
 ___|_| |_ _ _|_| |_| |_ _ _| |_ ___ ___| |
|  _| | . | | | | | . | | | |   | -_| -_| |
|___|_|___|___|_|_|___|_____|_|_|___|___|_|

cibuildwheel version 3.3.0

Build options:
  platform: linux
  allow_empty: False
  architectures: x86_64
  build_selector:
    build_config: cp312-musllinux_x86_64
    skip_config:
    requires_python: >=3.9
    enable: []
  output_dir: /home/zdiff/Projects/yara-x/wheelhouse
  package_dir: /home/zdiff/Projects/yara-x/py
  test_selector:
    skip_config:
  before_all:
  before_build:
  before_test:
  build_frontend: build
  build_verbosity: 0
  config_settings:
  container_engine: docker
  dependency_constraints: pinned
  environment:
  manylinux_images:
    x86_64: quay.io/pypa/manylinux_2_28_x86_64:2025.11.09-2
    i686: quay.io/pypa/manylinux_2_28_i686:2025.11.09-2
    pypy_x86_64: quay.io/pypa/manylinux_2_28_x86_64:2025.11.09-2
    aarch64: quay.io/pypa/manylinux_2_28_aarch64:2025.11.09-2
    ppc64le: quay.io/pypa/manylinux_2_28_ppc64le:2025.11.09-2
    s390x: quay.io/pypa/manylinux_2_28_s390x:2025.11.09-2
    armv7l: quay.io/pypa/manylinux_2_31_armv7l:2025.11.09-2
    riscv64: quay.io/pypa/manylinux_2_39_riscv64:2025.11.09-2
    pypy_aarch64: quay.io/pypa/manylinux_2_28_aarch64:2025.11.09-2
    pypy_i686: quay.io/pypa/manylinux_2_28_i686:2025.11.09-2
  musllinux_images:
    x86_64: quay.io/pypa/musllinux_1_2_x86_64:2025.11.09-2
    i686: quay.io/pypa/musllinux_1_2_i686:2025.11.09-2
    aarch64: quay.io/pypa/musllinux_1_2_aarch64:2025.11.09-2
    ppc64le: quay.io/pypa/musllinux_1_2_ppc64le:2025.11.09-2
    s390x: quay.io/pypa/musllinux_1_2_s390x:2025.11.09-2
    armv7l: quay.io/pypa/musllinux_1_2_armv7l:2025.11.09-2
    riscv64: quay.io/pypa/musllinux_1_2_riscv64:2025.11.09-2
  pyodide_version: None
  repair_command: auditwheel repair -w {dest_dir} {wheel}
  test_command:
  test_environment:
  test_extras:
  test_groups:
  test_requires:
  test_runtime:
    args: ()
  test_sources:
  xbuild_tools: None

Cache folder: /home/zdiff/.cache/cibuildwheel

Here we go!

Starting container image quay.io/pypa/musllinux_1_2_x86_64:2025.11.09-2...

info: This container will host the build for cp312-musllinux_x86_64...
+ docker version -f '{{json .}}'
+ docker image inspect quay.io/pypa/musllinux_1_2_x86_64:2025.11.09-2 --format '{{.Os}}/{{.Architecture}}'
99a057e32d8acfc8da176256a67a46ca9aa7f39d5ae3640d689585c804bd8278
    + /bin/true
    + mkdir -p /project
    + manylinux-interpreters --help
    + manylinux-interpreters ensure cp312-cp312
'cp312-cp312' already installed at '/opt/python/cp312-cp312'

                                                              ✓ 0.63s
Copying project into container...

    + mkdir -p /project

                                                              ✓ 0.14s

Building cp312-musllinux_x86_64 wheel
CPython 3.12 musllinux x86_64

Setting up build environment...

    + mkdir -p /
    + /opt/python/cp39-cp39/bin/python -c 'import sys, json, os; json.dump(os.environ.copy(), sys.stdout)'
    + which python
    + which pip

                                                              ✓ 0.18s
Building wheel...

    + rm -rf /tmp/cibuildwheel/built_wheel
    + mkdir -p /tmp/cibuildwheel/built_wheel
    + python -m build /project/py --wheel --outdir=/tmp/cibuildwheel/built_wheel
* Creating isolated environment: venv+pip...
* Installing packages in isolated environment:
  - maturin>=1.0
* Getting build dependencies for wheel...
* Installing packages in isolated environment:
  - puccinialin
* Building wheel...
Running `maturin pep517 build-wheel -i /tmp/build-env-omxum3q2/bin/python --compatibility off`
Python reports SOABI: cpython-312-x86_64-linux-musl
Computed rustc target triple: x86_64-unknown-linux-musl
Installation directory: /root/.cache/puccinialin
Downloading rustup-init from https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init
Downloading rustup-init:   0%|          | 0.00/21.2M [00:00<?, ?B/s]Rust not found, installing into a temporary directory
Downloading rustup-init: 100%|██████████| 21.2M/21.2M [00:00<00:00, 38.0MB/s]
Installing rust to /root/.cache/puccinialin/rustup
info: profile set to 'minimal'
info: default host triple is x86_64-unknown-linux-musl
info: syncing channel updates for 'stable-x86_64-unknown-linux-musl'
info: latest update on 2025-11-10, rust version 1.91.1 (ed61e7d7e 2025-11-07)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: installing component 'rust-std'
info: installing component 'rustc'
info: default toolchain set to 'stable-x86_64-unknown-linux-musl'
Checking if cargo is installed
cargo 1.91.1 (ea2d97820 2025-10-10)
...
🔗 Found pyo3 bindings with abi3 support
🐍 Found CPython 3.12 at /tmp/build-env-omxum3q2/bin/python
📡 Using build options features from pyproject.toml
...
    Finished `release` profile [optimized] target(s) in 3m 34s
warning: the following packages contain code that will be rejected by a future version of Rust: num-bigint-dig v0.8.5
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
📖 Found type stub file at yara_x.pyi
📦 Built wheel for abi3 Python ≥ 3.8 to /project/target/wheels/yara_x-1.10.0-cp38-abi3-linux_x86_64.whl
/project/target/wheels/yara_x-1.10.0-cp38-abi3-linux_x86_64.whl
Successfully built yara_x-1.10.0-cp38-abi3-linux_x86_64.whl
    + /opt/python/cp39-cp39/bin/python -c 'import sys, json, glob; json.dump(glob.glob('"'"'/tmp/cibuildwheel/built_wheel/*.whl'"'"'), sys.stdout)'
    + rm -rf /tmp/cibuildwheel/repaired_wheel
    + mkdir -p /tmp/cibuildwheel/repaired_wheel

                                                            ✓ 240.12s
Repairing wheel...

    + sh -c 'auditwheel repair -w /tmp/cibuildwheel/repaired_wheel /tmp/cibuildwheel/built_wheel/yara_x-1.10.0-cp38-abi3-linux_x86_64.whl'
INFO:auditwheel.main_repair:Repairing yara_x-1.10.0-cp38-abi3-linux_x86_64.whl
INFO:auditwheel.wheeltools:Previous filename tags: linux_x86_64
INFO:auditwheel.wheeltools:New filename tags: musllinux_1_2_x86_64
INFO:auditwheel.wheeltools:Previous WHEEL info tags: cp38-abi3-linux_x86_64
INFO:auditwheel.wheeltools:New WHEEL info tags: cp38-abi3-musllinux_1_2_x86_64
INFO:auditwheel.main_repair:
Fixed-up wheel written to /tmp/cibuildwheel/repaired_wheel/yara_x-1.10.0-cp38-abi3-musllinux_1_2_x86_64.whl
    + /opt/python/cp39-cp39/bin/python -c 'import sys, json, glob; json.dump(glob.glob('"'"'/tmp/cibuildwheel/repaired_wheel/*.whl'"'"'), sys.stdout)'
    + mkdir -p /output
    + mv /tmp/cibuildwheel/repaired_wheel/yara_x-1.10.0-cp38-abi3-musllinux_1_2_x86_64.whl /output

                                                              ✓ 1.75s

✓ cp312-musllinux_x86_64 finished in 4 minutes
Copying wheels back to host...

+ docker cp cibuildwheel-235b2f57-543f-41ba-921f-b928f697642d:/output/. /home/zdiff/Projects/yara-x/wheelhouse
Successfully copied 10.1MB to /home/zdiff/Projects/yara-x/wheelhouse

                                                              ✓ 0.01s

1 wheel produced in 4 minutes

  cp312-musllinux_x86_64: yara_x-1.10.0-cp38-abi3-musllinux_1_2_x86_64.whl 10.1 MB in 4 minutes, SHA256=2d91ef326ff0f5d90920810120d42de7a01a4ded4e4c665b2e2f51615bba8120
```