### PR TITLE
perf: speed up regex evaluation

### DIFF
--- a/lib/src/re/thompson/instr.rs
+++ b/lib/src/re/thompson/instr.rs
@@ -433,6 +433,7 @@ impl<'a> InstrParser<'a> {
         }
     }
 
+    #[inline(always)]
     fn decode_u32(slice: &[u8]) -> u32 {
         let bytes: &[u8; size_of::<u32>()] =
             unsafe { &*(slice.as_ptr() as *const [u8; size_of::<u32>()]) };
@@ -440,6 +441,7 @@ impl<'a> InstrParser<'a> {
         u32::from_le_bytes(*bytes)
     }
 
+    #[inline(always)]
     fn decode_offset(slice: &[u8]) -> Offset {
         let bytes: &[u8; size_of::<Offset>()] =
             unsafe { &*(slice.as_ptr() as *const [u8; size_of::<Offset>()]) };
@@ -447,6 +449,7 @@ impl<'a> InstrParser<'a> {
         Offset::from_le_bytes(*bytes)
     }
 
+    #[inline(always)]
     fn decode_num_alt(slice: &[u8]) -> NumAlt {
         let bytes: &[u8; size_of::<NumAlt>()] =
             unsafe { &*(slice.as_ptr() as *const [u8; size_of::<NumAlt>()]) };
@@ -454,6 +457,7 @@ impl<'a> InstrParser<'a> {
         NumAlt::from_le_bytes(*bytes)
     }
 
+    #[inline(always)]
     fn decode_split_id(slice: &[u8]) -> SplitId {
         let bytes: &[u8; size_of::<SplitId>()] =
             unsafe { &*(slice.as_ptr() as *const [u8; size_of::<SplitId>()]) };
@@ -566,6 +570,7 @@ impl<'a> ClassBitmap<'a> {
     }
 
     /// Returns true if the class contains the given byte.
+    #[inline]
     pub fn contains(&self, byte: u8) -> bool {
         unsafe {
             *BitSlice::<_, Lsb0>::from_slice(self.0)

--- a/lib/src/re/thompson/pikevm.rs
+++ b/lib/src/re/thompson/pikevm.rs
@@ -338,7 +338,9 @@ pub(crate) fn epsilon_closure<C: CodeLoc>(
             | Instr::ClassBitmap(_)
             | Instr::ClassRanges(_)
             | Instr::Match => {
-                closure.push((ip, rep_count));
+                if closure.iter().find(|(i, _)| *i == ip).is_none() {
+                    closure.push((ip, rep_count));
+                }
             }
             Instr::SplitA(id, offset) => {
                 if !state.executed(id) {

--- a/lib/src/re/thompson/pikevm.rs
+++ b/lib/src/re/thompson/pikevm.rs
@@ -4,7 +4,6 @@ use std::mem;
 use bitvec::array::BitArray;
 
 use super::instr::{Instr, InstrParser, Offset};
-use crate::re::bitmapset::BitmapSet;
 use crate::re::thompson::instr::SplitId;
 use crate::re::{Action, CodeLoc, DEFAULT_SCAN_LIMIT, WideIter};
 
@@ -17,10 +16,10 @@ pub(crate) struct PikeVM<'r> {
     /// position within the VM code, pointing to some VM instruction. Each item
     /// in the set is unique, the VM guarantees that there aren't two active
     /// threads at the same VM instruction.
-    threads: BitmapSet<u32>,
+    threads: Vec<(usize, u32)>,
     /// The set of threads that will become the active threads when the next
     /// byte is read from the input.
-    next_threads: BitmapSet<u32>,
+    next_threads: Vec<(usize, u32)>,
     /// Maximum number of bytes to scan. The VM will abort after ingesting
     /// this number of bytes from the input.
     scan_limit: u16,
@@ -33,8 +32,8 @@ impl<'r> PikeVM<'r> {
     pub fn new(code: &'r [u8]) -> Self {
         Self {
             code,
-            threads: BitmapSet::new(),
-            next_threads: BitmapSet::new(),
+            threads: Vec::new(),
+            next_threads: Vec::new(),
             cache: EpsilonClosureState::new(),
             scan_limit: DEFAULT_SCAN_LIMIT,
         }
@@ -317,7 +316,7 @@ pub(crate) fn epsilon_closure<C: CodeLoc>(
     curr_byte: Option<&u8>,
     prev_byte: Option<&u8>,
     state: &mut EpsilonClosureState,
-    closure: &mut BitmapSet<u32>,
+    closure: &mut Vec<(usize, u32)>,
 ) {
     state.threads.push((start.location(), rep_count));
     state.dirty = true;
@@ -339,7 +338,7 @@ pub(crate) fn epsilon_closure<C: CodeLoc>(
             | Instr::ClassBitmap(_)
             | Instr::ClassRanges(_)
             | Instr::Match => {
-                closure.insert(ip, rep_count);
+                closure.push((ip, rep_count));
             }
             Instr::SplitA(id, offset) => {
                 if !state.executed(id) {

--- a/lib/src/re/thompson/tests.rs
+++ b/lib/src/re/thompson/tests.rs
@@ -3,7 +3,6 @@ use pretty_assertions::assert_eq;
 
 use crate::compiler::Atom;
 use crate::re;
-use crate::re::bitmapset::BitmapSet;
 use crate::re::thompson::instr::SplitId;
 use crate::re::{BckCodeLoc, FwdCodeLoc};
 use crate::types::Regexp;
@@ -25,7 +24,7 @@ macro_rules! assert_re_code {
         assert_eq!($bck, bck_code.to_string());
         assert_eq!($atoms, atoms);
 
-        let mut fwd_closure = BitmapSet::<u32>::new();
+        let mut fwd_closure = Vec::new();
         let mut cache = EpsilonClosureState::new();
 
         epsilon_closure(
@@ -43,7 +42,7 @@ macro_rules! assert_re_code {
             fwd_closure.iter().map(|(ip, _)| *ip).collect::<Vec<_>>()
         );
 
-        let mut bck_closure = BitmapSet::<u32>::new();
+        let mut bck_closure = Vec::new();
         epsilon_closure(
             bck_code.as_ref(),
             BckCodeLoc::try_from(0_usize).unwrap(),


### PR DESCRIPTION
Use `Vec` instead of `BitmapSet` for storing threads in `PikeVM`, which improves the performance of regex evaluation in most cases. The number of threads is usually low, and the overhead of using `BitmapSet`, while can improve performance in very specific cases, in most real-life regex causes more harm than good. 