### PR TITLE
chore(deps): bump `async-lsp` to 0.2.4 in `ls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "async-lsp"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1c85c4bb41706ad1f8338e39fa725a24bc642be41140a38d818c93b9ae91f5"
+checksum = "c8b8fd1e175c5ee3108095da452e816519de618beccea23aa053c00cf5e344b9"
 dependencies = [
  "futures",
  "lsp-types",

--- a/ls/Cargo.toml
+++ b/ls/Cargo.toml
@@ -43,11 +43,11 @@ yara-x = { workspace = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.17", features = ["compat"] }
-async-lsp = {version = "0.2.2", default-features=false, features=["omni-trait", "tokio", "stdio", "tracing"]}
+async-lsp = {version = "0.2.4", default-features=false, features=["omni-trait", "tokio", "stdio", "tracing"]}
 walkdir = "2.5.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-async-lsp = {version = "0.2.2", default-features=false, features=["omni-trait"]}
+async-lsp = {version = "0.2.4", default-features=false, features=["omni-trait"]}
 console_error_panic_hook = "0.1.7"
 js-sys = "0.3.90"
 wasm-bindgen = { workspace = true }


### PR DESCRIPTION
New version contains [bug fix](https://github.com/oxalica/async-lsp/pull/26) in the middleware that is used in the YARA-X language server (`ConcurrencyLayer`).