### PR TITLE
feat: allow specifying context size for matches

### DIFF
--- a/lib/src/models.rs
+++ b/lib/src/models.rs
@@ -447,6 +447,18 @@ impl<'a> Match<'a, '_> {
         data.unwrap()
     }
 
+    /// Slice containing the data that matched with additional bytes
+    /// at the left and right if possible.
+    pub fn data_with_context(&self) -> &'a [u8] {
+        let data = match &self.ctx.scan_state {
+            ScanState::Finished(snippets) => snippets
+                .get_with_context(self.range(), self.ctx.match_context_size),
+            _ => None,
+        };
+
+        data.unwrap()
+    }
+
     /// XOR key used for decrypting the data if the pattern had the `xor`
     /// modifier, or `None` if otherwise.
     #[inline]

--- a/lib/src/models.rs
+++ b/lib/src/models.rs
@@ -439,24 +439,29 @@ impl<'a> Match<'a, '_> {
     /// Slice containing the data that matched.
     #[inline]
     pub fn data(&self) -> &'a [u8] {
-        let data = match &self.ctx.scan_state {
-            ScanState::Finished(snippets) => snippets.get(self.range()),
-            _ => None,
-        };
-
-        data.unwrap()
+        match &self.ctx.scan_state {
+            ScanState::Finished(snippets) => {
+                snippets.get(self.range()).unwrap()
+            }
+            _ => panic!("invalid scan state"),
+        }
     }
 
-    /// Slice containing the data that matched with additional bytes
-    /// at the left and right if possible.
-    pub fn data_with_context(&self) -> &'a [u8] {
-        let data = match &self.ctx.scan_state {
+    /// Similar to [`Match::data`] but returns a slice that covers the match
+    /// and some extra bytes at its left and right. The returned range indicates
+    /// the portion of the slice that corresponds to the match itself.
+    ///
+    /// Calling this function only makes sense if [`Scanner::match_context_size`]
+    /// is used for indicating how many bytes at the left and right of each
+    /// match are desired. Otherwise, this function will return the same result
+    /// as [`Match::data`].
+    pub fn data_with_context(&self) -> (&'a [u8], Range<usize>) {
+        match &self.ctx.scan_state {
             ScanState::Finished(snippets) => snippets
-                .get_with_context(self.range(), self.ctx.match_context_size),
-            _ => None,
-        };
-
-        data.unwrap()
+                .get_with_context(self.range(), self.ctx.match_context_size)
+                .unwrap(),
+            _ => panic!("invalid scan state"),
+        }
     }
 
     /// XOR key used for decrypting the data if the pattern had the `xor`

--- a/lib/src/scanner/blocks.rs
+++ b/lib/src/scanner/blocks.rs
@@ -4,6 +4,7 @@ This scanner is designed for scenarios where the data to be scanned is not
 available as a single contiguous block of memory, but rather arrives in
 smaller, discrete blocks, allowing for incremental scanning.
 */
+use std::cmp;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::mem;
@@ -95,6 +96,17 @@ impl<'r> Scanner<'r> {
             snippets: BTreeMap::new(),
         }
     }
