### PR TITLE
build: configure dependencies to allow WASM compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "waitpid-any",
 ]
 
 [[package]]
@@ -4334,16 +4333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "waitpid-any"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18aa3ce681e189f125c4c1e1388c03285e2fd434ef52c7203084012ac29c5e4a"
-dependencies = [
- "rustix 1.1.2",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/ls/Cargo.toml
+++ b/ls/Cargo.toml
@@ -9,21 +9,29 @@ license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 
+[lib]
+name = "yara_x_ls"
+crate-type = ["cdylib", "rlib"]
+
 [[bin]]
 name = "yr-ls"
 path = "src/main.rs"
 
 [dependencies]
-async-lsp = { version = "0.2.2", default-features=false, features=["omni-trait", "tokio", "client-monitor", "stdio"]}
 bitflags = { workspace = true }
 futures = "0.3.31"
-tokio = { version = "1.48.0", features = ["full"] }
-tokio-util = { version = "0.7.17", features = ["compat"] }
-tower = { version = "0.5.2" , features = ["full"]}
 yara-x-parser = { workspace = true }
 
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+tokio = { version = "1.48.0", features = ["full"] }
+tokio-util = { version = "0.7.17", features = ["compat"] }
+async-lsp = {version = "0.2.2", default-features=false, features=["omni-trait", "tokio", "stdio"]}
+tower = { version = "0.5.2" , features = ["full"]}
+
+[target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dependencies]
+async-lsp = {version = "0.2.2", default-features=false, features=["omni-trait"]}
+tower = { version = "0.5.2" }
 
 [dev-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-

--- a/ls/src/lib.rs
+++ b/ls/src/lib.rs
@@ -1,0 +1,33 @@
+use async_lsp::{
+    concurrency::ConcurrencyLayer, panic::CatchUnwindLayer,
+    server::LifecycleLayer,
+};
+use futures::{AsyncRead, AsyncWrite};
+use tower::ServiceBuilder;
+
+use crate::server::ServerState;
+
+mod features;
+mod server;
+#[cfg(test)]
+mod tests;
+mod utils;
+
+/// Starts the Language Server Main Loop with provided streams.
+///
+/// Provided streams must implement [`futures::AsyncRead`] and
+/// [`futures::AsyncWrite`] traits.
+pub async fn serve(
+    input: impl AsyncRead,
+    output: impl AsyncWrite,
+) -> Result<(), async_lsp::Error> {
+    let (server, _) = async_lsp::MainLoop::new_server(|client| {
+        ServiceBuilder::new()
+            .layer(LifecycleLayer::default())
+            .layer(CatchUnwindLayer::default())
+            .layer(ConcurrencyLayer::default())
+            .service(ServerState::new_router(client))
+    });
+
+    server.run_buffered(input, output).await
+}

--- a/ls/src/main.rs
+++ b/ls/src/main.rs
@@ -1,37 +1,4 @@
-use async_lsp::concurrency::ConcurrencyLayer;
-use async_lsp::panic::CatchUnwindLayer;
-use async_lsp::server::LifecycleLayer;
-
-use futures::{AsyncRead, AsyncWrite};
-use tower::ServiceBuilder;
-
-use crate::server::ServerState;
-
-#[cfg(test)]
-mod tests;
-
-mod features;
-mod server;
-mod utils;
-
-/// Starts the Language Server Main Loop with provided streams.
-///
-/// Provided streams must implement [`futures::AsyncRead`] and
-/// [`futures::AsyncWrite`] traits.
-pub async fn serve(
-    input: impl AsyncRead,
-    output: impl AsyncWrite,
-) -> Result<(), async_lsp::Error> {
-    let (server, _) = async_lsp::MainLoop::new_server(|client| {
-        ServiceBuilder::new()
-            .layer(LifecycleLayer::default())
-            .layer(CatchUnwindLayer::default())
-            .layer(ConcurrencyLayer::default())
-            .service(ServerState::new_router(client))
-    });
-
-    server.run_buffered(input, output).await
-}
+use yara_x_ls::serve;
 
 /// Starts the Language Server Main Loop using Standard Input Output.
 pub async fn serve_stdio() -> Result<(), async_lsp::Error> {


### PR DESCRIPTION
Now WASM conflicting dependencies are managed directly by build target in Cargo.toml. The library itself can be compiled into WASM without specifying any additional configuration. Means that other crates that wants to use `yara-x-ls` as a dependency and be able to compile into WASM does not have to disable `default-features`. This approach should also prevent `no-default-features` test failure.

I've also removed that `async-lsp/client-monitor` feature, since the current implementation does not use it.