### PR TITLE
feat: add VSIX module for parsing VS Code extensions

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -221,6 +221,12 @@ vt-module = [
     "dep:psl",
 ]
 
+# The `vsix` module parses Visual Studio Code Extension files.
+vsix-module = [
+    "dep:sha2",
+    "dep:zip",
+]
+
 # Enables all the default modules.
 default-modules = [
     "console-module",
@@ -238,6 +244,7 @@ default-modules = [
     "lnk-module",
     "test_proto2-module",
     "test_proto3-module",
+    "vsix-module",
     "vt-module",
 ]
 

--- a/lib/src/modules/add_modules.rs
+++ b/lib/src/modules/add_modules.rs
@@ -34,6 +34,8 @@ add_module!(modules, "test_proto3", test_proto3, "test_proto3.TestProto3", Some(
 add_module!(modules, "text", text, "text.Text", Some("text"), Some(text::__main__ as MainFn));
 #[cfg(feature = "time-module")]
 add_module!(modules, "time", time, "time.Time", Some("time"), Some(time::__main__ as MainFn));
+#[cfg(feature = "vsix-module")]
+add_module!(modules, "vsix", vsix, "vsix.Vsix", Some("vsix"), Some(vsix::__main__ as MainFn));
 #[cfg(feature = "vt-module")]
 add_module!(modules, "vt", titan, "vt.titan.LiveHuntData", Some("vt"), Some(vt::__main__ as MainFn));
 }

--- a/lib/src/modules/mod.rs
+++ b/lib/src/modules/mod.rs
@@ -226,6 +226,15 @@ pub mod mods {
     /// Data structure returned by the `pe` module.
     pub use super::protos::pe::PE;
 
+    /// Data structures defined by the `vsix` module.
+    ///
+    /// The main structure produced by the module is [`vsix::Vsix`]. The rest
+    /// of them are used by one or more fields in the main structure.
+    ///
+    pub use super::protos::vsix;
+    /// Data structure returned by the `vsix` module.
+    pub use super::protos::vsix::Vsix;
+
     /// A data structure containing the data returned by all modules.
     pub use super::protos::mods::Modules;
 
@@ -313,6 +322,7 @@ pub mod mods {
         info.lnk = protobuf::MessageField(invoke::<Lnk>(data));
         info.crx = protobuf::MessageField(invoke::<Crx>(data));
         info.dex = protobuf::MessageField(invoke::<Dex>(data));
+        info.vsix = protobuf::MessageField(invoke::<Vsix>(data));
         info
     }
 

--- a/lib/src/modules/modules.rs
+++ b/lib/src/modules/modules.rs
@@ -33,5 +33,7 @@ mod test_proto3;
 mod text;
 #[cfg(feature = "time-module")]
 mod time;
+#[cfg(feature = "vsix-module")]
+mod vsix;
 #[cfg(feature = "vt-module")]
 mod vt;

--- a/lib/src/modules/protos/mods.proto
+++ b/lib/src/modules/protos/mods.proto
@@ -8,6 +8,7 @@ import "elf.proto";
 import "pe.proto";
 import "lnk.proto";
 import "macho.proto";
+import "vsix.proto";
 
 package mods;
 
@@ -20,4 +21,5 @@ message Modules {
     optional lnk.Lnk lnk = 5;
     optional crx.Crx crx = 6;
     optional dex.Dex dex = 7;
+    optional vsix.Vsix vsix = 8;
 }

--- a/lib/src/modules/protos/vsix.proto
+++ b/lib/src/modules/protos/vsix.proto
@@ -1,0 +1,42 @@
+syntax = "proto2";
+import "yara.proto";
+
+package vsix;
+
+option (yara.module_options) = {
+  name : "vsix"
+  root_message: "vsix.Vsix"
+  rust_module: "vsix"
+  cargo_feature: "vsix-module"
+};
+
+message Vsix {
+  // True if the file is a valid VSIX extension.
+  optional bool is_vsix = 1;
+
+  // Extension identity
+  optional string name = 2;
+  optional string display_name = 3;
+  optional string publisher = 4;
+  optional string version = 5;
+  optional string id = 6;                    // publisher.name
+  optional string description = 7;
+
+  // Entry points (security-critical)
+  optional string main = 8;
+  optional string browser = 9;
+
+  // Activation events (security-critical)
+  repeated string activation_events = 10;
+
+  // Metadata
+  optional string vscode_version = 11;       // engines.vscode
+  optional string repository = 12;
+  optional string homepage = 13;
+  optional string license = 14;
+  repeated string categories = 15;
+  repeated string keywords = 16;
+
+  // Files in archive
+  repeated string files = 17;
+}

--- a/lib/src/modules/tests.rs
+++ b/lib/src/modules/tests.rs
@@ -204,6 +204,7 @@ fn test_invoke_modules() {
     assert!(modules.lnk.is_lnk.is_some_and(|value| !value));
     assert!(modules.crx.is_crx.is_some_and(|value| !value));
     assert!(modules.dex.is_dex.is_some_and(|value| !value));
+    assert!(modules.vsix.is_vsix.is_some_and(|value| !value));
 }
 
 #[cfg(feature = "test_proto2-module")]

--- a/lib/src/modules/vsix/mod.rs
+++ b/lib/src/modules/vsix/mod.rs
@@ -1,0 +1,101 @@
+/*! YARA module that parses Visual Studio Code Extension (VSIX) files.
+
+This allows creating YARA rules based on metadata extracted from those files.
+*/
+
+mod parser;
+
+use sha2::{Digest, Sha256};
+use std::cell::RefCell;
+
+use crate::modules::prelude::*;
+use crate::modules::protos::vsix::*;
+
+#[cfg(test)]
+mod tests;
+
+thread_local!(
+    static ACTIVATIONHASH_CACHE: RefCell<Option<String>> =
+        const { RefCell::new(None) };
+);
+
+#[module_main]
+fn main(data: &[u8], _meta: Option<&[u8]>) -> Result<Vsix, ModuleError> {
+    ACTIVATIONHASH_CACHE.with(|cache| *cache.borrow_mut() = None);
+    match parser::Vsix::parse(data) {
+        Ok(vsix) => Ok(vsix.into()),
+        Err(_) => {
+            let mut vsix = Vsix::new();
+            vsix.set_is_vsix(false);
+            Ok(vsix)
+        }
+    }
+}
+
+/// Returns the SHA-256 hash of the sorted activation events.
+///
+/// Events are sorted alphabetically before hashing to produce an
+/// order-independent fingerprint. A null byte separator is added
+/// between events to prevent hash collisions from concatenation
+/// (e.g., distinguishing ["ab", "c"] from ["a", "bc"]).
+///
+/// This differs from the CRX module's `permhash()` which does not
+/// sort permissions before hashing.
+#[module_export]
+fn activationhash(ctx: &ScanContext) -> Option<Lowercase<FixedLenString<64>>> {
+    let cached = ACTIVATIONHASH_CACHE.with(
+        |cache| -> Option<Lowercase<FixedLenString<64>>> {
+            cache.borrow().as_deref().map(|s| {
+                Lowercase::<FixedLenString<64>>::from_slice(ctx, s.as_bytes())
+            })
+        },
+    );
+
+    if cached.is_some() {
+        return cached;
+    }
+
+    let vsix = ctx.module_output::<Vsix>()?;
+
+    if !vsix.is_vsix() {
+        return None;
+    }
+
+    let mut events: Vec<&str> =
+        vsix.activation_events.iter().map(String::as_str).collect();
+    events.sort();
+
+    let mut sha256_hash = Sha256::new();
+    for event in events {
+        sha256_hash.update(event.as_bytes());
+        sha256_hash.update(b"\x00"); // Null byte separator
+    }
+
+    let digest = format!("{:x}", sha256_hash.finalize());
+
+    ACTIVATIONHASH_CACHE.with(|cache| {
+        *cache.borrow_mut() = Some(digest.clone());
+    });
+
+    Some(Lowercase::<FixedLenString<64>>::new(digest))
+}
+
+/// Returns true if the extension has the specified activation event.
+///
+/// # Arguments
+///
+/// * `event` - The activation event to check for (e.g., "*", "onCommand:test.run")
+#[module_export]
+fn has_activation_event(
+    ctx: &ScanContext,
+    event: RuntimeString,
+) -> Option<bool> {
+    let vsix = ctx.module_output::<Vsix>()?;
+
+    if !vsix.is_vsix() {
+        return None;
+    }
+
+    let event_str = event.as_bstr(ctx);
+    Some(vsix.activation_events.iter().any(|e| e.as_bytes() == event_str.as_bytes()))
+}

--- a/lib/src/modules/vsix/parser.rs
+++ b/lib/src/modules/vsix/parser.rs
@@ -77,12 +77,7 @@ impl Vsix {
         // sequences like "../", this is only a security concern when extracting
         // files to disk. Here, names are stored as opaque strings for pattern
         // matching, never used as paths.
-        let mut files = Vec::with_capacity(zip.len());
-        for i in 0..zip.len() {
-            if let Ok(file) = zip.by_index(i) {
-                files.push(file.name().to_string());
-            }
-        }
+        let files = zip.file_names().map(String::from).collect::<Vec<_>>();
 
         // Try to find and parse package.json
         let manifest = Self::read_manifest(&mut zip);

--- a/lib/src/modules/vsix/parser.rs
+++ b/lib/src/modules/vsix/parser.rs
@@ -72,7 +72,11 @@ impl Vsix {
     pub fn parse(data: &[u8]) -> Result<Self, Error> {
         let mut zip = Self::read_zip(data).map_err(|_| Error::InvalidVsix)?;
 
-        // Collect all file names from the archive
+        // Collect all file names from the archive as in-memory strings for YARA
+        // rule matching. Note: While file.name() can contain path traversal
+        // sequences like "../", this is only a security concern when extracting
+        // files to disk. Here, names are stored as opaque strings for pattern
+        // matching, never used as paths.
         let mut files = Vec::with_capacity(zip.len());
         for i in 0..zip.len() {
             if let Ok(file) = zip.by_index(i) {

--- a/lib/src/modules/vsix/parser.rs
+++ b/lib/src/modules/vsix/parser.rs
@@ -1,0 +1,164 @@
+use std::io::{Cursor, Read, Seek};
+
+use strum_macros::Display;
+use zip::result::ZipResult;
+use zip::ZipArchive;
+
+use crate::modules::protos;
+
+#[derive(Display)]
+pub enum Error {
+    InvalidVsix,
+}
+
+/// A Visual Studio Code Extension (VSIX) parser.
+///
+/// VSIX files are ZIP archives containing a `package.json` manifest
+/// that describes the extension. The manifest is typically located at
+/// `extension/package.json` but may also be at the root or in a
+/// `publisher.name-version/` directory.
+#[derive(Default)]
+pub struct Vsix {
+    manifest: Option<VsixManifest>,
+    files: Vec<String>,
+}
+
+/// The package.json manifest structure for VS Code extensions.
+#[derive(serde::Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct VsixManifest {
+    name: Option<String>,
+    display_name: Option<String>,
+    publisher: Option<String>,
+    version: Option<String>,
+    description: Option<String>,
+    main: Option<String>,
+    browser: Option<String>,
+    #[serde(default)]
+    activation_events: Vec<String>,
+    #[serde(default)]
+    engines: Option<VsixEngines>,
+    repository: Option<VsixRepository>,
+    homepage: Option<String>,
+    license: Option<String>,
+    #[serde(default)]
+    categories: Vec<String>,
+    #[serde(default)]
+    keywords: Vec<String>,
+}
+
+#[derive(serde::Deserialize, Debug, Default)]
+struct VsixEngines {
+    vscode: Option<String>,
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(untagged)]
+enum VsixRepository {
+    String(String),
+    Object { url: Option<String> },
+}
+
+impl VsixRepository {
+    fn url(&self) -> Option<&str> {
+        match self {
+            VsixRepository::String(s) => Some(s.as_str()),
+            VsixRepository::Object { url } => url.as_deref(),
+        }
+    }
+}
+
+impl Vsix {
+    pub fn parse(data: &[u8]) -> Result<Self, Error> {
+        let mut zip = Self::read_zip(data).map_err(|_| Error::InvalidVsix)?;
+
+        // Collect all file names from the archive
+        let mut files = Vec::with_capacity(zip.len());
+        for i in 0..zip.len() {
+            if let Ok(file) = zip.by_index(i) {
+                files.push(file.name().to_string());
+            }
+        }
+
+        // Try to find and parse package.json
+        let manifest = Self::read_manifest(&mut zip);
+
+        // If no manifest found, this is not a valid VSIX
+        if manifest.is_none() {
+            return Err(Error::InvalidVsix);
+        }
+
+        Ok(Vsix { manifest, files })
+    }
+
+    fn read_zip(zip_data: &[u8]) -> ZipResult<ZipArchive<Cursor<&[u8]>>> {
+        zip::ZipArchive::new(Cursor::new(zip_data))
+    }
+
+    fn read_manifest<R: Read + Seek>(zip: &mut ZipArchive<R>) -> Option<VsixManifest> {
+        // Try common locations for package.json
+        let paths = ["extension/package.json", "package.json"];
+
+        for path in paths {
+            if let Ok(file) = zip.by_name(path) {
+                if let Ok(manifest) = serde_json::from_reader::<_, VsixManifest>(file) {
+                    return Some(manifest);
+                }
+            }
+        }
+
+        // Try to find package.json in any subdirectory (e.g., publisher.name-version/)
+        for i in 0..zip.len() {
+            if let Ok(file) = zip.by_index(i) {
+                let name = file.name();
+                if name.ends_with("/package.json") && name.matches('/').count() == 1 {
+                    if let Ok(manifest) = serde_json::from_reader::<_, VsixManifest>(file) {
+                        return Some(manifest);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl From<Vsix> for protos::vsix::Vsix {
+    fn from(vsix: Vsix) -> Self {
+        let mut result = protos::vsix::Vsix::new();
+        result.set_is_vsix(true);
+        result.files = vsix.files;
+
+        if let Some(manifest) = vsix.manifest {
+            result.name = manifest.name.clone();
+            result.display_name = manifest.display_name;
+            result.publisher = manifest.publisher.clone();
+            result.version = manifest.version;
+            result.description = manifest.description;
+            result.main = manifest.main;
+            result.browser = manifest.browser;
+            result.activation_events = manifest.activation_events;
+            result.license = manifest.license;
+            result.homepage = manifest.homepage;
+            result.categories = manifest.categories;
+            result.keywords = manifest.keywords;
+
+            // Compute extension ID as publisher.name
+            if let (Some(publisher), Some(name)) = (&manifest.publisher, &manifest.name) {
+                result.id = Some(format!("{}.{}", publisher, name));
+            }
+
+            // Extract vscode version from engines
+            if let Some(engines) = manifest.engines {
+                result.vscode_version = engines.vscode;
+            }
+
+            // Extract repository URL
+            if let Some(repo) = manifest.repository {
+                result.repository = repo.url().map(|s| s.to_string());
+            }
+        }
+
+        result
+    }
+}

--- a/lib/src/modules/vsix/parser.rs
+++ b/lib/src/modules/vsix/parser.rs
@@ -99,13 +99,17 @@ impl Vsix {
         zip::ZipArchive::new(Cursor::new(zip_data))
     }
 
-    fn read_manifest<R: Read + Seek>(zip: &mut ZipArchive<R>) -> Option<VsixManifest> {
+    fn read_manifest<R: Read + Seek>(
+        zip: &mut ZipArchive<R>,
+    ) -> Option<VsixManifest> {
         // Try common locations for package.json
         let paths = ["extension/package.json", "package.json"];
 
         for path in paths {
             if let Ok(file) = zip.by_name(path) {
-                if let Ok(manifest) = serde_json::from_reader::<_, VsixManifest>(file) {
+                if let Ok(manifest) =
+                    serde_json::from_reader::<_, VsixManifest>(file)
+                {
                     return Some(manifest);
                 }
             }
@@ -115,8 +119,12 @@ impl Vsix {
         for i in 0..zip.len() {
             if let Ok(file) = zip.by_index(i) {
                 let name = file.name();
-                if name.ends_with("/package.json") && name.matches('/').count() == 1 {
-                    if let Ok(manifest) = serde_json::from_reader::<_, VsixManifest>(file) {
+                if name.ends_with("/package.json")
+                    && name.matches('/').count() == 1
+                {
+                    if let Ok(manifest) =
+                        serde_json::from_reader::<_, VsixManifest>(file)
+                    {
                         return Some(manifest);
                     }
                 }
@@ -148,8 +156,10 @@ impl From<Vsix> for protos::vsix::Vsix {
             result.keywords = manifest.keywords;
 
             // Compute extension ID as publisher.name
-            if let (Some(publisher), Some(name)) = (&manifest.publisher, &manifest.name) {
-                result.id = Some(format!("{}.{}", publisher, name));
+            if let (Some(publisher), Some(name)) =
+                (&manifest.publisher, &manifest.name)
+            {
+                result.id = Some(format!("{publisher}.{name}"));
             }
 
             // Extract vscode version from engines

--- a/lib/src/modules/vsix/tests/mod.rs
+++ b/lib/src/modules/vsix/tests/mod.rs
@@ -1,0 +1,309 @@
+use std::io::{Cursor, Write};
+use zip::write::SimpleFileOptions;
+
+use crate::tests::rule_true;
+use crate::tests::test_rule;
+
+/// Creates a minimal VSIX file with the given package.json content.
+fn create_vsix(package_json: &str) -> Vec<u8> {
+    let mut buffer = Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buffer);
+        let options = SimpleFileOptions::default();
+
+        // Add extension/package.json
+        zip.start_file("extension/package.json", options).unwrap();
+        zip.write_all(package_json.as_bytes()).unwrap();
+
+        // Add a dummy extension.js
+        zip.start_file("extension/extension.js", options).unwrap();
+        zip.write_all(b"// extension code").unwrap();
+
+        zip.finish().unwrap();
+    }
+    buffer.into_inner()
+}
+
+#[test]
+fn is_vsix() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test-extension",
+            "publisher": "test-publisher",
+            "version": "1.0.0"
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.is_vsix
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn not_vsix() {
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            not vsix.is_vsix
+        }
+        "#,
+        b"not a vsix file"
+    );
+}
+
+#[test]
+fn basic_fields() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "my-extension",
+            "displayName": "My Extension",
+            "publisher": "my-publisher",
+            "version": "1.2.3",
+            "description": "A test extension"
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.name == "my-extension" and
+            vsix.display_name == "My Extension" and
+            vsix.publisher == "my-publisher" and
+            vsix.version == "1.2.3" and
+            vsix.id == "my-publisher.my-extension" and
+            vsix.description == "A test extension"
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn entry_points() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "main": "./out/extension.js",
+            "browser": "./out/browser.js"
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.main == "./out/extension.js" and
+            vsix.browser == "./out/browser.js"
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn activation_events() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "activationEvents": ["onCommand:test.run", "*", "onLanguage:rust"]
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.has_activation_event("*") and
+            vsix.has_activation_event("onCommand:test.run") and
+            not vsix.has_activation_event("nonexistent")
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn activationhash() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "activationEvents": ["onCommand:test.run", "*"]
+        }"#,
+    );
+
+    // Hash of sorted events with null separators: "*\0onCommand:test.run\0"
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.activationhash() == "cb9b0f7a2ad019b1701eb4ef983557c0b5b3c05aba9dabedfe16f99df69c9ba8"
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn vscode_version() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "engines": {
+                "vscode": "^1.80.0"
+            }
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.vscode_version == "^1.80.0"
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn repository_url() {
+    // Test repository as object
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "repository": {
+                "type": "git",
+                "url": "https://github.com/test/repo"
+            }
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.repository == "https://github.com/test/repo"
+        }
+        "#,
+        &vsix
+    );
+
+    // Test repository as string
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "repository": "https://github.com/test/repo2"
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            vsix.repository == "https://github.com/test/repo2"
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn categories_and_keywords() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0",
+            "categories": ["Themes", "Snippets"],
+            "keywords": ["rust", "cargo"]
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            for any cat in vsix.categories : (cat == "Themes") and
+            for any kw in vsix.keywords : (kw == "rust")
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn files_list() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "test",
+            "publisher": "pub",
+            "version": "1.0.0"
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule test {
+          condition:
+            for any f in vsix.files : (f == "extension/package.json") and
+            for any f in vsix.files : (f == "extension/extension.js")
+        }
+        "#,
+        &vsix
+    );
+}
+
+#[test]
+fn wildcard_activation_detection() {
+    let vsix = create_vsix(
+        r#"{
+            "name": "suspicious-ext",
+            "publisher": "unknown",
+            "version": "1.0.0",
+            "activationEvents": ["*"]
+        }"#,
+    );
+
+    rule_true!(
+        r#"
+        import "vsix"
+        rule wildcard_activation {
+          condition:
+            vsix.is_vsix and
+            vsix.has_activation_event("*")
+        }
+        "#,
+        &vsix
+    );
+}

--- a/ls/src/tests/testdata/completion10.response.json
+++ b/ls/src/tests/testdata/completion10.response.json
@@ -75,6 +75,11 @@
     "preselect": true
   },
   {
+    "label": "vsix",
+    "kind": 9,
+    "preselect": true
+  },
+  {
     "label": "vt",
     "kind": 9,
     "preselect": true

--- a/ls/src/tests/testdata/completion11.response.json
+++ b/ls/src/tests/testdata/completion11.response.json
@@ -75,6 +75,11 @@
     "preselect": true
   },
   {
+    "label": "vsix",
+    "kind": 9,
+    "preselect": true
+  },
+  {
     "label": "vt",
     "kind": 9,
     "preselect": true


### PR DESCRIPTION
## Summary

Add a new module for parsing Visual Studio Code Extension (VSIX) files, enabling YARA rules to match on extension metadata and security-relevant properties.

This module is designed for security analysis of VS Code extensions, similar to how the existing `crx` module handles Chrome extensions.

### Fields exposed

| Field | Description |
|-------|-------------|
| `name`, `display_name`, `publisher`, `version`, `id` | Extension identity |
| `main`, `browser` | Entry points (security-critical) |
| `activation_events` | Array of activation triggers |
| `vscode_version` | Required VS Code version |
| `repository`, `homepage`, `license` | Metadata |
| `categories`, `keywords` | Classification |
| `files` | List of files in archive |

### Functions

| Function | Description |
|----------|-------------|
| `activationhash()` | SHA-256 hash of sorted activation events |
| `has_activation_event(event)` | Check for specific activation event |

### Example rules

```yara
import "vsix"

// Detect extensions with wildcard activation (potentially suspicious)
rule wildcard_activation {
  condition:
    vsix.is_vsix and vsix.has_activation_event("*")
}

// Find extensions by publisher
rule anthropic_extension {
  condition:
    vsix.is_vsix and vsix.publisher iequals "anthropic"
}

// Theme extensions (no code entry points)
rule theme_only {
  condition:
    vsix.is_vsix and
    not defined vsix.main and
    not defined vsix.browser and
    for any cat in vsix.categories : (cat == "Themes")
}
```

## Test plan

- [x] 11 unit tests covering all fields and functions
- [x] All tests pass

```bash
cargo test -p yara-x vsix
```

🤖 Generated with [Claude Code](https://claude.ai/code)