### PR TITLE
perf: emit `i32.eqz` instead of `if_else` block for `not` expressions

### DIFF
--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -757,24 +757,8 @@ fn emit_not(
     operand: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
-    // The `not` expression is emitted as:
-    //
-    //   if (evaluate_operand()) {
-    //     false
-    //   } else {
-    //     true
-    //   }
-    //
     emit_bool_expr(ctx, ir, operand, instr);
-    instr.if_else(
-        I32,
-        |then| {
-            then.i32_const(0);
-        },
-        |else_| {
-            else_.i32_const(1);
-        },
-    );
+    instr.unop(UnaryOp::I32Eqz);
 }
 
 /// Emits the code for `and` operations.


### PR DESCRIPTION
I got inspired by your compiled ruleset size optimizations (https://github.com/VirusTotal/yara-x/commit/5efc214e4fff0094be50b8f369860bed3d24105e, https://github.com/VirusTotal/yara-x/commit/a8656813a9357bdb421fe36b293dbb49153cf961) which really moved the needle for us with our massive rule sets, and I decided to explore some more optimizations. This is the first and simplest one. I was not able to measure a decisive improvements (only a small statistical `Maximum resident set size` decrease over a few runs), but it seems cleaner to me this way anyway. I may follow with further (possible) improvements, if they look good -- if no more PRs come, I failed to came up with anything worthwhile 🤣  

The `not` operator was emitting a 5-instruction if/else block to flip a boolean value. The single WASM instruction `i32.eqz` is semantically identical, saving 4 instructions per `not` expression. Across large rulesets with thousands of rules, this reduces compiled ruleset size.