### PR TITLE
perf: optimize `BitmapSet` duplicate tracking

### DIFF
--- a/lib/src/re/bitmapset.rs
+++ b/lib/src/re/bitmapset.rs
@@ -123,6 +123,8 @@ where
         }
     }
 
+    /// Used for inserting a new (key, value) pair when we are sure
+    /// that the key doesn't exist yet.
     #[inline]
     fn insert_new_key(&mut self, key: usize, value: T) -> bool {
         if let Some(set) = &mut self.set {
@@ -135,15 +137,15 @@ where
         true
     }
 
+    /// Used for inserting a new (key, value) pair when we are sure
+    /// that another pair with the same key exists.
     #[inline]
     fn insert_existing_key(&mut self, key: usize, value: T) -> bool {
-        if self.set.is_none() {
+        let set = self.set.get_or_insert_with(|| {
             let mut set = FxHashSet::default();
-            set.reserve(self.items.len() + 1);
-            set.extend(self.items.iter().copied());
-            self.set = Some(set);
-        }
-        let set = self.set.as_mut().unwrap();
+            set.extend(self.items.iter());
+            set
+        });
         if set.insert((key, value)) {
             self.items.push((key, value));
             true

--- a/lib/src/re/bitmapset.rs
+++ b/lib/src/re/bitmapset.rs
@@ -32,8 +32,11 @@ where
     // Vector that contains the (key,value) pairs in the set, in insertion
     // order.
     items: Vec<(usize, T)>,
-    // Set that contains the (key,value) pairs.
-    set: FxHashSet<(usize, T)>,
+    // Hash index used for pairs that can't be decided by the bitmap and
+    // first-item checks once a key collision has been observed. Most VM
+    // frontiers insert a key only once; keeping this lazy avoids hashing every
+    // cold, bitmap-proven-new key.
+    set: Option<FxHashSet<(usize, T)>>,
     // Bitmap for keys that are > initial_key.
     p_bitmap: BitVec<usize>,
     // Bitmap for keys that are < initial_key.
@@ -49,7 +52,7 @@ where
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
-            set: FxHashSet::default(),
+            set: None,
             p_bitmap: BitVec::repeat(false, 1024),
             n_bitmap: BitVec::repeat(false, 1024),
         }
@@ -92,17 +95,12 @@ where
                         assert!(offset < Self::MAX_OFFSET);
                         self.n_bitmap.resize(offset + 1, false);
                         self.n_bitmap.set_unchecked(offset, true);
-                        self.items.push((key, value));
-                        self.set.insert((key, value))
+                        self.insert_new_key(key, value)
                     } else if !*self.n_bitmap.get_unchecked(offset) {
                         self.n_bitmap.set_unchecked(offset, true);
-                        self.items.push((key, value));
-                        self.set.insert((key, value))
-                    } else if self.set.insert((key, value)) {
-                        self.items.push((key, value));
-                        true
+                        self.insert_new_key(key, value)
                     } else {
-                        false
+                        self.insert_existing_key(key, value)
                     }
                 }
             }
@@ -113,20 +111,44 @@ where
                         assert!(offset < Self::MAX_OFFSET);
                         self.p_bitmap.resize(offset + 1, false);
                         self.p_bitmap.set_unchecked(offset, true);
-                        self.items.push((key, value));
-                        self.set.insert((key, value))
+                        self.insert_new_key(key, value)
                     } else if !*self.p_bitmap.get_unchecked(offset) {
                         self.p_bitmap.set_unchecked(offset, true);
-                        self.items.push((key, value));
-                        self.set.insert((key, value))
-                    } else if self.set.insert((key, value)) {
-                        self.items.push((key, value));
-                        true
+                        self.insert_new_key(key, value)
                     } else {
-                        false
+                        self.insert_existing_key(key, value)
                     }
                 }
             }
