### PR TITLE
docs: add documentation for .len() function

### DIFF
--- a/site/content/docs/writing_rules/conditions.md
+++ b/site/content/docs/writing_rules/conditions.md
@@ -556,6 +556,37 @@ The `for..in` operator is similar to `for..of`, but the latter iterates over a
 set of patterns, while the former iterates over ranges, enumerations, arrays
 and dictionaries.
 
+## Built-in `.len()` method
+
+YARA-X provides a `.len()` method that can be called on strings, arrays and
+dictionaries. It returns an integer representing the size of the value it is
+called on:
+
+- On **strings**, `.len()` returns the number of bytes in the string.
+- On **arrays**, `.len()` returns the number of elements.
+- On **dictionaries** (maps), `.len()` returns the number of entries.
+
+```yara
+import "some_module"
+
+rule LenExample {
+    condition:
+        some_module.some_string.len() > 0 and
+        some_module.some_array.len() >= 3 and
+        some_module.some_dict.len() == 1
+}
+```
+
+{{< callout title="Notice">}}
+
+The `.len()` method is not the same as the `string.length()` function from the
+[string module](/docs/modules/string). The `.len()` method is a built-in that
+can be called directly on any string, array or dictionary value, while
+`string.length()` is a function in the `string` module that takes a string
+argument.
+
+{{< /callout >}}
+
 ## The "with" statement
 
 YARA-X now supports the `with` statement defined by [RFC](https://github.com/VirusTotal/yara/discussions/1783), which allows you to define identifiers

--- a/site/content/docs/writing_rules/differences.md
+++ b/site/content/docs/writing_rules/differences.md
@@ -271,3 +271,28 @@ global global global rule duplicated_global  {
 
 In YARA-X you can specify each modifier once. They can still appear in any
 order, though. This very unlikely to affect any real-life rule.
+
+## Built-in `.len()` method
+
+YARA-X introduces a `.len()` built-in method that can be called on strings,
+arrays and dictionaries (maps). This method does not exist in YARA 4.x.
+
+- On strings, `.len()` returns the number of bytes.
+- On arrays, `.len()` returns the number of elements.
+- On dictionaries, `.len()` returns the number of entries.
+
+For example:
+
+```yara
+import "some_module"
+
+rule LenExample {
+    condition:
+        some_module.some_string.len() == 3 and
+        some_module.some_array.len() >= 2 and
+        some_module.some_dict.len() == 1
+}
+```
+
+In YARA 4.x, there was no equivalent built-in method for obtaining the length
+of these types directly.


### PR DESCRIPTION
Adds docs for .len() so people know its there and can use it.