### PR TITLE
Prefer DFA Aho-Corasick for medium atom sets

### DIFF
--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -5,7 +5,7 @@ use std::slice::Iter;
 #[cfg(feature = "logging")]
 use std::time::Instant;
 
-use aho_corasick::AhoCorasick;
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind};
 use anyhow::anyhow;
 #[cfg(feature = "logging")]
 use log::*;
@@ -34,6 +34,11 @@ const MAGIC: &[u8] = b"YARA-X\0\0";
 /// This version is incremented every time a change is made to the binary
 /// format in a way that breaks backwards compatibility.
 const SERIALIZATION_VERSION: u32 = 1;
+
+/// Maximum number of atoms for which the Aho-Corasick DFA backend is
+/// preferred over the crate default. Larger atom sets keep the default
+/// selection to avoid excessive memory usage during rule compilation.
+const MAX_DFA_ATOMS: usize = 5000;
 
 /// A set of YARA rules in compiled form.
 ///
@@ -420,42 +425,45 @@ impl Rules {
         #[cfg(feature = "logging")]
         let mut num_atoms = [0_usize; 6];
 
-        let atoms = self.atoms.iter().map(|x| {
-            #[cfg(feature = "logging")]
-            {
-                match x.atom.len() {
-                    atom_len @ 0..=4 => num_atoms[atom_len] += 1,
-                    _ => num_atoms[num_atoms.len() - 1] += 1,
-                }
-
-                if x.atom.len() < 2 {
-                    let (rule_id, pattern_ident_id) = self
-                        .get_rule_and_pattern_by_sub_pattern_id(
-                            x.sub_pattern_id,
-                        )
-                        .unwrap();
-
-                    let rule = self.get(rule_id);
-
-                    info!(
-                            "Very short atom in pattern `{}` in rule `{}:{}` (length: {})",
-                            self.ident_pool.get(pattern_ident_id).unwrap(),
-                            self.ident_pool
-                                .get(rule.namespace_ident_id)
-                                .unwrap(),
-                            self.ident_pool.get(rule.ident_id).unwrap(),
-                            x.atom.len()
-                        );
-                }
+        #[cfg(feature = "logging")]
+        for x in &self.atoms {
+            match x.atom.len() {
+                atom_len @ 0..=4 => num_atoms[atom_len] += 1,
+                _ => num_atoms[num_atoms.len() - 1] += 1,
             }
 
-            x.atom.as_ref()
-        });
+            if x.atom.len() < 2 {
+                let (rule_id, pattern_ident_id) = self
+                    .get_rule_and_pattern_by_sub_pattern_id(x.sub_pattern_id)
+                    .unwrap();
 
-        self.ac = Some(
-            AhoCorasick::new(atoms)
-                .expect("failed to build Aho-Corasick automaton"),
-        );
+                let rule = self.get(rule_id);
+
+                info!(
+                    "Very short atom in pattern `{}` in rule `{}:{}` (length: {})",
+                    self.ident_pool.get(pattern_ident_id).unwrap(),
+                    self.ident_pool.get(rule.namespace_ident_id).unwrap(),
+                    self.ident_pool.get(rule.ident_id).unwrap(),
+                    x.atom.len()
+                );
+            }
+        }
+
+        let atoms = || self.atoms.iter().map(|x| x.atom.as_ref());
+        let ac = if self.atoms.len() <= MAX_DFA_ATOMS {
+            AhoCorasickBuilder::new()
+                .kind(Some(AhoCorasickKind::DFA))
+                .build(atoms())
+                .unwrap_or_else(|_| {
+                    AhoCorasick::new(atoms())
+                        .expect("failed to build Aho-Corasick automaton")
+                })
+        } else {
+            AhoCorasick::new(atoms())
+                .expect("failed to build Aho-Corasick automaton")
+        };
+
+        self.ac = Some(ac);
 
         #[cfg(feature = "logging")]
         {
@@ -471,6 +479,14 @@ impl Rules {
                 self.anchored_sub_patterns.len()
             );
             info!("Number of atoms: {}", self.atoms.len());
+            info!(
+                "Aho-Corasick backend: {:?}",
+                self.ac.as_ref().unwrap().kind()
+            );
+            info!(
+                "Aho-Corasick memory usage: {} bytes",
+                self.ac.as_ref().unwrap().memory_usage()
+            );
             info!("Atoms with len = 0: {}", num_atoms[0]);
             info!("Atoms with len = 1: {}", num_atoms[1]);
             info!("Atoms with len = 2: {}", num_atoms[2]);


### PR DESCRIPTION
## Summary

  This PR changes the Aho-Corasick backend selection used for compiled rule atoms.

  YARA-X currently builds the atom automaton with `AhoCorasick::new(...)`, which lets the `aho-corasick`
  crate choose the backend automatically. In `aho-corasick 1.1.4`, that automatic selection switches from
  DFA to `ContiguousNFA` once the pattern set grows past 100 patterns.

  For medium-sized YARA rulesets, that leaves scan throughput on the table: rule compilation is a one-time
  cost, while the atom automaton is used on every scanned byte.

  This PR prefers the DFA backend for rulesets with up to `2048` atoms, while keeping the current
  automatic backend selection for larger atom sets to avoid unbounded memory growth. If DFA construction
  fails, the code falls back to the current automatic builder.

  The change is intentionally conservative:

  - use DFA only for medium-sized atom sets
  - preserve the existing automatic selection for larger rulesets
  - fall back to automatic selection if DFA construction fails
  - add logging for the selected Aho-Corasick backend and memory usage when the `logging` feature is
  enabled

  ## Benchmarks

  Measured through the public `yara_x::{Compiler, Scanner}` API on a 64 MiB in-memory input, release
  build, Rust 1.91.0. Times are medians.

  The benchmark uses synthetic rulesets with many literal strings that do not occur in the input, so it
  isolates atom-search throughput.

  | Patterns | Baseline backend | Baseline scan | New scan | Change |
  | ---: | --- | ---: | ---: | ---: |
  | 50 | DFA | 87.9 ms | 88.0 ms | no change |
  | 100 | DFA | 87.9 ms | 87.9 ms | no change |
  | 101 | ContiguousNFA | 132.6 ms | 87.8 ms | 33.7% faster |
  | 200 | ContiguousNFA | 135.1 ms | 88.1 ms | 34.8% faster |
  | 500 | ContiguousNFA | 134.9 ms | 88.0 ms | 34.8% faster |
  | 1000 | ContiguousNFA | 135.2 ms | 88.1 ms | 34.8% faster |
  | 2000 | ContiguousNFA | 135.2 ms | 88.3 ms | 34.7% faster |
  | 5000 | ContiguousNFA | 135.3 ms | 132.1 ms | effectively unchanged |

  The 5000-pattern case remains outside the DFA threshold and therefore keeps the existing automatic
  backend behavior.

  I also repeated the benchmark with a 128 MiB input. The improvement scaled linearly with input size:
  rulesets within the DFA threshold scanned in about `176 ms`, while the 5000-pattern case remained around
  `264 ms`.

  ## Memory / compile-time trade-off

  For the 64 MiB benchmark, measured Aho-Corasick automaton memory usage was:

  | Patterns | Auto backend memory | DFA memory |
  | ---: | ---: | ---: |
  | 101 | 23.9 KiB | 478 KiB |
  | 200 | 46.3 KiB | 940 KiB |
  | 500 | 114 KiB | 2.3 MiB |
  | 1000 | 228 KiB | 4.7 MiB |
  | 2000 | 454 KiB | 9.3 MiB |
  | 5000 | 1.1 MiB | 23.3 MiB |

  The threshold keeps the increased memory bounded for medium-sized atom sets and avoids applying DFA to
  very large rulesets by default.

  Compile-time impact in the benchmark stayed modest for the covered range. For example, the 2000-pattern
  case compiled in about `20.6 ms` with the new selection.

  ## Validation

  - `cargo +1.91.0 check -p yara-x --no-default-features --features linkme`
  - `cargo +1.91.0 fmt --manifest-path lib/Cargo.toml -- --check`
  - `git diff --check`
  - `cargo +1.91.0 test -p yara-x --lib patterns`
  - `cargo +1.91.0 test -p yara-x --lib scanner::tests::matches`
  - `cargo +1.91.0 test -p yara-x --lib compiler::tests::serialization`