+        }
+    }
+
+    #[inline]
+    fn insert_new_key(&mut self, key: usize, value: T) -> bool {
+        if let Some(set) = &mut self.set {
+            // Once duplicate-key tracking is active, record this pair so
+            // future duplicate-key checks remain O(1).
+            let inserted = set.insert((key, value));
+            debug_assert!(inserted);
+        }
+        self.items.push((key, value));
+        true
+    }
+
+    #[inline]
+    fn insert_existing_key(&mut self, key: usize, value: T) -> bool {
+        if self.set.is_none() {
+            let mut set = FxHashSet::default();
+            set.reserve(self.items.len() + 1);
+            set.extend(self.items.iter().copied());
+            self.set = Some(set);
+        }
+        let set = self.set.as_mut().unwrap();
+        if set.insert((key, value)) {
+            self.items.push((key, value));
+            true
+        } else {
+            false
         }
     }
 
@@ -153,7 +175,9 @@ where
                 }
             }
         }
-        self.set.clear();
+        if let Some(set) = &mut self.set {
+            set.clear();
+        }
     }
 
     /// Returns an iterator for the items in the set.
@@ -187,10 +211,21 @@ mod tests {
         assert!(!s.insert(2000, 0));
         assert!(s.insert(4, 1));
         assert!(!s.insert(4, 1));
+        assert!(s.insert(2, 1));
+        assert!(!s.insert(2, 1));
 
         assert_eq!(
             s.items,
-            vec![(4, 0), (2, 0), (3, 0), (10, 0), (0, 0), (2000, 0), (4, 1)]
+            vec![
+                (4, 0),
+                (2, 0),
+                (3, 0),
+                (10, 0),
+                (0, 0),
+                (2000, 0),
+                (4, 1),
+                (2, 1)
+            ]
         );
 
         s.clear();
@@ -203,10 +238,12 @@ mod tests {
         assert!(s.insert(10, 0));
         assert!(s.insert(300, 0));
         assert!(s.insert(250, 0));
+        assert!(s.insert(200, 1));
+        assert!(!s.insert(200, 1));
 
         assert_eq!(
             s.items,
-            vec![(200, 0), (3, 0), (10, 0), (300, 0), (250, 0)]
+            vec![(200, 0), (3, 0), (10, 0), (300, 0), (250, 0), (200, 1)]
         );
     }
 }


### PR DESCRIPTION
  ## Summary

  This changes `BitmapSet` so its hash index is materialized lazily, only after a key collision requires
  checking more than the bitmap/first-item fast paths.

  For bitmap-proven-new keys, `BitmapSet::insert` can now append directly without hashing the `(key,
  value)` pair. Once duplicate-key tracking is activated, new pairs are also recorded in the hash index so
  later duplicate checks remain O(1).

  The existing insertion-order behavior is preserved, and the `thread_set` test now covers same-key/
  different-value inserts, duplicate rejection, and reuse after `clear()`.

  ## Benchmark

  I used a small external release-mode benchmark with `yara-x` as a path dependency, `default-features =
  false`, `features = ["linkme"]`, to focus on the Pike VM path.

  Regex stress rule:

  ```yara
  rule pike_regex_stress {
    strings:
      $re = /ABCD.{0,256}(foo|bar|baz|quux){2,6}XYZ/
    condition:
      $re
  }

  Input: 350 repeated ABCD + 256 bytes + ZZZ segments, 92,050 bytes total, 20 warmups, 120 measured scans.

  baseline main:  median_ms=9.777218, mean_ms=9.774727
  patched branch: median_ms=5.840666, mean_ms=5.883286

  I also checked a simple positive regex workload with default features enabled:

  baseline: median_ms=3.104918 / 3.136119
  patched:  median_ms=3.121736 / 3.127951

  That workload did not show a meaningful median regression in my local runs.

  ## Validation

  cargo +1.91.0 fmt --check
  cargo +1.91.0 test -p yara-x --features linkme --lib
  cargo +1.91.0 test -p yara-x --no-default-features --features linkme re::bitmapset::tests::thread_set
  git diff --check origin/main...HEAD

  cargo +1.91.0 test -p yara-x --features linkme --lib passed with 246 tests.
