### PR TITLE
perf: optimize checksum32 computation

### DIFF
--- a/lib/src/modules/hash/mod.rs
+++ b/lib/src/modules/hash/mod.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::convert::TryInto;
 
 use md5::Md5;
 use rustc_hash::FxHashMap;
@@ -213,6 +214,27 @@ fn crc_str(ctx: &ScanContext, s: RuntimeString) -> Option<i64> {
     Some(crc.into())
 }
 
+#[inline]
+fn checksum32(data: &[u8]) -> u32 {
+    let mut sum = 0_u64;
+    let mut chunks = data.chunks_exact(8);
+
+    for chunk in &mut chunks {
+        let x = u64::from_le_bytes(chunk.try_into().unwrap());
+        let pairs = (x & 0x00ff_00ff_00ff_00ff)
+            + ((x >> 8) & 0x00ff_00ff_00ff_00ff);
+        let quads = (pairs & 0x0000_ffff_0000_ffff)
+            + ((pairs >> 16) & 0x0000_ffff_0000_ffff);
+        sum = sum.wrapping_add((quads & 0xffff_ffff) + (quads >> 32));
+    }
+
+    let mut checksum = sum as u32;
+    for byte in chunks.remainder() {
+        checksum = checksum.wrapping_add(*byte as u32);
+    }
+    checksum
+}
+
 /// Calculates the 32-bit checksum of a portion of the scanned data.
 #[module_export(name = "checksum32")]
 fn checksum_data(ctx: &ScanContext, offset: i64, size: i64) -> Option<i64> {
@@ -226,11 +248,7 @@ fn checksum_data(ctx: &ScanContext, offset: i64, size: i64) -> Option<i64> {
 
     let range = offset.try_into().ok()?..(offset + size).try_into().ok()?;
     let data = ctx.scanned_data()?.get(range)?;
-    let mut checksum = 0_u32;
-
-    for byte in data {
-        checksum = checksum.wrapping_add(*byte as u32)
-    }
+    let checksum = checksum32(data);
 
     CHECKSUM32_CACHE.with(|cache| {
         cache.borrow_mut().insert((offset, size), checksum.into());
@@ -242,9 +260,5 @@ fn checksum_data(ctx: &ScanContext, offset: i64, size: i64) -> Option<i64> {
 /// Calculates the 32-bit checksum of a string.
 #[module_export(name = "checksum32")]
 fn checksum_str(ctx: &ScanContext, s: RuntimeString) -> Option<i64> {
-    let mut checksum = 0_u32;
-    for byte in s.as_bstr(ctx).as_bytes() {
-        checksum = checksum.wrapping_add(*byte as u32)
-    }
-    Some(checksum.into())
+    Some(checksum32(s.as_bstr(ctx).as_bytes()).into())
 }

--- a/lib/src/modules/hash/tests/mod.rs
+++ b/lib/src/modules/hash/tests/mod.rs
@@ -82,3 +82,15 @@ fn test_hash_module() {
         b"TEST STRING"
     );
 }
+
+#[test]
+#[cfg(feature = "hash-module")]
+fn checksum32_chunks_match_byte_sum() {
+    let data = (0..257).map(|n| n as u8).collect::<Vec<_>>();
+    let expected = data
+        .iter()
+        .fold(0_u32, |sum, byte| sum.wrapping_add(*byte as u32));
+
+    assert_eq!(super::checksum32(&data), expected);
+    assert_eq!(super::checksum32(&[255; 257]), 65_535);
+}


### PR DESCRIPTION
  ## Summary

  This PR optimizes the `hash.checksum32` implementation by summing input bytes in 8-byte chunks instead
  of iterating byte by byte.

  The public behavior is unchanged: the checksum still uses wrapping `u32` addition over all bytes. Both
  the file-range and string variants now share the same helper, which also avoids duplicating the checksum
  loop.

  ## Benchmark

  Benchmarked locally against `origin/main` at `8a241d9e`, using a temporary benchmark crate with `yara-x
  = { default-features = false, features = ["linkme", "hash-module"] }`.

  Benchmark rule:

  ```yara
  import "hash"

  rule checksum_full {
    condition:
      hash.checksum32(0, filesize) >= 0
  }

  Benchmark setup:

  - Rust 1.91.0
  - Release build
  - 3 warmup scans
  - 20 measured scans
  - Reported values are medians in milliseconds
  - overhead subtracts an empty condition: true rule scan from the checksum rule scan
  - Lower is better

  | Input size | main overhead | PR overhead | Speedup |
  | ---: | ---: | ---: | ---: |
  | 64 MiB | 8.508 ms | 5.495 ms | 1.55x |
  | 128 MiB | 17.019 ms | 10.905 ms | 1.56x |

  The improvement is intentionally scoped to rules that use hash.checksum32; general scans without that
  module call are unaffected.

  ## Validation

  Ran locally with Rust 1.91.0:

  cargo +1.91.0 fmt --check
  cargo +1.91.0 test -p yara-x --no-default-features --features linkme,hash-module checksum32 --lib
  cargo +1.91.0 test -p yara-x --no-default-features --features linkme,hash-module test_hash_module --lib
  cargo +1.91.0 check -p yara-x --no-default-features --features linkme,hash-module
  git diff --check

  Results:

  - New checksum32 chunking test passed.
  - Existing hash module checksum tests passed.
  - check, fmt, and diff --check passed.
