### PR TITLE
feat: Implement permhash for crx.

### DIFF
--- a/lib/src/modules/crx/mod.rs
+++ b/lib/src/modules/crx/mod.rs
@@ -5,12 +5,24 @@ This allows creating YARA rules based on metadata extracted from those files.
 
 mod parser;
 
+use sha2::{Digest, Sha256};
+use std::cell::RefCell;
+
 use crate::modules::crx::Crx;
 use crate::modules::prelude::*;
 use crate::modules::protos::crx::*;
 
+#[cfg(test)]
+mod tests;
+
+thread_local!(
+    static PERMHASH_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+);
+
 #[module_main]
 fn main(data: &[u8], _meta: Option<&[u8]>) -> Result<Crx, ModuleError> {
+    PERMHASH_CACHE.with(|cache| *cache.borrow_mut() = None);
     match parser::Crx::parse(data) {
         Ok(crx) => Ok(crx.into()),
         Err(_) => {
@@ -19,4 +31,39 @@ fn main(data: &[u8], _meta: Option<&[u8]>) -> Result<Crx, ModuleError> {
             Ok(crx)
         }
     }
+}
+
+#[module_export]
+fn permhash(ctx: &ScanContext) -> Option<Lowercase<FixedLenString<64>>> {
+    let cached = PERMHASH_CACHE.with(
+        |cache| -> Option<Lowercase<FixedLenString<64>>> {
+            cache.borrow().as_deref().map(|s| {
+                Lowercase::<FixedLenString<64>>::from_slice(ctx, s.as_bytes())
+            })
+        },
+    );
+
+    if cached.is_some() {
+        return cached;
+    }
+
+    let crx = ctx.module_output::<Crx>()?;
+
+    if !crx.is_crx() {
+        return None;
+    }
+
+    let mut sha256_hash = Sha256::new();
+
+    for permission in &crx.permissions {
+        sha256_hash.update(permission.as_bytes());
+    }
+
+    let digest = format!("{:x}", sha256_hash.finalize());
+
+    PERMHASH_CACHE.with(|cache| {
+        *cache.borrow_mut() = Some(digest.clone());
+    });
+
+    Some(Lowercase::<FixedLenString<64>>::new(digest))
 }

--- a/lib/src/modules/crx/tests/mod.rs
+++ b/lib/src/modules/crx/tests/mod.rs
@@ -1,0 +1,23 @@
+use pretty_assertions::assert_eq;
+
+use crate::modules::tests::create_binary_from_zipped_ihex;
+use crate::tests::rule_true;
+use crate::tests::test_rule;
+
+#[test]
+fn permhash() {
+    let crx = create_binary_from_zipped_ihex(
+        "src/modules/crx/tests/testdata/3d1c2b1777fb5d5f4e4707ab3a1b64131c26f8dc1c30048dce7a1944b4098f3e.in.zip",
+    );
+
+    rule_true!(
+        r#"
+        import "crx"
+        rule test {
+          condition:
+            crx.permhash() == "0bd16e5d8c30b71e844aa6f30b381adf20dc14cc555f5594fc3ac49985c9a52e"
+        }
+        "#,
+        &crx
+    );
+}

--- a/site/content/docs/modules/crx.md
+++ b/site/content/docs/modules/crx.md
@@ -25,6 +25,22 @@ distribute browser extensions. Essentially, they are ZIP archives with a
 different file extension and additional metadata, including one or more digital
 signatures that validate the file’s integrity.
 
+-------
+
+## Functions
+
+{{< callout context="caution" title="Important">}}
+
+Hashes returned by the functions below are always in lowercase.
+
+{{< /callout >}}
+
+### permhash()
+
+Returns permhash of the crx. See [Google blog post](https://cloud.google.com/blog/topics/threat-intelligence/permhash-no-curls-necessary/) for more details.
+
+Example: `crx.permhash() == "0bd16e5d8c30b71e844aa6f30b381adf20dc14cc555f5594fc3ac49985c9a52e"`
+
 #### Examples
 
 ```


### PR DESCRIPTION
This commit implements `permhash[1]` for crx module.

```
[1]: https://cloud.google.com/blog/topics/threat-intelligence/permhash-no-curls-necessary/
[1]: https://github.com/google/permhash
```