### PR TITLE
feat(compiler): provide source line in the diagnostics report

### DIFF
--- a/lib/src/compiler/report.rs
+++ b/lib/src/compiler/report.rs
@@ -148,6 +148,22 @@ impl Report {
                     ),
                 };
 
+            // Extract the source line to include into diagnostics
+            let start = span.start();
+            let line_start = match code[..start].rfind('\n') {
+                Some(i) => i + 1,
+                None => 0,
+            };
+            let line_end = match code[start..].find('\n') {
+                Some(i) => start + i,
+                None => code.len(),
+            };
+
+            // Strip trailing CR from possible CRLF
+            let source_line = code[line_start..line_end]
+                .trim_end_matches('\r')
+                .to_string();
+
             Label {
                 level: level_as_text(level),
                 code_origin,
@@ -155,6 +171,7 @@ impl Report {
                 column,
                 span,
                 text,
+                source_line,
             }
         })
     }
@@ -353,6 +370,7 @@ pub struct Label<'a> {
     column: usize,
     span: Span,
     text: &'a str,
+    source_line: String,
 }
 
 impl Label<'_> {

--- a/lib/src/compiler/tests/mod.rs
+++ b/lib/src/compiler/tests/mod.rs
@@ -1136,7 +1136,8 @@ fn errors_serialization() {
                 "line": 1,
                 "column": 23,
                 "span": { "start": 22, "end": 25 },
-                "text": "this identifier has not been declared"
+                "text": "this identifier has not been declared",
+                "source_line": "rule test {condition: foo}"
             }
         ],
         "footers": [],


### PR DESCRIPTION
This will fill in the missing information to reconstruct a nice error / warnings for consumers of serialized diagnostics (for example in C API)

I thought long and hard on this and I think this is the best approach if I'm not missing anything. Basically, we'd like to use C API of YARA-X and extract compilation diagnostics from it. The problem is that C API exposes the serialized report where you have all the information about the issue + the `annotate-snippets` text, where the source line is embedded. However, if you'd like to build your own rich info diagnostic printer, you don't have the source line available.

Yes, you can cache the source code on the caller side but you probably don't want to do that if you have multiple files because YARA-X is also caching the source codes so doing it on 2 sides of the fence seems kind of redundant. This allows caller to not cache the source code, let YARA-X do the caching and extraction of the source lines and provide only the necessary parts.

If you think another solution is more appropriate, let me know. Thanks