### PR TITLE
feat: Add crx and dex modules to python invoke API.

### DIFF
--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib"]
 console-module = ["yara-x/console-module"]
 crx-module = ["yara-x/crx-module"]
 cuckoo-module = ["yara-x/cuckoo-module"]
+dex-module = ["yara-x/dex-module"]
 dotnet-module = ["yara-x/dotnet-module"]
 elf-module = ["yara-x/elf-module"]
 hash-module = ["yara-x/hash-module"]
@@ -39,6 +40,7 @@ default = [
     "crx-module",
     "cuckoo-module",
     "dotnet-module",
+    "dex-module",
     "elf-module",
     "hash-module",
     "lnk-module",

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -66,6 +66,10 @@ enum SupportedModules {
     Pe,
     #[cfg(feature = "dotnet-module")]
     Dotnet,
+    #[cfg(feature = "crx-module")]
+    Crx,
+    #[cfg(feature = "dex-module")]
+    Dex,
 }
 
 /// Formats YARA rules.
@@ -312,6 +316,14 @@ impl Module {
                 #[cfg(feature = "dotnet-module")]
                 SupportedModules::Dotnet => {
                     yrx::mods::invoke_dyn::<yrx::mods::Dotnet>(data)
+                }
+                #[cfg(feature = "crx-module")]
+                SupportedModules::Crx => {
+                    yrx::mods::invoke_dyn::<yrx::mods::Crx>(data)
+                }
+                #[cfg(feature = "dex-module")]
+                SupportedModules::Dex => {
+                    yrx::mods::invoke_dyn::<yrx::mods::Dex>(data)
                 }
                 _ => return Ok(py.None().into_bound(py)),
             };


### PR DESCRIPTION
While working on something else I realized the crx and dex modules are not exposed in the Python API for invocation directly. This commit fixes it by adding them to the SupportedModules list (and also exposes it as a feature in the case of the dex module).