### PR TITLE
fix: use dunce to canonicalize path in sli scan cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,6 +1209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5315,6 +5321,7 @@ dependencies = [
  "clap_complete",
  "crossbeam",
  "crossterm 0.29.0",
+ "dunce",
  "enable-ansi-support",
  "encoding_rs",
  "env_logger",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -71,6 +71,7 @@ yara-x-fmt = { workspace = true }
 chardetng = "0.1.17"
 crossbeam = "0.8.4"
 crossterm = "0.29.0"
+dunce = "1.0.5"
 encoding_rs = "0.8.35"
 superconsole = "0.2.0"
 unicode-width = "0.2.2"

--- a/cli/src/commands/scan.rs
+++ b/cli/src/commands/scan.rs
@@ -11,6 +11,7 @@ use clap::{
     arg, value_parser, Arg, ArgAction, ArgMatches, Command, ValueEnum,
 };
 use crossbeam::channel::Sender;
+use dunce;
 use itertools::Itertools;
 use superconsole::style::Stylize;
 use superconsole::{Component, Line, Lines, Span};
@@ -1069,8 +1070,7 @@ mod output_handler {
             scan_results: &mut dyn ExactSizeIterator<Item = Rule>,
             _output: &Sender<Message>,
         ) -> bool {
-            let path = file_path
-                .canonicalize()
+            let path = dunce::canonicalize(&file_path)
                 .ok()
                 .as_ref()
                 .and_then(|absolute| absolute.to_str())


### PR DESCRIPTION
After migration, our users reported strange path prefixes with YARA-X that were not used with YARA. Looks like a known "problem" that [dunce](https://crates.io/crates/dunce) solves. There are not many canonicalizations going on in YARA-X, but I still applied this only to the one-and-only use in CLI, which is the most user-facing and I didn't want to touch compiler etc.

```
"matches": [
    {
      "rule": "hunting_interpreter_wscript",
      "file": "\\\\?\\C:\\temp\\samples\\CBDE39ACCBB9420E0F65BEDB225C89EF7909D1FEEFFDF467AA0EC8F435906E7B",
      ...
    },
    ...
```