### PR TITLE
perf(scanner): optimize XOR match verification

### DIFF
--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -1549,19 +1549,60 @@ fn verify_xor_match(
         return None;
     }
 
+    let candidate = &scanned_data[match_start..match_end];
+
     if key == 0 {
-        if pattern != &scanned_data[match_start..match_end] {
+        if pattern != candidate {
             return None;
         }
-    } else {
-        for (i, b) in scanned_data[match_start..match_end].iter().enumerate() {
-            if pattern[i] != b ^ key {
-                return None;
-            }
-        }
+    } else if !xor_slices_eq(pattern, candidate, key) {
+        return None;
     }
 
     Some(key)
+}
+
+#[inline]
+fn xor_slices_eq(pattern: &[u8], candidate: &[u8], key: u8) -> bool {
+    debug_assert_eq!(pattern.len(), candidate.len());
+
+    if pattern.len() < 8 {
+        let key_word = u32::from_ne_bytes([key; 4]);
+        let (pattern_chunks, pattern_remainder) = pattern.as_chunks::<4>();
+        let (candidate_chunks, candidate_remainder) =
+            candidate.as_chunks::<4>();
+
+        for (pattern, candidate) in pattern_chunks.iter().zip(candidate_chunks)
+        {
+            let pattern = u32::from_ne_bytes(*pattern);
+            let candidate = u32::from_ne_bytes(*candidate);
+            if pattern != candidate ^ key_word {
+                return false;
+            }
+        }
+
+        return pattern_remainder
+            .iter()
+            .zip(candidate_remainder)
+            .all(|(pattern, candidate)| *pattern == (*candidate ^ key));
+    }
+
+    let key_word = u64::from_ne_bytes([key; 8]);
+    let (pattern_chunks, pattern_remainder) = pattern.as_chunks::<8>();
+    let (candidate_chunks, candidate_remainder) = candidate.as_chunks::<8>();
+
+    for (pattern, candidate) in pattern_chunks.iter().zip(candidate_chunks) {
+        let pattern = u64::from_ne_bytes(*pattern);
+        let candidate = u64::from_ne_bytes(*candidate);
+        if pattern != candidate ^ key_word {
+            return false;
+        }
+    }
+
+    pattern_remainder
+        .iter()
+        .zip(candidate_remainder)
+        .all(|(pattern, candidate)| *pattern == (*candidate ^ key))
 }
 
 /// Verifies that `pattern` actually matches in base64 form at `match_start`


### PR DESCRIPTION
## Summary

  This PR speeds up verification for strings using the `xor` modifier by comparing candidates in fixed-
  size integer chunks instead of byte by byte for non-zero XOR keys.

  The scanner already derives the XOR key from the matching atom and checks `fullword` boundaries before
  verifying the whole candidate. This change keeps that flow intact, but moves the candidate comparison
  into a helper that uses 32-bit chunks for 4-7 byte patterns, 64-bit chunks for 8+ byte patterns, and
  byte comparisons for the remaining tail bytes.

  The zero-key path still uses the existing slice equality check.

  ## Benchmarks

  Local benchmark harness using the public `Compiler`/`Scanner` API, Rust `1.91.0`, release build,
  `default-features = false`, features `linkme,exact-atoms`. Each number is the median of 12 scans after
  warmup, comparing this branch against `origin/main` at `b808a258`.

  | Case | main | this PR | Change |
  | --- | ---: | ---: | ---: |
  | `xor_long_false` | 48.774 ms | 36.635 ms | -24.9% |
  | `xor_long_positive` | 49.983 ms | 37.883 ms | -24.2% |
  | `xor_short_false` | 1.635 ms | 1.556 ms | -4.8% |
  | `xor_short_positive` | 2.432 ms | 2.345 ms | -3.6% |
  | `nocase_long_false` control | 39.787 ms | 39.670 ms | ~0% |
  | `fullword_boundary_fail` control | 1.508 ms | 1.503 ms | ~0% |

  ## Validation

  - `cargo +1.91.0 fmt --manifest-path lib/Cargo.toml -- --check`
  - `git diff --check`
  - `cargo +1.91.0 check -p yara-x --no-default-features --features linkme,exact-atoms`
  - `cargo +1.91.0 test -p yara-x --lib xor --no-default-features --features linkme,exact-atoms`
  - `cargo +1.91.0 test -p yara-x --lib xor`
