### PR TITLE
fix(py): avoid panic on bad reader input

### DIFF
--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -255,10 +255,10 @@ impl Read for PyReader {
                 self.obj.call_method1(py, consts::read(py), (buf.len(),))?;
 
             let bytes = if self.is_text_io {
-                let s = data.extract::<Cow<str>>(py).unwrap();
+                let s = data.extract::<Cow<str>>(py)?;
                 s.as_bytes().to_vec()
             } else {
-                data.extract::<Cow<[u8]>>(py).unwrap().to_vec()
+                data.extract::<Cow<[u8]>>(py)?.to_vec()
             };
 
             if bytes.is_empty() {
@@ -775,9 +775,19 @@ impl Compiler {
             yrx::linters::metadata(identifier).required(required).error(error);
         match value_type {
             MetaType::STRING => {
+                let compiled_regex = regexp
+                    .as_ref()
+                    .map(|regexp| -> PyResult<(regex::Regex, regex::bytes::Regex)> {
+                        Ok((
+                            regex::Regex::new(regexp.as_str())
+                                .map_err(|err| PyValueError::new_err(err.to_string()))?,
+                            regex::bytes::Regex::new(regexp.as_str())
+                                .map_err(|err| PyValueError::new_err(err.to_string()))?,
+                        ))
+                    })
+                    .transpose()?;
+
                 let message = if let Some(regexp) = regexp.clone() {
-                    let _ = regex::bytes::Regex::new(regexp.as_str())
-                        .map_err(|err| PyValueError::new_err(err.to_string()));
                     format!(
                         "`{identifier}` must be a string that matches `/{regexp}/`"
                     )
@@ -785,16 +795,12 @@ impl Compiler {
                     format!("`{identifier}` must be a string")
                 };
                 linter = linter.validator(
-                    move |meta| match (&meta.value, &regexp) {
-                        (MetaValue::String((s, _)), Some(regexp)) => {
-                            regex::Regex::new(regexp.as_str())
-                                .unwrap()
-                                .is_match(s)
+                    move |meta| match (&meta.value, &compiled_regex) {
+                        (MetaValue::String((s, _)), Some((regexp, _))) => {
+                            regexp.is_match(s)
                         }
-                        (MetaValue::Bytes((s, _)), Some(regexp)) => {
-                            regex::bytes::Regex::new(regexp.as_str())
-                                .unwrap()
-                                .is_match(s)
+                        (MetaValue::Bytes((s, _)), Some((_, regexp))) => {
+                            regexp.is_match(s)
                         }
                         (MetaValue::String(_), None) => true,
                         (MetaValue::Bytes(_), None) => true,
@@ -1540,6 +1546,9 @@ fn yara_x(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Formatter>()?;
     m.add_class::<Module>()?;
     m.add_class::<MetaType>()?;
-    m.gil_used(false)?;
+    // This module still exposes unsendable classes and uses unsafe lifetime
+    // extensions in the bindings, so it should not advertise free-threaded
+    // safety until the API is properly audited and redesigned.
+    m.gil_used(true)?;
     Ok(())
 }

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -775,17 +775,31 @@ impl Compiler {
             yrx::linters::metadata(identifier).required(required).error(error);
         match value_type {
             MetaType::STRING => {
-                let compiled_regex = regexp
-                    .as_ref()
-                    .map(|regexp| -> PyResult<(regex::Regex, regex::bytes::Regex)> {
-                        Ok((
-                            regex::Regex::new(regexp.as_str())
-                                .map_err(|err| PyValueError::new_err(err.to_string()))?,
-                            regex::bytes::Regex::new(regexp.as_str())
-                                .map_err(|err| PyValueError::new_err(err.to_string()))?,
-                        ))
-                    })
-                    .transpose()?;
+                let compiled_regex =
+                    regexp
+                        .as_ref()
+                        .map(
+                            |regexp| -> PyResult<(
+                                regex::Regex,
+                                regex::bytes::Regex,
+                            )> {
+                                Ok((
+                                    regex::Regex::new(regexp.as_str())
+                                        .map_err(|err| {
+                                            PyValueError::new_err(
+                                                err.to_string(),
+                                            )
+                                        })?,
+                                    regex::bytes::Regex::new(regexp.as_str())
+                                        .map_err(|err| {
+                                            PyValueError::new_err(
+                                                err.to_string(),
+                                            )
+                                        })?,
+                                ))
+                            },
+                        )
+                        .transpose()?;
 
                 let message = if let Some(regexp) = regexp.clone() {
                     format!(

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -35,6 +35,12 @@ def test_invalid_rule_name_regexp():
     compiler.allowed_rule_name("(AXS|ERS")
 
 
+def test_invalid_allowed_metadata_regexp():
+  compiler = yara_x.Compiler()
+  with pytest.raises(ValueError):
+    compiler.allowed_metadata('author', yara_x.MetaType.STRING, regexp='(AXS|ERS')
+
+
 def test_int_globals():
   compiler = yara_x.Compiler()
   compiler.define_global('some_int', 1)
@@ -271,6 +277,14 @@ def test_serialization():
   f.seek(0)
   rules = yara_x.Rules.deserialize_from(f)
   assert len(rules.scan(b'').matching_rules) == 1
+
+def test_deserialize_from_bad_reader_raises_ioerror():
+  class BadReader:
+    def read(self, n):
+      return 123
+
+  with pytest.raises(OSError):
+    yara_x.Rules.deserialize_from(BadReader())
 
 
 def tests_compiler_errors():


### PR DESCRIPTION
## Summary

Fix three robustness issues in the Python bindings:

- `Rules.deserialize_from()` no longer panics when a file-like object's `read()` method returns an invalid type
- `Compiler.allowed_metadata(..., regexp=...)` now rejects invalid regexes eagerly instead of panicking later during validation
- the module no longer advertises free-threaded support while it still exposes `unsendable` classes and extends Rust lifetimes with `unsafe`

## What changed

In `py/src/lib.rs`:

- replaced two `unwrap()` calls in `PyReader` with normal error propagation
- validated and precompiled metadata regexes in `allowed_metadata()` instead of ignoring regex compilation errors and unwrapping later
- changed the module declaration to `gil_used(true)`

In `py/tests/test_api.py`:

- added a regression test ensuring a bad `read()` implementation raises `OSError` instead of surfacing a Rust panic
- added a regression test ensuring an invalid metadata regex raises `ValueError`

## Why

`PyReader` previously assumed that `read()` returned either `str` or `bytes`-like data and used `unwrap()` on the extraction path. A malformed file-like object could therefore trigger a `PanicException` from Python.

Separately, `allowed_metadata()` attempted to validate regexes but discarded the error, and then later recompiled the same regex inside the linter closure with `unwrap()`. Invalid regexes were therefore accepted at configuration time and could panic later when a rule was compiled / evaluated.

Finally, the module was marked with `gil_used(false)` even though the bindings still expose `#[pyclass(unsendable)]` types such as `Scanner` and `Compiler`, and use `unsafe` lifetime extensions for `Scanner` / `RulesIter`. That is not a good state to advertise as free-threaded-safe yet.

## Validation

Ran:

- `cargo +1.91.0 fmt --all --check`