### PR TITLE
fix(ls): validate bool metadata as bool in diagnostics

### DIFF
--- a/ls/src/features/diagnostics.rs
+++ b/ls/src/features/diagnostics.rs
@@ -163,7 +163,7 @@ pub fn compiler_diagnostics(
                         |meta| {
                             matches!(
                                 meta.value,
-                                yara_x_parser::ast::MetaValue::Float(_)
+                                yara_x_parser::ast::MetaValue::Bool(_)
                             )
                         },
                         format!(


### PR DESCRIPTION
The LS was validating metadata rules with type = "bool" against MetaValue::Float(_), which caused incorrect diagnostics for valid boolean metadata