+
+    /// Sets the context size for matches.
+    ///
+    /// This specifies how many bytes at the left and right of each match will
+    /// be reported by [`crate::Match::data_with_context`]. By default, the
+    /// match context size is 0, which means that [`crate::Match::data_with_context`]
+    /// will return exactly the same data as [`crate::Match::data`].
+    pub fn match_context_size(&mut self, size: usize) -> &mut Self {
+        self.scan_context_mut().match_context_size = size;
+        self
+    }
 }
 impl<'r> Scanner<'r> {
     /// Scans a block of data.
@@ -166,28 +178,30 @@ impl<'r> Scanner<'r> {
             for match_ in
                 match_list.iter().filter(|match_| match_.base == base)
             {
-                if let Some(match_data) = data.get(match_.block_range()) {
-                    // Snippets are indexed by their offsets within the scanned
-                    // data. This offset is not relative to the start of the
-                    // memory block, it takes into account the block's base
-                    // offset.
-                    //
-                    // The matching data is stored into the snippets B-tree map.
-                    // If an entry exists for the same offset, it will be replaced
-                    // with the new matching data only if it's larger than the
-                    // existing one.
-                    match self.snippets.entry(match_.range.start) {
+                let context_start = cmp::max(
+                    match_.range.start.saturating_sub(ctx.match_context_size),
+                    base,
+                );
+
+                let context_end = cmp::min(
+                    match_.range.end + ctx.match_context_size,
+                    base + data.len(),
+                );
+
+                let block_start = context_start - base;
+                let block_end = context_end - base;
+
+                if let Some(context_data) = data.get(block_start..block_end) {
+                    // Snippets are indexed by the offset where the context starts.
+                    match self.snippets.entry(context_start) {
                         Entry::Occupied(mut entry) => {
                             let snippet = entry.get_mut();
-                            if match_data.len() > snippet.len() {
-                                debug_assert!(match_data.starts_with(snippet));
-                                entry.insert(match_data.to_vec());
-                            } else {
-                                debug_assert!(snippet.starts_with(match_data));
+                            if context_data.len() > snippet.len() {
+                                entry.insert(context_data.to_vec());
                             }
                         }
                         Entry::Vacant(entry) => {
-                            entry.insert(match_data.to_vec());
+                            entry.insert(context_data.to_vec());
                         }
                     }
                 } else {
@@ -375,6 +389,40 @@ mod tests {
         let match2 = matches.next().unwrap();
         assert_eq!(match2.data(), b"ipsum".as_slice());
         assert_eq!(match2.range(), 1006..1011);
+    }
+
+    #[test]
+    fn block_scanner_context() {
+        let rules = compile(
+            r#"
+            rule test { strings: $a = "ipsum" condition: $a }"#,
+        )
+        .unwrap();
+
+        let mut scanner = Scanner::new(&rules);
+
+        let results = scanner
+            .match_context_size(5)
+            .scan(0, b"Lorem ipsum sit amet")
+            .unwrap()
+            .scan(1000, b"dolor ipsum sit amet")
+            .unwrap()
+            .finish()
+            .unwrap();
+
+        assert_eq!(results.matching_rules().len(), 1);
+
+        let rule = results.matching_rules().next().unwrap();
+        let pattern = rule.patterns().next().unwrap();
+        let mut matches = pattern.matches();
+
+        let match1 = matches.next().unwrap();
+        let data1 = match1.data_with_context();
+        assert_eq!(data1, b"orem ipsum sit ".as_slice());
+
+        let match2 = matches.next().unwrap();
+        let data2 = match2.data_with_context();
+        assert_eq!(data2, b"olor ipsum sit ".as_slice());
     }
 
     #[test]

--- a/lib/src/scanner/blocks.rs
+++ b/lib/src/scanner/blocks.rs
@@ -417,12 +417,14 @@ mod tests {
         let mut matches = pattern.matches();
 
         let match1 = matches.next().unwrap();
-        let data1 = match1.data_with_context();
+        let (data1, range1) = match1.data_with_context();
         assert_eq!(data1, b"orem ipsum sit ".as_slice());
+        assert_eq!(range1, 5..10);
 
         let match2 = matches.next().unwrap();
-        let data2 = match2.data_with_context();
+        let (data2, range2) = match2.data_with_context();
         assert_eq!(data2, b"olor ipsum sit ".as_slice());
+        assert_eq!(range2, 5..10);
     }
 
     #[test]

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -101,6 +101,10 @@ pub(crate) struct ScanContext<'r, 'd> {
     /// The time that can be spent in a scan operation, including the
     /// execution of the rule conditions.
     pub scan_timeout: Option<Duration>,
+    /// The number of bytes at the left and right of the matching data
+    /// that is stored to provide additional context about where the match
+    /// was found.
+    pub match_context_size: usize,
     /// The current state of the scanner.
     pub scan_state: ScanState<'d>,
     /// Vector containing the IDs of the rules that matched, including both
@@ -1832,6 +1836,7 @@ pub fn create_wasm_store_and_ctx<'r>(
         console_log: None,
         current_struct: None,
         scan_timeout: None,
+        match_context_size: 0,
         scan_state: ScanState::Idle,
         root_struct: rules.globals().make_root(),
         matching_rules: Vec::new(),

--- a/lib/src/scanner/matches.rs
+++ b/lib/src/scanner/matches.rs
@@ -43,11 +43,6 @@ impl Match {
         self.xor_key = Some(key);
         self
     }
-
-    /// Range relative to the block where the match occurred.
-    pub fn block_range(&self) -> Range<usize> {
-        self.range.start.sub(self.base)..self.range.end.sub(self.base)
-    }
 }
 
 /// Represents the list of matches for a pattern.

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -4,7 +4,6 @@ The scanner takes the rules produces by the compiler and scans data with them.
 */
 use std::collections::{BTreeMap, HashMap, hash_map};
 use std::fmt::{Debug, Formatter};
-use std::fs;
 use std::io::Read;
 use std::mem::transmute;
 use std::ops::Range;
@@ -14,6 +13,7 @@ use std::slice::Iter;
 use std::sync::Once;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
+use std::{cmp, fs};
 
 use bitvec::prelude::*;
 #[cfg(unix)]
@@ -120,6 +120,13 @@ impl AsRef<[u8]> for ScannedData<'_> {
             ScannedData::Vec(v) => v.as_ref(),
             ScannedData::Mmap(m) => m.as_ref(),
         }
+    }
+}
+
+impl ScannedData<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.as_ref().len()
     }
 }
 
@@ -248,6 +255,17 @@ impl<'r> Scanner<'r> {
         F: FnMut(String) + 'r,
     {
         self.scan_context_mut().console_log = Some(Box::new(callback));
+        self
+    }
+
+    /// Sets the context size for matches.
+    ///
+    /// This specifies how many bytes at the left and right of each match will
+    /// be reported by [`crate::Match::data_with_context`]. By default, the
+    /// match context size is 0, which means that [`crate::Match::data_with_context`]
+    /// will return exactly the same data as [`crate::Match::data`].
+    pub fn match_context_size(&mut self, size: usize) -> &mut Self {
+        self.scan_context_mut().match_context_size = size;
         self
     }
 
@@ -653,22 +671,50 @@ pub(crate) enum DataSnippets<'d> {
 
 impl DataSnippets<'_> {
     pub(crate) fn get(&self, range: Range<usize>) -> Option<&[u8]> {
+        self.get_with_context(range, 0)
+    }
+
+    /// Gets the data for the given `range`, but adding `context_size` additional
+    /// bytes to the left and right.
+    ///
+    /// The result will be `None` only if the data for `range` can't be found.
+    /// The additional bytes at the left and right will be added if possible,
+    /// but otherwise won't affect the result.
+    pub(crate) fn get_with_context(
+        &self,
+        range: Range<usize>,
+        context_size: usize,
+    ) -> Option<&[u8]> {
         match self {
-            Self::SingleBlock(data) => data.as_ref().get(range),
+            Self::SingleBlock(data) => {
+                let start = range.start.saturating_sub(context_size);
+                let end = range.end.saturating_add(context_size);
+                let end = cmp::min(end, data.len());
+                data.as_ref().get(start..end)
+            }
             Self::MultiBlock(btree) => {
-                // Find in the btree the snippet that starts exactly at the
-                // offset indicated by range.start, if not found, take the
-                // previous one, which may also contain the requested range.
-                let (snippet_offset, snippet_data) =
-                    btree.range(..=range.start).next_back()?;
+                for (snippet_offset, snippet_data) in
+                    btree.range(..=range.start).rev()
+                {
+                    // Calculate the start and end of the slice within the snippet.
+                    let start = range.start.saturating_sub(*snippet_offset);
+                    let end = range.end.saturating_sub(*snippet_offset);
 
-                // Calculate the start and end of the slice within the snippet.
-                let start = range.start - snippet_offset;
-                let end = range.end - snippet_offset;
+                    if end > snippet_data.len() {
+                        continue;
+                    }
 
-                // Returns the data, or `None` if `start` and `end` are not
-                // within the snippet boundaries.
-                snippet_data.get(start..end)
+                    let start = start.saturating_sub(context_size);
+                    let end = end.saturating_add(context_size);
+                    let end = cmp::min(end, snippet_data.len());
+
+                    match snippet_data.get(start..end) {
+                        Some(data) if !data.is_empty() => return Some(data),
+                        _ => continue,
+                    }
+                }
+
+                None
             }
         }
     }
@@ -932,21 +978,82 @@ mod snippet_tests {
     use std::collections::BTreeMap;
 
     #[test]
-    fn snippets() {
+    fn snippets_multiblock() {
         let mut btree_map = BTreeMap::new();
 
-        btree_map.insert(0, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        btree_map.insert(50, vec![51, 52, 53, 54]);
+        btree_map.insert(0, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        btree_map.insert(50, vec![50, 51, 52, 53, 54]);
+        btree_map.insert(52, vec![52, 53]);
+        btree_map.insert(100, vec![100, 101, 102, 103]);
 
         let snippets = DataSnippets::MultiBlock(btree_map);
 
-        assert_eq!(snippets.get(0..2), Some([1, 2].as_slice()));
-        assert_eq!(snippets.get(1..3), Some([2, 3].as_slice()));
-        assert_eq!(snippets.get(8..9), Some([9].as_slice()));
-        assert_eq!(snippets.get(9..10), None);
-        assert_eq!(snippets.get(50..51), Some([51].as_slice()));
-        assert_eq!(snippets.get(50..54), Some([51, 52, 53, 54].as_slice()));
-        assert_eq!(snippets.get(52..54), Some([53, 54].as_slice()));
+        assert_eq!(snippets.get(0..2), Some([0, 1].as_slice()));
+        assert_eq!(snippets.get(1..3), Some([1, 2].as_slice()));
+        assert_eq!(snippets.get(8..9), Some([8].as_slice()));
+        assert_eq!(snippets.get(10..11), None);
+        assert_eq!(snippets.get(50..51), Some([50].as_slice()));
+        assert_eq!(snippets.get(51..53), Some([51, 52].as_slice()));
+        assert_eq!(snippets.get(50..54), Some([50, 51, 52, 53].as_slice()));
+        assert_eq!(snippets.get(52..54), Some([52, 53].as_slice()));
+        assert_eq!(snippets.get(52..55), Some([52, 53, 54].as_slice()));
+        assert_eq!(snippets.get(52..53), Some([52].as_slice()));
         assert_eq!(snippets.get(50..56), None);
+        assert_eq!(snippets.get(100..101), Some([100].as_slice()));
+        assert_eq!(snippets.get(101..103), Some([101, 102].as_slice()));
+
+        assert_eq!(
+            snippets.get_with_context(0..2, 1),
+            Some([0, 1, 2].as_slice())
+        );
+
+        assert_eq!(
+            snippets.get_with_context(0..2, 2),
+            Some([0, 1, 2, 3].as_slice())
+        );
+
+        assert_eq!(
+            snippets.get_with_context(2..4, 2),
+            Some([0, 1, 2, 3, 4, 5].as_slice())
+        );
+
+        assert_eq!(
+            snippets.get_with_context(51..52, 3),
+            Some([50, 51, 52, 53, 54].as_slice())
+        );
+
+        assert_eq!(
+            snippets.get_with_context(102..103, 3),
+            Some([100, 101, 102, 103].as_slice())
+        );
+    }
+
+    #[test]
+    fn snippets_singleblock() {
+        let data = b"Lorem ipsum dolor sit amet".to_vec();
+        let scanned_data = super::ScannedData::Vec(data);
+        let snippets = DataSnippets::SingleBlock(scanned_data);
+
+        // Test get
+        assert_eq!(snippets.get(6..11), Some(b"ipsum".as_slice()));
+        assert_eq!(snippets.get(0..5), Some(b"Lorem".as_slice()));
+        assert_eq!(snippets.get(20..26), Some(b"t amet".as_slice()));
+        assert_eq!(snippets.get(27..30), None);
+
+        // Test get_with_context
+        // context_size = 5
+        assert_eq!(
+            snippets.get_with_context(6..11, 5),
+            Some(b"orem ipsum dolo".as_slice())
+        );
+        assert_eq!(
+            snippets.get_with_context(0..5, 5),
+            Some(b"Lorem ipsu".as_slice())
+        );
+        assert_eq!(
+            snippets.get_with_context(20..26, 5),
+            Some(b"or sit amet".as_slice())
+        );
+        assert_eq!(snippets.get_with_context(32..35, 5), None);
     }
 }

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -4,6 +4,7 @@ The scanner takes the rules produces by the compiler and scans data with them.
 */
 use std::collections::{BTreeMap, HashMap, hash_map};
 use std::fmt::{Debug, Formatter};
+use std::fs;
 use std::io::Read;
 use std::mem::transmute;
 use std::ops::Range;
@@ -13,7 +14,6 @@ use std::slice::Iter;
 use std::sync::Once;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
-use std::{cmp, fs};
 
 use bitvec::prelude::*;
 #[cfg(unix)]
@@ -671,11 +671,15 @@ pub(crate) enum DataSnippets<'d> {
 
 impl DataSnippets<'_> {
     pub(crate) fn get(&self, range: Range<usize>) -> Option<&[u8]> {
-        self.get_with_context(range, 0)
+        self.get_with_context(range, 0).map(|(data, _)| data)
     }
 
     /// Gets the data for the given `range`, but adding `context_size` additional
     /// bytes to the left and right.
+    ///
+    /// Returns a tuple where the first item is the data slice with context,
+    /// and the second item is a range relative to the slice indicating where
+    /// the `range` part is located.
     ///
     /// The result will be `None` only if the data for `range` can't be found.
     /// The additional bytes at the left and right will be added if possible,
@@ -684,13 +688,18 @@ impl DataSnippets<'_> {
         &self,
         range: Range<usize>,
         context_size: usize,
-    ) -> Option<&[u8]> {
+    ) -> Option<(&[u8], Range<usize>)> {
         match self {
             Self::SingleBlock(data) => {
                 let start = range.start.saturating_sub(context_size);
                 let end = range.end.saturating_add(context_size);
-                let end = cmp::min(end, data.len());
-                data.as_ref().get(start..end)
+                let end = std::cmp::min(end, data.len());
+
+                let slice = data.as_ref().get(start..end)?;
+                let rel_start = range.start - start;
+                let rel_end = range.end - start;
+
+                Some((slice, rel_start..rel_end))
             }
             Self::MultiBlock(btree) => {
                 for (snippet_offset, snippet_data) in
@@ -706,10 +715,16 @@ impl DataSnippets<'_> {
 
                     let start = start.saturating_sub(context_size);
                     let end = end.saturating_add(context_size);
-                    let end = cmp::min(end, snippet_data.len());
+                    let end = std::cmp::min(end, snippet_data.len());
 
                     match snippet_data.get(start..end) {
-                        Some(data) if !data.is_empty() => return Some(data),
+                        Some(data) if !data.is_empty() => {
+                            let rel_start =
+                                range.start - (*snippet_offset + start);
+                            let rel_end =
+                                range.end - (*snippet_offset + start);
+                            return Some((data, rel_start..rel_end));
+                        }
                         _ => continue,
                     }
                 }
@@ -1004,27 +1019,27 @@ mod snippet_tests {
 
         assert_eq!(
             snippets.get_with_context(0..2, 1),
-            Some([0, 1, 2].as_slice())
+            Some(([0, 1, 2].as_slice(), 0..2))
         );
 
         assert_eq!(
             snippets.get_with_context(0..2, 2),
-            Some([0, 1, 2, 3].as_slice())
+            Some(([0, 1, 2, 3].as_slice(), 0..2))
         );
 
         assert_eq!(
             snippets.get_with_context(2..4, 2),
-            Some([0, 1, 2, 3, 4, 5].as_slice())
+            Some(([0, 1, 2, 3, 4, 5].as_slice(), 2..4))
         );
 
         assert_eq!(
             snippets.get_with_context(51..52, 3),
-            Some([50, 51, 52, 53, 54].as_slice())
+            Some(([50, 51, 52, 53, 54].as_slice(), 1..2))
         );
 
         assert_eq!(
             snippets.get_with_context(102..103, 3),
-            Some([100, 101, 102, 103].as_slice())
+            Some(([100, 101, 102, 103].as_slice(), 2..3))
         );
     }
 
@@ -1044,15 +1059,15 @@ mod snippet_tests {
         // context_size = 5
         assert_eq!(
             snippets.get_with_context(6..11, 5),
-            Some(b"orem ipsum dolo".as_slice())
+            Some((b"orem ipsum dolo".as_slice(), 5..10))
         );
         assert_eq!(
             snippets.get_with_context(0..5, 5),
-            Some(b"Lorem ipsu".as_slice())
+            Some((b"Lorem ipsu".as_slice(), 0..5))
         );
         assert_eq!(
             snippets.get_with_context(20..26, 5),
-            Some(b"or sit amet".as_slice())
+            Some((b"or sit amet".as_slice(), 5..11))
         );
         assert_eq!(snippets.get_with_context(32..35, 5), None);
     }


### PR DESCRIPTION
This change introduces the ability to retrieve additional bytes around a match, providing more context about where the pattern was found.

A new method `Match::data_with_context()` is added, along with a `match_context_size()` option for the scanner. Users can now configure how many bytes to include to the left and right of each match.

Closes #622