### PR TITLE
perf: group multiple `matches` expressions inside `or` conditions into a RegexSet

### DIFF
--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -10,9 +10,10 @@ use yara_x_parser::ast::{Ident, WithSpan};
 use crate::compiler::errors::{CompileError, UnknownPattern};
 use crate::compiler::ir::{IR, PatternIdx};
 use crate::compiler::report::ReportBuilder;
-use crate::compiler::{RegexId, Warnings, ir};
+use crate::compiler::{RegexId, RegexSetId, Warnings, ir};
 use crate::errors::{UnknownField, UnknownIdentifier};
 use crate::modules::BUILTIN_MODULES;
+use crate::string_pool::StringPool;
 use crate::symbols::{StackedSymbolTable, Symbol, SymbolLookup};
 use crate::types::Type;
 use crate::wasm;
@@ -67,13 +68,10 @@ pub(crate) struct CompileContext<'a, 'src> {
     pub loop_iteration_multiplier: i64,
 
     /// Grouped RegexSets constructed during IR creation for or-expressions.
-    pub regex_sets: &'a mut rustc_hash::FxHashMap<
-        crate::compiler::RegexSetId,
-        Vec<crate::compiler::RegexId>,
-    >,
+    pub regex_sets: &'a mut rustc_hash::FxHashMap<RegexSetId, Vec<RegexId>>,
 
     /// Pool for regular expressions.
-    pub regexp_pool: &'a mut crate::string_pool::StringPool<RegexId>,
+    pub regex_pool: &'a mut StringPool<RegexId>,
 }
 
 impl<'src> CompileContext<'_, 'src> {

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -65,6 +65,12 @@ pub(crate) struct CompileContext<'a, 'src> {
     /// Tracks the product of iteration counts of nested loops.
     /// Used to detect loops that may iterate an excessive number of times.
     pub loop_iteration_multiplier: i64,
+
+    /// Tracks regular expressions matched against specific canonical targets across all rules.
+    pub matches_by_target: &'a mut rustc_hash::FxHashMap<crate::compiler::MatchTarget, rustc_hash::FxHashSet<crate::compiler::RegexpId>>,
+
+    /// Pool for regular expressions.
+    pub regexp_pool: &'a mut crate::string_pool::StringPool<crate::compiler::RegexpId>,
 }
 
 impl<'src> CompileContext<'_, 'src> {

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -10,7 +10,7 @@ use yara_x_parser::ast::{Ident, WithSpan};
 use crate::compiler::errors::{CompileError, UnknownPattern};
 use crate::compiler::ir::{IR, PatternIdx};
 use crate::compiler::report::ReportBuilder;
-use crate::compiler::{Warnings, ir};
+use crate::compiler::{MatchTarget, RegexId, Warnings, ir};
 use crate::errors::{UnknownField, UnknownIdentifier};
 use crate::modules::BUILTIN_MODULES;
 use crate::symbols::{StackedSymbolTable, Symbol, SymbolLookup};
@@ -67,10 +67,11 @@ pub(crate) struct CompileContext<'a, 'src> {
     pub loop_iteration_multiplier: i64,
 
     /// Tracks regular expressions matched against specific canonical targets across all rules.
-    pub matches_by_target: &'a mut rustc_hash::FxHashMap<crate::compiler::MatchTarget, rustc_hash::FxHashSet<crate::compiler::RegexpId>>,
+    pub matches_by_target:
+        &'a mut rustc_hash::FxHashMap<MatchTarget, FxHashSet<RegexId>>,
 
     /// Pool for regular expressions.
-    pub regexp_pool: &'a mut crate::string_pool::StringPool<crate::compiler::RegexpId>,
+    pub regexp_pool: &'a mut crate::string_pool::StringPool<RegexId>,
 }
 
 impl<'src> CompileContext<'_, 'src> {

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -72,6 +72,9 @@ pub(crate) struct CompileContext<'a, 'src> {
 
     /// Pool for regular expressions.
     pub regexp_pool: &'a mut crate::string_pool::StringPool<RegexId>,
+
+    /// The ID of the current namespace being compiled.
+    pub current_namespace_id: crate::compiler::NamespaceId,
 }
 
 impl<'src> CompileContext<'_, 'src> {

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -10,7 +10,7 @@ use yara_x_parser::ast::{Ident, WithSpan};
 use crate::compiler::errors::{CompileError, UnknownPattern};
 use crate::compiler::ir::{IR, PatternIdx};
 use crate::compiler::report::ReportBuilder;
-use crate::compiler::{MatchTarget, RegexId, Warnings, ir};
+use crate::compiler::{RegexId, Warnings, ir};
 use crate::errors::{UnknownField, UnknownIdentifier};
 use crate::modules::BUILTIN_MODULES;
 use crate::symbols::{StackedSymbolTable, Symbol, SymbolLookup};
@@ -66,9 +66,11 @@ pub(crate) struct CompileContext<'a, 'src> {
     /// Used to detect loops that may iterate an excessive number of times.
     pub loop_iteration_multiplier: i64,
 
-    /// Tracks regular expressions matched against specific canonical targets across all rules.
-    pub matches_by_target:
-        &'a mut rustc_hash::FxHashMap<MatchTarget, FxHashSet<RegexId>>,
+    /// Grouped RegexSets constructed during IR creation for or-expressions.
+    pub regex_sets: &'a mut rustc_hash::FxHashMap<
+        crate::compiler::RegexSetId,
+        Vec<crate::compiler::RegexId>,
+    >,
 
     /// Pool for regular expressions.
     pub regexp_pool: &'a mut crate::string_pool::StringPool<RegexId>,

--- a/lib/src/compiler/context.rs
+++ b/lib/src/compiler/context.rs
@@ -74,9 +74,6 @@ pub(crate) struct CompileContext<'a, 'src> {
 
     /// Pool for regular expressions.
     pub regexp_pool: &'a mut crate::string_pool::StringPool<RegexId>,
-
-    /// The ID of the current namespace being compiled.
-    pub current_namespace_id: crate::compiler::NamespaceId,
 }
 
 impl<'src> CompileContext<'_, 'src> {

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -27,7 +27,7 @@ use crate::compiler::ir::{
 };
 use crate::compiler::{
     FieldAccess, ForVars, LiteralId, OfExprTuple, OfPatternSet, PatternId,
-    RegexpId, RuleId, RuleInfo, Var,
+    RegexId, RuleId, RuleInfo, Var,
 };
 use crate::scanner::RuntimeObjectHandle;
 use crate::string_pool::{BStringPool, StringPool};
@@ -205,7 +205,7 @@ pub(crate) struct EmitContext<'a> {
     pub wasm_exports: &'a FxHashMap<String, FunctionId>,
 
     /// Pool with regular expressions used in rule conditions.
-    pub regexp_pool: &'a mut StringPool<RegexpId>,
+    pub regexp_pool: &'a mut StringPool<RegexId>,
 
     /// Pool with literal strings used in the rules.
     pub lit_pool: &'a mut BStringPool<LiteralId>,

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -640,6 +640,14 @@ fn emit_expr(
                 .call(ctx.function_id(wasm::export__str_matches.mangled_name));
         }
 
+        Expr::MatchesMany { lhs, regex_set } => {
+            emit_expr(ctx, ir, *lhs, instr);
+            instr.i32_const((*regex_set).into());
+            instr.call(ctx.function_id(
+                wasm::export__str_matches_regex_set.mangled_name,
+            ));
+        }
+
         Expr::Lookup(lookup) => {
             // Emit code for the primary expression (array or map) that is
             // being indexed.

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -205,7 +205,7 @@ pub(crate) struct EmitContext<'a> {
     pub wasm_exports: &'a FxHashMap<String, FunctionId>,
 
     /// Pool with regular expressions used in rule conditions.
-    pub regexp_pool: &'a mut StringPool<RegexId>,
+    pub regex_pool: &'a mut StringPool<RegexId>,
 
     /// Pool with literal strings used in the rules.
     pub lit_pool: &'a mut BStringPool<LiteralId>,
@@ -313,7 +313,7 @@ fn emit_expr(
                     .i64_const(RuntimeString::Literal(literal_id).into_wasm());
             }
             TypeValue::Regexp(Some(regexp)) => {
-                let re_id = ctx.regexp_pool.get_or_intern(regexp.as_str());
+                let re_id = ctx.regex_pool.get_or_intern(regexp.as_str());
 
                 instr.i32_const(re_id.into());
             }

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1893,6 +1893,33 @@ fn matches_expr_from_ast(
         }
     }
 
+    if let Expr::FieldAccess(field_access) = ctx.ir.get(lhs) {
+        let mut indices = Vec::new();
+        let mut all_fields = true;
+        for operand in &field_access.operands {
+            if let Expr::Symbol(symbol) = ctx.ir.get(*operand) {
+                if let Symbol::Field { index, .. } = symbol.as_ref() {
+                    indices.push(*index as i32);
+                } else {
+                    all_fields = false;
+                    break;
+                }
+            } else {
+                all_fields = false;
+                break;
+            }
+        }
+        if all_fields && !indices.is_empty() {
+            if let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(rhs) {
+                let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
+                ctx.matches_by_target
+                    .entry(crate::compiler::MatchTarget::FieldAccess(indices))
+                    .or_default()
+                    .insert(re_id);
+            }
+        }
+    }
+
     Ok(ctx.ir.matches(lhs, rhs))
 }
 

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -2344,7 +2344,7 @@ fn or_expr_from_ast(
 
             if let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(*rhs)
             {
-                let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
+                let re_id = ctx.regex_pool.get_or_intern(re.as_str());
                 matches_by_lhs
                     .entry(target)
                     .or_default()

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -3,13 +3,14 @@
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::BTreeSet;
+use std::hash::{Hash, Hasher};
 use std::iter;
 use std::ops::RangeInclusive;
 use std::rc::Rc;
 
 use bstr::{BString, ByteSlice};
 use itertools::Itertools;
-
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use yara_x_parser::Span;
 use yara_x_parser::ast;
 use yara_x_parser::ast::WithSpan;
@@ -26,12 +27,12 @@ use crate::compiler::errors::{
 use crate::compiler::ir::hex2hir::hex_pattern_hir_from_ast;
 use crate::compiler::ir::{
     Error, Expr, ExprId, Iterable, LiteralPattern, MatchAnchor, Pattern,
-    PatternFlags, PatternInRule, Quantifier, Range, RegexpPattern,
+    PatternFlags, PatternInRule, Quantifier, Range, RegexpPattern, dfs,
 };
 use crate::compiler::report::{Level, ReportBuilder};
 use crate::compiler::{
     CompileContext, CompileError, FilesizeBounds, ForVars, PatternIdx,
-    TextPatternAsHex, warnings,
+    RegexId, RegexSetId, TextPatternAsHex, warnings,
 };
 use crate::errors::CustomError;
 use crate::errors::{MethodNotAllowedInWith, PotentiallySlowLoop};
@@ -2274,21 +2275,21 @@ fn or_expr_from_ast(
         (Type::Float, Type::Bool),
     ];
 
-    // Step 1: Validate operand types and emit standard warnings.
-    // Ensure all operands in the `or` expression conform to boolean-compatible
-    // types, checking for potential mismatches across adjacent pairs.
-    let operands_hir: Vec<ExprId> = expr
+    // Validate operand types and emit standard warnings. Ensure all operands
+    // in the `or` expression conform to boolean-compatible types, checking
+    // for potential mismatches across adjacent pairs.
+    let or_operands: Vec<ExprId> = expr
         .operands()
         .map(|expr| expr_from_ast(ctx, expr))
         .collect::<Result<Vec<ExprId>, CompileError>>()?;
 
-    for (hir, ast) in iter::zip(operands_hir.iter(), expr.operands()) {
+    for (hir, ast) in iter::zip(or_operands.iter(), expr.operands()) {
         let ty = ctx.ir.get(*hir).ty();
         warn_if_not_bool(ctx, ty, ast.span());
     }
 
     for ((lhs_hir, lhs_ast), (rhs_hir, rhs_ast)) in
-        iter::zip(operands_hir.iter(), expr.operands()).tuple_windows()
+        iter::zip(or_operands.iter(), expr.operands()).tuple_windows()
     {
         check_operands(
             ctx,
@@ -2301,49 +2302,42 @@ fn or_expr_from_ast(
         )?;
     }
 
-    // Step 2: Group `matches` expressions by their target expression hash.
-    // Traverse the IR subtree for the left-hand side of each `matches` operand
-    // to compute a unique 64-bit hash. Operands sharing the identical target
-    // hash are aggregated together to identify potential multi-match sets.
-    let mut matches_by_lhs: rustc_hash::FxHashMap<
-        u64,
-        Vec<(usize, ExprId, crate::compiler::RegexId)>,
-    > = rustc_hash::FxHashMap::default();
+    // Group `matches` expressions by their left-side operand. All the `matches`
+    // expressions sharing the same left-side operand will be aggregated together
+    // into a MatchMany operation that matches the left-side operand against
+    // a set of regular expressions.
+    let mut matches_by_lhs: FxHashMap<u64, Vec<(usize, ExprId, RegexId)>> =
+        FxHashMap::default();
 
-    for (i, &op) in operands_hir.iter().enumerate() {
-        if let Expr::Matches { lhs, rhs } = ctx.ir.get(op) {
-            let mut hasher = rustc_hash::FxHasher::default();
+    for (i, &op) in or_operands.iter().enumerate() {
+        if let Expr::Matches { lhs, rhs } = ctx.ir.get(op)
+            && let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(*rhs)
+        {
+            let mut hasher = FxHasher::default();
             for evt in ctx.ir.dfs_iter(*lhs) {
-                if let crate::compiler::ir::dfs::Event::Enter((_, expr, _)) =
-                    evt
-                {
-                    std::hash::Hash::hash(expr, &mut hasher);
+                if let dfs::Event::Enter((_, expr, _)) = evt {
+                    Hash::hash(expr, &mut hasher);
                 }
             }
-            let target = std::hash::Hasher::finish(&hasher);
-
-            if let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(*rhs)
-            {
-                let re_id = ctx.regex_pool.get_or_intern(re.as_str());
-                matches_by_lhs
-                    .entry(target)
-                    .or_default()
-                    .push((i, *lhs, re_id));
-            }
+            let lhs_expr_hash = hasher.finish();
+            let re_id = ctx.regex_pool.get_or_intern(re.as_str());
+            matches_by_lhs
+                .entry(lhs_expr_hash)
+                .or_default()
+                .push((i, *lhs, re_id));
         }
     }
 
-    // Step 3: Collapse grouped regular expressions into `MatchesMany`.
-    // For any target expression associated with two or more regular expressions,
-    // construct a unified `RegexSet`, replace the individual `matches` nodes
-    // with a single `MatchesMany` expression, and record the collapsed indices.
+    // Collapse grouped regular expressions into `MatchesMany`. For any target
+    // expression associated with two or more regular expressions, construct a
+    // unified `RegexSet`, replace the individual `matches` nodes with a single
+    // `MatchesMany` expression, and record the collapsed indices.
     let mut final_operands = Vec::new();
-    let mut collapsed_indices = rustc_hash::FxHashSet::default();
+    let mut collapsed_indices = FxHashSet::default();
 
     for (_, group) in matches_by_lhs {
         if group.len() >= 2 {
-            let set_id =
-                crate::compiler::RegexSetId::from(ctx.regex_sets.len() as i32);
+            let set_id = RegexSetId::from(ctx.regex_sets.len() as i32);
             let re_ids: Vec<_> =
                 group.iter().map(|&(_, _, re_id)| re_id).collect();
             ctx.regex_sets.insert(set_id, re_ids);
@@ -2359,11 +2353,11 @@ fn or_expr_from_ast(
         }
     }
 
-    // Step 4: Assemble final operands and construct the `or` expression.
-    // Preserve all non-collapsed operands in their original relative order. If
-    // all operands collapse into a single expression, return it directly without
-    // an wrapping `or` node.
-    for (i, &op) in operands_hir.iter().enumerate() {
+    // Assemble final operands and construct the `or` expression. Preserve all
+    // non-collapsed operands in their original relative order. If all operands
+    // collapse into a single expression, return it directly without a wrapping
+    // `or` node.
+    for (i, &op) in or_operands.iter().enumerate() {
         if !collapsed_indices.contains(&i) {
             final_operands.push(op);
         }
@@ -2374,14 +2368,12 @@ fn or_expr_from_ast(
     }
 
     ctx.ir.or(final_operands).map_err(|err| match err {
-        crate::compiler::ir::Error::NumberOutOfRange => {
-            NumberOutOfRange::build(
-                ctx.report_builder,
-                i64::MIN,
-                i64::MAX,
-                ctx.report_builder.span_to_code_loc(span),
-            )
-        }
+        Error::NumberOutOfRange => NumberOutOfRange::build(
+            ctx.report_builder,
+            i64::MIN,
+            i64::MAX,
+            ctx.report_builder.span_to_code_loc(span),
+        ),
     })
 }
 

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -2179,40 +2179,23 @@ macro_rules! gen_n_ary_operation {
 
             // Make sure that all operands have one of the accepted types.
             for (hir, ast) in iter::zip(operands_hir.iter(), expr.operands()) {
-                check_type(ctx, *hir, ast.span(), accepted_types)?;
                 if let Some(check_fn) = check_fn {
                     check_fn(ctx, *hir, ast.span())?;
                 }
             }
 
-            // Iterate the operands in pairs (first, second), (second, third),
-            // (third, fourth), etc.
-            for ((lhs_hir, rhs_ast), (rhs_hir, lhs_ast)) in
+            for ((lhs_hir, lhs_ast), (rhs_hir, rhs_ast)) in
                 iter::zip(operands_hir.iter(), expr.operands()).tuple_windows()
             {
-                let lhs_ty = ctx.ir.get(*lhs_hir).ty();
-                let rhs_ty = ctx.ir.get(*rhs_hir).ty();
-
-                let types_are_compatible = {
-                    // If the types are the same, they are compatible.
-                    (lhs_ty == rhs_ty) ||
-                        // If the list of compatible types contains the pair
-                        // (lhs_ty, rhs_ty) or (rhs_ty, lhs_ty), they are
-                        // compatible.
-                        compatible_types.contains(&(lhs_ty, rhs_ty))
-                            || compatible_types.contains(&(rhs_ty, lhs_ty))
-
-                };
-
-                if !types_are_compatible {
-                    return Err(MismatchingTypes::build(
-                            ctx.report_builder,
-                            lhs_ty.to_string(),
-                            rhs_ty.to_string(),
-                            ctx.report_builder.span_to_code_loc(expr.first().span().combine(&lhs_ast.span())),
-                            ctx.report_builder.span_to_code_loc(rhs_ast.span()),
-                    ));
-                }
+                check_operands(
+                    ctx,
+                    *lhs_hir,
+                    *rhs_hir,
+                    expr.first().span().combine(&lhs_ast.span()),
+                    rhs_ast.span(),
+                    accepted_types,
+                    compatible_types,
+                )?;
             }
 
             ctx.ir.$variant(operands_hir).map_err(|err| {
@@ -2291,40 +2274,37 @@ fn or_expr_from_ast(
         (Type::Float, Type::Bool),
     ];
 
+    // Step 1: Validate operand types and emit standard warnings.
+    // Ensure all operands in the `or` expression conform to boolean-compatible
+    // types, checking for potential mismatches across adjacent pairs.
     let operands_hir: Vec<ExprId> = expr
         .operands()
         .map(|expr| expr_from_ast(ctx, expr))
         .collect::<Result<Vec<ExprId>, CompileError>>()?;
 
     for (hir, ast) in iter::zip(operands_hir.iter(), expr.operands()) {
-        check_type(ctx, *hir, ast.span(), accepted_types)?;
         let ty = ctx.ir.get(*hir).ty();
         warn_if_not_bool(ctx, ty, ast.span());
     }
 
-    for ((lhs_hir, rhs_ast), (rhs_hir, lhs_ast)) in
+    for ((lhs_hir, lhs_ast), (rhs_hir, rhs_ast)) in
         iter::zip(operands_hir.iter(), expr.operands()).tuple_windows()
     {
-        let lhs_ty = ctx.ir.get(*lhs_hir).ty();
-        let rhs_ty = ctx.ir.get(*rhs_hir).ty();
-
-        let types_are_compatible = (lhs_ty == rhs_ty)
-            || compatible_types.contains(&(lhs_ty, rhs_ty))
-            || compatible_types.contains(&(rhs_ty, lhs_ty));
-
-        if !types_are_compatible {
-            return Err(MismatchingTypes::build(
-                ctx.report_builder,
-                lhs_ty.to_string(),
-                rhs_ty.to_string(),
-                ctx.report_builder.span_to_code_loc(
-                    expr.first().span().combine(&lhs_ast.span()),
-                ),
-                ctx.report_builder.span_to_code_loc(rhs_ast.span()),
-            ));
-        }
+        check_operands(
+            ctx,
+            *lhs_hir,
+            *rhs_hir,
+            expr.first().span().combine(&lhs_ast.span()),
+            rhs_ast.span(),
+            accepted_types,
+            compatible_types,
+        )?;
     }
 
+    // Step 2: Group `matches` expressions by their target expression hash.
+    // Traverse the IR subtree for the left-hand side of each `matches` operand
+    // to compute a unique 64-bit hash. Operands sharing the identical target
+    // hash are aggregated together to identify potential multi-match sets.
     let mut matches_by_lhs: rustc_hash::FxHashMap<
         u64,
         Vec<(usize, ExprId, crate::compiler::RegexId)>,
@@ -2353,6 +2333,10 @@ fn or_expr_from_ast(
         }
     }
 
+    // Step 3: Collapse grouped regular expressions into `MatchesMany`.
+    // For any target expression associated with two or more regular expressions,
+    // construct a unified `RegexSet`, replace the individual `matches` nodes
+    // with a single `MatchesMany` expression, and record the collapsed indices.
     let mut final_operands = Vec::new();
     let mut collapsed_indices = rustc_hash::FxHashSet::default();
 
@@ -2375,6 +2359,10 @@ fn or_expr_from_ast(
         }
     }
 
+    // Step 4: Assemble final operands and construct the `or` expression.
+    // Preserve all non-collapsed operands in their original relative order. If
+    // all operands collapse into a single expression, return it directly without
+    // an wrapping `or` node.
     for (i, &op) in operands_hir.iter().enumerate() {
         if !collapsed_indices.contains(&i) {
             final_operands.push(op);

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -2368,13 +2368,13 @@ fn or_expr_from_ast(
             if let Some(target) = target
                 && let Expr::Const(TypeValue::Regexp(Some(re))) =
                     ctx.ir.get(*rhs)
-                {
-                    let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
-                    matches_by_lhs
-                        .entry(target)
-                        .or_default()
-                        .push((i, *lhs, re_id));
-                }
+            {
+                let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
+                matches_by_lhs
+                    .entry(target)
+                    .or_default()
+                    .push((i, *lhs, re_id));
+            }
         }
     }
 

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1909,15 +1909,14 @@ fn matches_expr_from_ast(
                 break;
             }
         }
-        if all_fields && !indices.is_empty() {
-            if let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(rhs) {
+        if all_fields && !indices.is_empty()
+            && let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(rhs) {
                 let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
                 ctx.matches_by_target
                     .entry(crate::compiler::MatchTarget::FieldAccess(indices))
                     .or_default()
                     .insert(re_id);
             }
-        }
     }
 
     Ok(ctx.ir.matches(lhs, rhs))

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1915,7 +1915,10 @@ fn matches_expr_from_ast(
         {
             let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
             ctx.matches_by_target
-                .entry(crate::compiler::MatchTarget::FieldAccess(indices))
+                .entry(crate::compiler::MatchTarget::FieldAccess(
+                    ctx.current_namespace_id,
+                    indices,
+                ))
                 .or_default()
                 .insert(re_id);
         }

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1909,14 +1909,16 @@ fn matches_expr_from_ast(
                 break;
             }
         }
-        if all_fields && !indices.is_empty()
-            && let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(rhs) {
-                let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
-                ctx.matches_by_target
-                    .entry(crate::compiler::MatchTarget::FieldAccess(indices))
-                    .or_default()
-                    .insert(re_id);
-            }
+        if all_fields
+            && !indices.is_empty()
+            && let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(rhs)
+        {
+            let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
+            ctx.matches_by_target
+                .entry(crate::compiler::MatchTarget::FieldAccess(indices))
+                .or_default()
+                .insert(re_id);
+        }
     }
 
     Ok(ctx.ir.matches(lhs, rhs))

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -1893,37 +1893,6 @@ fn matches_expr_from_ast(
         }
     }
 
-    if let Expr::FieldAccess(field_access) = ctx.ir.get(lhs) {
-        let mut indices = Vec::new();
-        let mut all_fields = true;
-        for operand in &field_access.operands {
-            if let Expr::Symbol(symbol) = ctx.ir.get(*operand) {
-                if let Symbol::Field { index, .. } = symbol.as_ref() {
-                    indices.push(*index as i32);
-                } else {
-                    all_fields = false;
-                    break;
-                }
-            } else {
-                all_fields = false;
-                break;
-            }
-        }
-        if all_fields
-            && !indices.is_empty()
-            && let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(rhs)
-        {
-            let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
-            ctx.matches_by_target
-                .entry(crate::compiler::MatchTarget::FieldAccess(
-                    ctx.current_namespace_id,
-                    indices,
-                ))
-                .or_default()
-                .insert(re_id);
-        }
-    }
-
     Ok(ctx.ir.matches(lhs, rhs))
 }
 
@@ -2306,28 +2275,152 @@ gen_n_ary_operation!(
     })
 );
 
-gen_n_ary_operation!(
-    or_expr_from_ast,
-    or,
-    // Boolean operations accept integer, float and string operands.
-    // If operands are not boolean they are casted to boolean.
-    Type::Bool | Type::Integer | Type::Float | Type::String,
-    // All operand types can be mixed in a boolean operation, as they
-    // are casted to boolean anyways.
-    &[
+fn or_expr_from_ast(
+    ctx: &mut CompileContext,
+    expr: &ast::NAryExpr,
+) -> Result<ExprId, CompileError> {
+    let span = expr.span();
+    let accepted_types =
+        &[Type::Bool, Type::Integer, Type::Float, Type::String];
+    let compatible_types = &[
         (Type::Integer, Type::Bool),
         (Type::Integer, Type::Float),
         (Type::Integer, Type::String),
         (Type::String, Type::Bool),
         (Type::String, Type::Float),
-        (Type::Float, Type::Bool)
-    ],
-    Some(|ctx, operand, span| {
-        let ty = ctx.ir.get(operand).ty();
-        warn_if_not_bool(ctx, ty, span);
-        Ok(())
+        (Type::Float, Type::Bool),
+    ];
+
+    let operands_hir: Vec<ExprId> = expr
+        .operands()
+        .map(|expr| expr_from_ast(ctx, expr))
+        .collect::<Result<Vec<ExprId>, CompileError>>()?;
+
+    for (hir, ast) in iter::zip(operands_hir.iter(), expr.operands()) {
+        check_type(ctx, *hir, ast.span(), accepted_types)?;
+        let ty = ctx.ir.get(*hir).ty();
+        warn_if_not_bool(ctx, ty, ast.span());
+    }
+
+    for ((lhs_hir, rhs_ast), (rhs_hir, lhs_ast)) in
+        iter::zip(operands_hir.iter(), expr.operands()).tuple_windows()
+    {
+        let lhs_ty = ctx.ir.get(*lhs_hir).ty();
+        let rhs_ty = ctx.ir.get(*rhs_hir).ty();
+
+        let types_are_compatible = (lhs_ty == rhs_ty)
+            || compatible_types.contains(&(lhs_ty, rhs_ty))
+            || compatible_types.contains(&(rhs_ty, lhs_ty));
+
+        if !types_are_compatible {
+            return Err(MismatchingTypes::build(
+                ctx.report_builder,
+                lhs_ty.to_string(),
+                rhs_ty.to_string(),
+                ctx.report_builder.span_to_code_loc(
+                    expr.first().span().combine(&lhs_ast.span()),
+                ),
+                ctx.report_builder.span_to_code_loc(rhs_ast.span()),
+            ));
+        }
+    }
+
+    let mut matches_by_lhs: rustc_hash::FxHashMap<
+        crate::compiler::MatchTarget,
+        Vec<(usize, ExprId, crate::compiler::RegexId)>,
+    > = rustc_hash::FxHashMap::default();
+
+    for (i, &op) in operands_hir.iter().enumerate() {
+        if let Expr::Matches { lhs, rhs } = ctx.ir.get(op) {
+            let target = match ctx.ir.get(*lhs) {
+                Expr::FieldAccess(fa) => {
+                    let mut indices = Vec::new();
+                    let mut all_fields = true;
+                    for &fa_op in &fa.operands {
+                        if let Expr::Symbol(symbol) = ctx.ir.get(fa_op) {
+                            if let crate::symbols::Symbol::Field {
+                                index,
+                                ..
+                            } = symbol.as_ref()
+                            {
+                                indices.push(*index as i32);
+                            } else {
+                                all_fields = false;
+                                break;
+                            }
+                        } else {
+                            all_fields = false;
+                            break;
+                        }
+                    }
+                    if all_fields && !indices.is_empty() {
+                        Some(crate::compiler::MatchTarget::FieldAccess(
+                            ctx.current_namespace_id,
+                            indices,
+                        ))
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            if let Some(target) = target
+                && let Expr::Const(TypeValue::Regexp(Some(re))) =
+                    ctx.ir.get(*rhs)
+                {
+                    let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
+                    matches_by_lhs
+                        .entry(target)
+                        .or_default()
+                        .push((i, *lhs, re_id));
+                }
+        }
+    }
+
+    let mut final_operands = Vec::new();
+    let mut collapsed_indices = rustc_hash::FxHashSet::default();
+
+    for (_, group) in matches_by_lhs {
+        if group.len() >= 2 {
+            let set_id =
+                crate::compiler::RegexSetId::from(ctx.regex_sets.len() as i32);
+            let re_ids: Vec<_> =
+                group.iter().map(|&(_, _, re_id)| re_id).collect();
+            ctx.regex_sets.insert(set_id, re_ids);
+
+            let first_lhs = group[0].1;
+            let multimatch = ctx.ir.matches_regex_set(first_lhs, set_id);
+
+            final_operands.push(multimatch);
+
+            for (i, _, _) in group {
+                collapsed_indices.insert(i);
+            }
+        }
+    }
+
+    for (i, &op) in operands_hir.iter().enumerate() {
+        if !collapsed_indices.contains(&i) {
+            final_operands.push(op);
+        }
+    }
+
+    if final_operands.len() == 1 {
+        return Ok(final_operands[0]);
+    }
+
+    ctx.ir.or(final_operands).map_err(|err| match err {
+        crate::compiler::ir::Error::NumberOutOfRange => {
+            NumberOutOfRange::build(
+                ctx.report_builder,
+                i64::MIN,
+                i64::MAX,
+                ctx.report_builder.span_to_code_loc(span),
+            )
+        }
     })
-);
+}
 
 gen_unary_op!(minus_expr_from_ast, minus, Type::Integer | Type::Float, None);
 

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -2326,48 +2326,23 @@ fn or_expr_from_ast(
     }
 
     let mut matches_by_lhs: rustc_hash::FxHashMap<
-        crate::compiler::MatchTarget,
+        u64,
         Vec<(usize, ExprId, crate::compiler::RegexId)>,
     > = rustc_hash::FxHashMap::default();
 
     for (i, &op) in operands_hir.iter().enumerate() {
         if let Expr::Matches { lhs, rhs } = ctx.ir.get(op) {
-            let target = match ctx.ir.get(*lhs) {
-                Expr::FieldAccess(fa) => {
-                    let mut indices = Vec::new();
-                    let mut all_fields = true;
-                    for &fa_op in &fa.operands {
-                        if let Expr::Symbol(symbol) = ctx.ir.get(fa_op) {
-                            if let crate::symbols::Symbol::Field {
-                                index,
-                                ..
-                            } = symbol.as_ref()
-                            {
-                                indices.push(*index as i32);
-                            } else {
-                                all_fields = false;
-                                break;
-                            }
-                        } else {
-                            all_fields = false;
-                            break;
-                        }
-                    }
-                    if all_fields && !indices.is_empty() {
-                        Some(crate::compiler::MatchTarget::FieldAccess(
-                            ctx.current_namespace_id,
-                            indices,
-                        ))
-                    } else {
-                        None
-                    }
+            let mut hasher = rustc_hash::FxHasher::default();
+            for evt in ctx.ir.dfs_iter(*lhs) {
+                if let crate::compiler::ir::dfs::Event::Enter((_, expr, _)) =
+                    evt
+                {
+                    std::hash::Hash::hash(expr, &mut hasher);
                 }
-                _ => None,
-            };
+            }
+            let target = std::hash::Hasher::finish(&hasher);
 
-            if let Some(target) = target
-                && let Expr::Const(TypeValue::Regexp(Some(re))) =
-                    ctx.ir.get(*rhs)
+            if let Expr::Const(TypeValue::Regexp(Some(re))) = ctx.ir.get(*rhs)
             {
                 let re_id = ctx.regexp_pool.get_or_intern(re.as_str());
                 matches_by_lhs

--- a/lib/src/compiler/ir/dfs.rs
+++ b/lib/src/compiler/ir/dfs.rs
@@ -303,6 +303,10 @@ pub(super) fn dfs_common(
             stack.push(Event::Enter((*lhs, EventContext::None)));
         }
 
+        Expr::MatchesMany { lhs, .. } => {
+            stack.push(Event::Enter((*lhs, EventContext::None)));
+        }
+
         Expr::PatternMatch { anchor, .. }
         | Expr::PatternMatchVar { anchor, .. } => {
             push_anchor(anchor, stack);

--- a/lib/src/compiler/ir/hex2hir.rs
+++ b/lib/src/compiler/ir/hex2hir.rs
@@ -227,7 +227,7 @@ mod tests {
         let mut warnings = Warnings::default();
         let mut rule_patterns = vec![];
 
-        let mut matches_by_target = rustc_hash::FxHashMap::default();
+        let mut regex_sets = rustc_hash::FxHashMap::default();
         let mut regexp_pool = crate::string_pool::StringPool::new();
 
         let mut ctx = CompileContext {
@@ -243,7 +243,7 @@ mod tests {
             vars: VarStack::new(),
             for_of_depth: 0,
             loop_iteration_multiplier: 1,
-            matches_by_target: &mut matches_by_target,
+            regex_sets: &mut regex_sets,
             regexp_pool: &mut regexp_pool,
             current_namespace_id: crate::compiler::NamespaceId::from(0),
         };

--- a/lib/src/compiler/ir/hex2hir.rs
+++ b/lib/src/compiler/ir/hex2hir.rs
@@ -245,7 +245,6 @@ mod tests {
             loop_iteration_multiplier: 1,
             regex_sets: &mut regex_sets,
             regexp_pool: &mut regexp_pool,
-            current_namespace_id: crate::compiler::NamespaceId::from(0),
         };
 
         let mut pattern = HexPattern::new("test_ident");

--- a/lib/src/compiler/ir/hex2hir.rs
+++ b/lib/src/compiler/ir/hex2hir.rs
@@ -245,6 +245,7 @@ mod tests {
             loop_iteration_multiplier: 1,
             matches_by_target: &mut matches_by_target,
             regexp_pool: &mut regexp_pool,
+            current_namespace_id: crate::compiler::NamespaceId::from(0),
         };
 
         let mut pattern = HexPattern::new("test_ident");

--- a/lib/src/compiler/ir/hex2hir.rs
+++ b/lib/src/compiler/ir/hex2hir.rs
@@ -228,7 +228,7 @@ mod tests {
         let mut rule_patterns = vec![];
 
         let mut regex_sets = rustc_hash::FxHashMap::default();
-        let mut regexp_pool = crate::string_pool::StringPool::new();
+        let mut regex_pool = crate::string_pool::StringPool::new();
 
         let mut ctx = CompileContext {
             ir: &mut ir,
@@ -244,7 +244,7 @@ mod tests {
             for_of_depth: 0,
             loop_iteration_multiplier: 1,
             regex_sets: &mut regex_sets,
-            regexp_pool: &mut regexp_pool,
+            regex_pool: &mut regex_pool,
         };
 
         let mut pattern = HexPattern::new("test_ident");

--- a/lib/src/compiler/ir/hex2hir.rs
+++ b/lib/src/compiler/ir/hex2hir.rs
@@ -227,6 +227,9 @@ mod tests {
         let mut warnings = Warnings::default();
         let mut rule_patterns = vec![];
 
+        let mut matches_by_target = rustc_hash::FxHashMap::default();
+        let mut regexp_pool = crate::string_pool::StringPool::new();
+
         let mut ctx = CompileContext {
             ir: &mut ir,
             relaxed_re_syntax: false,
@@ -240,6 +243,8 @@ mod tests {
             vars: VarStack::new(),
             for_of_depth: 0,
             loop_iteration_multiplier: 1,
+            matches_by_target: &mut matches_by_target,
+            regexp_pool: &mut regexp_pool,
         };
 
         let mut pattern = HexPattern::new("test_ident");

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -51,7 +51,7 @@ use crate::compiler::ir::dfs::{
     DFSIter, DFSWithScopeIter, Event, EventContext, dfs_common,
 };
 
-use crate::compiler::FilesizeBounds;
+use crate::compiler::{FilesizeBounds, RegexSetId};
 use crate::re;
 use crate::symbols::Symbol;
 use crate::types::Value::Const;
@@ -1556,6 +1556,20 @@ impl IR {
         expr_id
     }
 
+    /// Creates a new [`Expr::MatchesMany`].
+    pub fn matches_regex_set(
+        &mut self,
+        lhs: ExprId,
+        regex_set: crate::compiler::RegexSetId,
+    ) -> ExprId {
+        let expr_id = ExprId::from(self.nodes.len());
+        self.parents[lhs.0 as usize] = expr_id;
+        self.parents.push(ExprId::none());
+        self.nodes.push(Expr::MatchesMany { lhs, regex_set });
+        debug_assert_eq!(self.parents.len(), self.nodes.len());
+        expr_id
+    }
+
     /// Creates a new [`Expr::PatternMatch`]
     pub fn pattern_match(
         &mut self,
@@ -2000,6 +2014,7 @@ impl Debug for IR {
                         Expr::IEndsWith { .. } => writeln!(f, "IENDS_WITH -- hash: {expr_hash:#08x}")?,
                         Expr::IEquals { .. } => writeln!(f, "IEQUALS -- hash: {expr_hash:#08x}")?,
                         Expr::Matches { .. } => writeln!(f, "MATCHES -- hash: {expr_hash:#08x}")?,
+                        Expr::MatchesMany { .. } => writeln!(f, "MATCHES_MANY -- hash: {expr_hash:#08x}")?,
                         Expr::Defined { .. } => writeln!(f, "DEFINED -- hash: {expr_hash:#08x}")?,
                         Expr::FieldAccess { .. } => writeln!(f, "FIELD_ACCESS -- hash: {expr_hash:#08x}")?,
                         Expr::With { .. } => writeln!(f, "WITH -- hash: {expr_hash:#08x}")?,
@@ -2234,6 +2249,10 @@ pub(crate) enum Expr {
 
     /// `matches` expression.
     Matches { rhs: ExprId, lhs: ExprId },
+
+    /// Match expression similar to `Expr::Matches` but that matches against
+    /// multiple regular expressions at the same time.
+    MatchesMany { lhs: ExprId, regex_set: RegexSetId },
 
     /// A `defined` expression (e.g. `defined foo`)
     Defined { operand: ExprId },
@@ -2682,6 +2701,11 @@ impl Expr {
                     *rhs = replacement;
                 }
             }
+            Expr::MatchesMany { lhs, .. } => {
+                if *lhs == child {
+                    *lhs = replacement;
+                }
+            }
             Expr::PatternMatch { anchor, .. }
             | Expr::PatternMatchVar { anchor, .. } => {
                 replace_in_anchor(anchor)
@@ -2786,6 +2810,7 @@ impl Expr {
             | Expr::IEndsWith { .. }
             | Expr::IEquals { .. }
             | Expr::Matches { .. }
+            | Expr::MatchesMany { .. }
             | Expr::PatternMatch { .. }
             | Expr::PatternMatchVar { .. }
             | Expr::OfExprTuple(_)
@@ -2857,6 +2882,7 @@ impl Expr {
             | Expr::IEndsWith { .. }
             | Expr::IEquals { .. }
             | Expr::Matches { .. }
+            | Expr::MatchesMany { .. }
             | Expr::PatternMatch { .. }
             | Expr::PatternMatchVar { .. }
             | Expr::OfExprTuple(_)

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -2014,7 +2014,7 @@ impl Debug for IR {
                         Expr::IEndsWith { .. } => writeln!(f, "IENDS_WITH -- hash: {expr_hash:#08x}")?,
                         Expr::IEquals { .. } => writeln!(f, "IEQUALS -- hash: {expr_hash:#08x}")?,
                         Expr::Matches { .. } => writeln!(f, "MATCHES -- hash: {expr_hash:#08x}")?,
-                        Expr::MatchesMany { .. } => writeln!(f, "MATCHES_MANY -- hash: {expr_hash:#08x}")?,
+                        Expr::MatchesMany { regex_set, .. } => writeln!(f, "MATCHES_MANY RegexSetId({}) -- hash: {expr_hash:#08x}", usize::from(*regex_set))?,
                         Expr::Defined { .. } => writeln!(f, "DEFINED -- hash: {expr_hash:#08x}")?,
                         Expr::FieldAccess { .. } => writeln!(f, "FIELD_ACCESS -- hash: {expr_hash:#08x}")?,
                         Expr::With { .. } => writeln!(f, "WITH -- hash: {expr_hash:#08x}")?,

--- a/lib/src/compiler/ir/tests/testdata/1.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.cse.ir
@@ -4,14 +4,14 @@ RULE test_1
     5: CONST integer(1)
 
 RULE test_2
-  10: EQ -- hash: 0xfb622d3fda4c9468
-    8: SUB -- hash: 0x38aff83d94a3aa25
-      4: ADD -- hash: 0xaa45310763b4b319
-        2: FIELD_ACCESS -- hash: 0xe58b5f97183b1a0c
+  10: EQ -- hash: 0xa60cf135438e6090
+    8: SUB -- hash: 0xdc58c9f57c354387
+      4: ADD -- hash: 0x73cffc9d7ea6b7e5
+        2: FIELD_ACCESS -- hash: 0x4a147f30f75a8a38
           0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           1: SYMBOL Field { index: 13, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         3: CONST integer(1)
-      7: FIELD_ACCESS -- hash: 0xe58b5f97183b1a0c
+      7: FIELD_ACCESS -- hash: 0x4a147f30f75a8a38
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 13, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
     9: CONST integer(1)
@@ -39,16 +39,16 @@ RULE test_6
     8: CONST integer(1)
 
 RULE test_7
-  8: AND -- hash: 0x966e46de448a5ee5
-    4: EQ -- hash: 0x6500d8d8a8951685
-      2: FIELD_ACCESS -- hash: 0x6b278e4a6873a6f4
+  8: AND -- hash: 0x5ff91274637c63b1
+    4: EQ -- hash: 0x2e8ba46ec7871b51
+      2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       3: CONST integer(0)
 
 RULE test_8
-  5: ADD -- hash: 0x52c16f85b5684320
-    2: FIELD_ACCESS -- hash: 0x6b278e4a6873a6f4
+  5: ADD -- hash: 0x1d972cb4137a7747
+    2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
     3: CONST integer(1)

--- a/lib/src/compiler/ir/tests/testdata/1.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.hoisting.ir
@@ -4,14 +4,14 @@ RULE test_1
     5: CONST integer(1)
 
 RULE test_2
-  10: EQ -- hash: 0xfb622d3fda4c9468
-    8: SUB -- hash: 0x38aff83d94a3aa25
-      4: ADD -- hash: 0xaa45310763b4b319
-        2: FIELD_ACCESS -- hash: 0xe58b5f97183b1a0c
+  10: EQ -- hash: 0xa60cf135438e6090
+    8: SUB -- hash: 0xdc58c9f57c354387
+      4: ADD -- hash: 0x73cffc9d7ea6b7e5
+        2: FIELD_ACCESS -- hash: 0x4a147f30f75a8a38
           0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           1: SYMBOL Field { index: 13, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         3: CONST integer(1)
-      7: FIELD_ACCESS -- hash: 0xe58b5f97183b1a0c
+      7: FIELD_ACCESS -- hash: 0x4a147f30f75a8a38
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 13, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
     9: CONST integer(1)
@@ -39,16 +39,16 @@ RULE test_6
     8: CONST integer(1)
 
 RULE test_7
-  8: AND -- hash: 0x966e46de448a5ee5
-    4: EQ -- hash: 0x6500d8d8a8951685
-      2: FIELD_ACCESS -- hash: 0x6b278e4a6873a6f4
+  8: AND -- hash: 0x5ff91274637c63b1
+    4: EQ -- hash: 0x2e8ba46ec7871b51
+      2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       3: CONST integer(0)
 
 RULE test_8
-  5: ADD -- hash: 0x52c16f85b5684320
-    2: FIELD_ACCESS -- hash: 0x6b278e4a6873a6f4
+  5: ADD -- hash: 0x1d972cb4137a7747
+    2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
     3: CONST integer(1)

--- a/lib/src/compiler/ir/tests/testdata/1.ir
+++ b/lib/src/compiler/ir/tests/testdata/1.ir
@@ -4,14 +4,14 @@ RULE test_1
     5: CONST integer(1)
 
 RULE test_2
-  10: EQ -- hash: 0xfb622d3fda4c9468
-    8: SUB -- hash: 0x38aff83d94a3aa25
-      4: ADD -- hash: 0xaa45310763b4b319
-        2: FIELD_ACCESS -- hash: 0xe58b5f97183b1a0c
+  10: EQ -- hash: 0xa60cf135438e6090
+    8: SUB -- hash: 0xdc58c9f57c354387
+      4: ADD -- hash: 0x73cffc9d7ea6b7e5
+        2: FIELD_ACCESS -- hash: 0x4a147f30f75a8a38
           0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           1: SYMBOL Field { index: 13, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         3: CONST integer(1)
-      7: FIELD_ACCESS -- hash: 0xe58b5f97183b1a0c
+      7: FIELD_ACCESS -- hash: 0x4a147f30f75a8a38
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 13, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
     9: CONST integer(1)
@@ -39,16 +39,16 @@ RULE test_6
     8: CONST integer(1)
 
 RULE test_7
-  8: AND -- hash: 0x966e46de448a5ee5
-    4: EQ -- hash: 0x6500d8d8a8951685
-      2: FIELD_ACCESS -- hash: 0x6b278e4a6873a6f4
+  8: AND -- hash: 0x5ff91274637c63b1
+    4: EQ -- hash: 0x2e8ba46ec7871b51
+      2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       3: CONST integer(0)
 
 RULE test_8
-  5: ADD -- hash: 0x52c16f85b5684320
-    2: FIELD_ACCESS -- hash: 0x6b278e4a6873a6f4
+  5: ADD -- hash: 0x1d972cb4137a7747
+    2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
     3: CONST integer(1)

--- a/lib/src/compiler/ir/tests/testdata/10.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/10.cse.ir
@@ -1,5 +1,5 @@
 RULE test
-  13: FOR_IN -- hash: 0x12dbfc09ed5ac100
+  13: FOR_IN -- hash: 0xfd14d4882d1f6026
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,15 +7,15 @@ RULE test
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(1)
     1: CONST integer(10)
-    12: WITH -- hash: 0xac40a564e67960e7
-      6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xdb7bdb9e18e2be98
-        5: ADD -- hash: 0x685e7a2ba5a36f1d
-          3: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+    12: WITH -- hash: 0xe5f28003804fec06
+      6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xedfbb8eef52ecd47
+        5: ADD -- hash: 0xd087500d7c07b7de
+          3: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
             2: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           4: CONST integer(16)
-      8: FN_CALL uint32be@offset:i@i:R0:4294967295u -- hash: 0x954bbb64201a5bf8
+      8: FN_CALL uint32be@offset:i@i:R0:4294967295u -- hash: 0xae9a6e5779a03664
         7: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 7 }, type_value: integer(unknown) }
-      11: NE -- hash: 0xe0b33818592dcf55
+      11: NE -- hash: 0x2475e24cefdb3f3e
         9: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 8 }, type_value: integer(unknown) }
         10: CONST integer(1347092738)
 

--- a/lib/src/compiler/ir/tests/testdata/10.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/10.hoisting.ir
@@ -1,5 +1,5 @@
 RULE test
-  13: FOR_IN -- hash: 0x12dbfc09ed5ac100
+  13: FOR_IN -- hash: 0xfd14d4882d1f6026
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,15 +7,15 @@ RULE test
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(1)
     1: CONST integer(10)
-    12: WITH -- hash: 0xac40a564e67960e7
-      6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xdb7bdb9e18e2be98
-        5: ADD -- hash: 0x685e7a2ba5a36f1d
-          3: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+    12: WITH -- hash: 0xe5f28003804fec06
+      6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xedfbb8eef52ecd47
+        5: ADD -- hash: 0xd087500d7c07b7de
+          3: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
             2: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           4: CONST integer(16)
-      8: FN_CALL uint32be@offset:i@i:R0:4294967295u -- hash: 0x954bbb64201a5bf8
+      8: FN_CALL uint32be@offset:i@i:R0:4294967295u -- hash: 0xae9a6e5779a03664
         7: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 7 }, type_value: integer(unknown) }
-      11: NE -- hash: 0xe0b33818592dcf55
+      11: NE -- hash: 0x2475e24cefdb3f3e
         9: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 8 }, type_value: integer(unknown) }
         10: CONST integer(1347092738)
 

--- a/lib/src/compiler/ir/tests/testdata/10.ir
+++ b/lib/src/compiler/ir/tests/testdata/10.ir
@@ -1,5 +1,5 @@
 RULE test
-  13: FOR_IN -- hash: 0x12dbfc09ed5ac100
+  13: FOR_IN -- hash: 0xfd14d4882d1f6026
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,15 +7,15 @@ RULE test
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(1)
     1: CONST integer(10)
-    12: WITH -- hash: 0xac40a564e67960e7
-      6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xdb7bdb9e18e2be98
-        5: ADD -- hash: 0x685e7a2ba5a36f1d
-          3: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+    12: WITH -- hash: 0xe5f28003804fec06
+      6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xedfbb8eef52ecd47
+        5: ADD -- hash: 0xd087500d7c07b7de
+          3: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
             2: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           4: CONST integer(16)
-      8: FN_CALL uint32be@offset:i@i:R0:4294967295u -- hash: 0x954bbb64201a5bf8
+      8: FN_CALL uint32be@offset:i@i:R0:4294967295u -- hash: 0xae9a6e5779a03664
         7: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 7 }, type_value: integer(unknown) }
-      11: NE -- hash: 0xe0b33818592dcf55
+      11: NE -- hash: 0x2475e24cefdb3f3e
         9: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 8 }, type_value: integer(unknown) }
         10: CONST integer(1347092738)
 

--- a/lib/src/compiler/ir/tests/testdata/12.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/12.cse.ir
@@ -1,39 +1,39 @@
 RULE test
-  54: FOR_IN -- hash: 0xa709f38b89bfe025
+  54: FOR_IN -- hash: 0xb3907652e47beb80
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: array, index: 4 }
-    2: FIELD_ACCESS -- hash: 0x46c662e9e5c5cbcf
+    2: FIELD_ACCESS -- hash: 0xab4f8283c0e53bfa
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 56, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    53: AND -- hash: 0x799c20ca39b7039f
-      12: FOR_OF -- hash: 0x8931dd42d26d892
+    53: AND -- hash: 0x4d8c6ca7f7b038e9
+      12: FOR_OF -- hash: 0x2f22787ddf2a05e8
             n: Var { frame_id: 2, ty: integer, index: 7 }
             i: Var { frame_id: 2, ty: integer, index: 8 }
             max_count: Var { frame_id: 2, ty: integer, index: 9 }
             count: Var { frame_id: 2, ty: integer, index: 10 }
             item: Var { frame_id: 2, ty: integer, index: 11 }
-        11: PATTERN_MATCH Var { var: Var { frame_id: 2, ty: integer, index: 11 }, type_value: integer(unknown) } IN -- hash: 0xe05e27098b7a923a
-          5: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+        11: PATTERN_MATCH Var { var: Var { frame_id: 2, ty: integer, index: 11 }, type_value: integer(unknown) } IN -- hash: 0xe11c4fde46b8d594
+          5: FIELD_ACCESS -- hash: 0x4e507ee934802418
             3: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
             4: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          10: ADD -- hash: 0xc28a65d98fa3a2d4
-            8: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+          10: ADD -- hash: 0xe49ed0540b890623
+            8: FIELD_ACCESS -- hash: 0x4e507ee934802418
               6: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
               7: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
             9: CONST integer(512)
-      52: FOR_IN -- hash: 0xe7027e84e0d9f4dc
+      52: FOR_IN -- hash: 0x603a22daabc68
             n: Var { frame_id: 3, ty: integer, index: 7 }
             i: Var { frame_id: 3, ty: integer, index: 8 }
             max_count: Var { frame_id: 3, ty: integer, index: 9 }
             count: Var { frame_id: 3, ty: integer, index: 10 }
             item: Var { frame_id: 3, ty: array, index: 11 }
-        15: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        15: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
           13: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           14: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-        51: FOR_IN -- hash: 0xe79e13157fac1a3f
+        51: FOR_IN -- hash: 0x9a65469129227a90
               n: Var { frame_id: 4, ty: integer, index: 14 }
               i: Var { frame_id: 4, ty: integer, index: 15 }
               max_count: Var { frame_id: 4, ty: integer, index: 16 }
@@ -42,34 +42,34 @@ RULE test
           16: CONST integer(100)
           17: CONST integer(0)
           18: CONST integer(4096)
-          50: AND -- hash: 0xb834ba793edd5e9b
-            32: GE -- hash: 0xe5c0d20558fc0fb2
-              24: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xafbedd68e503f7f1
-                23: ADD -- hash: 0x47a7b46d42b6b5ab
-                  21: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+          50: AND -- hash: 0x1b1a568f17bcf825
+            32: GE -- hash: 0xcf54ff2b85c632e4
+              24: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x16ed736c1a4b50dd
+                23: ADD -- hash: 0x4ff11ce819e3968
+                  21: FIELD_ACCESS -- hash: 0x4e507ee934802418
                     19: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
                     20: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                   22: SYMBOL Var { var: Var { frame_id: 4, ty: integer, index: 19 }, type_value: integer(unknown) }
-              31: ADD -- hash: 0xedcebbb45d332fa1
-                27: FIELD_ACCESS -- hash: 0x7bd0120a5399dc33
+              31: ADD -- hash: 0x6a69741994d76af9
+                27: FIELD_ACCESS -- hash: 0xe05931a42eb94c5e
                   25: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                   26: SYMBOL Field { index: 11, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                30: FIELD_ACCESS -- hash: 0xb7218577f57bd98a
+                30: FIELD_ACCESS -- hash: 0x7869638c32afd7cb
                   28: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 12 }, type_value: struct }
                   29: SYMBOL Field { index: 5, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-            49: LT -- hash: 0x44a41e4399f5b1fb
-              38: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xafbedd68e503f7f1
-                37: ADD -- hash: 0x47a7b46d42b6b5ab
-                  35: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+            49: LT -- hash: 0xc658c8b2d714ed97
+              38: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x16ed736c1a4b50dd
+                37: ADD -- hash: 0x4ff11ce819e3968
+                  35: FIELD_ACCESS -- hash: 0x4e507ee934802418
                     33: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
                     34: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                   36: SYMBOL Var { var: Var { frame_id: 4, ty: integer, index: 19 }, type_value: integer(unknown) }
-              48: BITWISE_AND -- hash: 0x3d6e11906b146000
-                45: ADD -- hash: 0xedcebbb45d332fa1
-                  41: FIELD_ACCESS -- hash: 0x7bd0120a5399dc33
+              48: BITWISE_AND -- hash: 0x6d24fb1623e66cd1
+                45: ADD -- hash: 0x6a69741994d76af9
+                  41: FIELD_ACCESS -- hash: 0xe05931a42eb94c5e
                     39: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                     40: SYMBOL Field { index: 11, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                  44: FIELD_ACCESS -- hash: 0xb7218577f57bd98a
+                  44: FIELD_ACCESS -- hash: 0x7869638c32afd7cb
                     42: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 12 }, type_value: struct }
                     43: SYMBOL Field { index: 5, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                 47: CONST integer(-4096)

--- a/lib/src/compiler/ir/tests/testdata/12.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/12.hoisting.ir
@@ -1,71 +1,71 @@
 RULE test
-  56: WITH -- hash: 0x25df0a1eb2ea70e8
-    55: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  56: WITH -- hash: 0x6ce2515b14666db7
+    55: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
       13: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       14: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    60: WITH -- hash: 0x444aec6855c55f44
-      59: FIELD_ACCESS -- hash: 0x7bd0120a5399dc33
+    60: WITH -- hash: 0xc0dbc481fbb439ce
+      59: FIELD_ACCESS -- hash: 0xe05931a42eb94c5e
         25: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         26: SYMBOL Field { index: 11, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-      66: WITH -- hash: 0x829c65da106b01c1
-        65: FIELD_ACCESS -- hash: 0x7bd0120a5399dc33
+      66: WITH -- hash: 0x57d3ee6af7060425
+        65: FIELD_ACCESS -- hash: 0xe05931a42eb94c5e
           39: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           40: SYMBOL Field { index: 11, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        54: FOR_IN -- hash: 0x3e44056aaf556aa3
+        54: FOR_IN -- hash: 0xc20ef45cd3ce8ade
               n: Var { frame_id: 1, ty: integer, index: 3 }
               i: Var { frame_id: 1, ty: integer, index: 4 }
               max_count: Var { frame_id: 1, ty: integer, index: 5 }
               count: Var { frame_id: 1, ty: integer, index: 6 }
               item: Var { frame_id: 1, ty: array, index: 7 }
-          2: FIELD_ACCESS -- hash: 0x46c662e9e5c5cbcf
+          2: FIELD_ACCESS -- hash: 0xab4f8283c0e53bfa
             0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             1: SYMBOL Field { index: 56, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-          53: AND -- hash: 0xc107c1d05c0f81b2
-            12: FOR_OF -- hash: 0x746de8a90292d14
+          53: AND -- hash: 0x6e529af6e2ef3ad4
+            12: FOR_OF -- hash: 0x2dd63934422c5a6a
                   n: Var { frame_id: 2, ty: integer, index: 10 }
                   i: Var { frame_id: 2, ty: integer, index: 11 }
                   max_count: Var { frame_id: 2, ty: integer, index: 12 }
                   count: Var { frame_id: 2, ty: integer, index: 13 }
                   item: Var { frame_id: 2, ty: integer, index: 14 }
-              11: PATTERN_MATCH Var { var: Var { frame_id: 2, ty: integer, index: 14 }, type_value: integer(unknown) } IN -- hash: 0xdf11e7bfee7ce6bc
-                5: FIELD_ACCESS -- hash: 0x5189eca0760672df
+              11: PATTERN_MATCH Var { var: Var { frame_id: 2, ty: integer, index: 14 }, type_value: integer(unknown) } IN -- hash: 0xdfd01094a9bb2a16
+                5: FIELD_ACCESS -- hash: 0x12d1cab4b33a7120
                   3: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 8 }, type_value: struct }
                   4: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                10: ADD -- hash: 0x8dd264774babf28d
-                  8: FIELD_ACCESS -- hash: 0x5189eca0760672df
+                10: ADD -- hash: 0xafe6cef1c79155dc
+                  8: FIELD_ACCESS -- hash: 0x12d1cab4b33a7120
                     6: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 8 }, type_value: struct }
                     7: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                   9: CONST integer(512)
-            58: WITH -- hash: 0x86c4059b51bf3aff
-              57: FIELD_ACCESS -- hash: 0x5189eca0760672df
+            58: WITH -- hash: 0xd604f50e65135da4
+              57: FIELD_ACCESS -- hash: 0x12d1cab4b33a7120
                 19: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 8 }, type_value: struct }
                 20: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-              64: WITH -- hash: 0x6edce6518af699d2
-                63: FIELD_ACCESS -- hash: 0x5189eca0760672df
+              64: WITH -- hash: 0xe0380f4b6ca7b7fb
+                63: FIELD_ACCESS -- hash: 0x12d1cab4b33a7120
                   33: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 8 }, type_value: struct }
                   34: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                52: FOR_IN -- hash: 0x2dc3c9fb2147d545
+                52: FOR_IN -- hash: 0xe17e0a7e154aa4c3
                       n: Var { frame_id: 3, ty: integer, index: 12 }
                       i: Var { frame_id: 3, ty: integer, index: 13 }
                       max_count: Var { frame_id: 3, ty: integer, index: 14 }
                       count: Var { frame_id: 3, ty: integer, index: 15 }
                       item: Var { frame_id: 3, ty: array, index: 16 }
                   15: SYMBOL Var { var: Var { frame_id: 0, ty: array, index: 0 }, type_value: array }
-                  62: WITH -- hash: 0x59136236fb7e5c2c
-                    61: ADD -- hash: 0x3fd489730941e61d
+                  62: WITH -- hash: 0x4bc0dda75686a6e
+                    61: ADD -- hash: 0x119636de791cfc7e
                       27: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 1 }, type_value: integer(unknown) }
-                      30: FIELD_ACCESS -- hash: 0x53f903cb1a07af42
+                      30: FIELD_ACCESS -- hash: 0x1540e1df573bad83
                         28: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 17 }, type_value: struct }
                         29: SYMBOL Field { index: 5, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                    68: WITH -- hash: 0xb78337725d015b61
-                      67: BITWISE_AND -- hash: 0x293bca44886231b7
-                        45: ADD -- hash: 0x763751337f3adb8a
+                    68: WITH -- hash: 0xc75581eeb74c42d9
+                      67: BITWISE_AND -- hash: 0xf5276d60faa76a34
+                        45: ADD -- hash: 0x47f8fe9eef15f1eb
                           41: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 2 }, type_value: integer(unknown) }
-                          44: FIELD_ACCESS -- hash: 0x53f903cb1a07af42
+                          44: FIELD_ACCESS -- hash: 0x1540e1df573bad83
                             42: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 17 }, type_value: struct }
                             43: SYMBOL Field { index: 5, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                         47: CONST integer(-4096)
-                      51: FOR_IN -- hash: 0xa258ad9590e1af19
+                      51: FOR_IN -- hash: 0x8ba19c29d61ba8c7
                             n: Var { frame_id: 4, ty: integer, index: 21 }
                             i: Var { frame_id: 4, ty: integer, index: 22 }
                             max_count: Var { frame_id: 4, ty: integer, index: 23 }
@@ -74,16 +74,16 @@ RULE test
                         16: CONST integer(100)
                         17: CONST integer(0)
                         18: CONST integer(4096)
-                        50: AND -- hash: 0x711d80a51b83da4
-                          32: GE -- hash: 0x5a724ffd8e497c43
-                            24: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x8ced77366c66ff4
-                              23: ADD -- hash: 0xa51432bcd2363534
+                        50: AND -- hash: 0xdcb7f38210df8cab
+                          32: GE -- hash: 0x8ad0c9646eead213
+                            24: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xfbcc1372c30b0fd1
+                              23: ADD -- hash: 0x1b21a42a89d09db6
                                 21: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 10 }, type_value: integer(unknown) }
                                 22: SYMBOL Var { var: Var { frame_id: 4, ty: integer, index: 26 }, type_value: integer(unknown) }
                             31: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 19 }, type_value: integer(unknown) }
-                          49: LT -- hash: 0x7503ee46ca9a41df
-                            38: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xddb6379988aa0896
-                              37: ADD -- hash: 0x79fb92e2f419cdd7
+                          49: LT -- hash: 0xa56267adab3b97af
+                            38: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xd0b37398e4eea874
+                              37: ADD -- hash: 0xf0090450afb43658
                                 35: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 11 }, type_value: integer(unknown) }
                                 36: SYMBOL Var { var: Var { frame_id: 4, ty: integer, index: 26 }, type_value: integer(unknown) }
                             48: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 20 }, type_value: integer(unknown) }

--- a/lib/src/compiler/ir/tests/testdata/12.ir
+++ b/lib/src/compiler/ir/tests/testdata/12.ir
@@ -1,39 +1,39 @@
 RULE test
-  54: FOR_IN -- hash: 0xa709f38b89bfe025
+  54: FOR_IN -- hash: 0xb3907652e47beb80
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: array, index: 4 }
-    2: FIELD_ACCESS -- hash: 0x46c662e9e5c5cbcf
+    2: FIELD_ACCESS -- hash: 0xab4f8283c0e53bfa
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 56, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    53: AND -- hash: 0x799c20ca39b7039f
-      12: FOR_OF -- hash: 0x8931dd42d26d892
+    53: AND -- hash: 0x4d8c6ca7f7b038e9
+      12: FOR_OF -- hash: 0x2f22787ddf2a05e8
             n: Var { frame_id: 2, ty: integer, index: 7 }
             i: Var { frame_id: 2, ty: integer, index: 8 }
             max_count: Var { frame_id: 2, ty: integer, index: 9 }
             count: Var { frame_id: 2, ty: integer, index: 10 }
             item: Var { frame_id: 2, ty: integer, index: 11 }
-        11: PATTERN_MATCH Var { var: Var { frame_id: 2, ty: integer, index: 11 }, type_value: integer(unknown) } IN -- hash: 0xe05e27098b7a923a
-          5: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+        11: PATTERN_MATCH Var { var: Var { frame_id: 2, ty: integer, index: 11 }, type_value: integer(unknown) } IN -- hash: 0xe11c4fde46b8d594
+          5: FIELD_ACCESS -- hash: 0x4e507ee934802418
             3: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
             4: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          10: ADD -- hash: 0xc28a65d98fa3a2d4
-            8: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+          10: ADD -- hash: 0xe49ed0540b890623
+            8: FIELD_ACCESS -- hash: 0x4e507ee934802418
               6: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
               7: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
             9: CONST integer(512)
-      52: FOR_IN -- hash: 0xe7027e84e0d9f4dc
+      52: FOR_IN -- hash: 0x603a22daabc68
             n: Var { frame_id: 3, ty: integer, index: 7 }
             i: Var { frame_id: 3, ty: integer, index: 8 }
             max_count: Var { frame_id: 3, ty: integer, index: 9 }
             count: Var { frame_id: 3, ty: integer, index: 10 }
             item: Var { frame_id: 3, ty: array, index: 11 }
-        15: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        15: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
           13: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           14: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-        51: FOR_IN -- hash: 0xe79e13157fac1a3f
+        51: FOR_IN -- hash: 0x9a65469129227a90
               n: Var { frame_id: 4, ty: integer, index: 14 }
               i: Var { frame_id: 4, ty: integer, index: 15 }
               max_count: Var { frame_id: 4, ty: integer, index: 16 }
@@ -42,34 +42,34 @@ RULE test
           16: CONST integer(100)
           17: CONST integer(0)
           18: CONST integer(4096)
-          50: AND -- hash: 0xb834ba793edd5e9b
-            32: GE -- hash: 0xe5c0d20558fc0fb2
-              24: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xafbedd68e503f7f1
-                23: ADD -- hash: 0x47a7b46d42b6b5ab
-                  21: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+          50: AND -- hash: 0x1b1a568f17bcf825
+            32: GE -- hash: 0xcf54ff2b85c632e4
+              24: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x16ed736c1a4b50dd
+                23: ADD -- hash: 0x4ff11ce819e3968
+                  21: FIELD_ACCESS -- hash: 0x4e507ee934802418
                     19: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
                     20: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                   22: SYMBOL Var { var: Var { frame_id: 4, ty: integer, index: 19 }, type_value: integer(unknown) }
-              31: ADD -- hash: 0xedcebbb45d332fa1
-                27: FIELD_ACCESS -- hash: 0x7bd0120a5399dc33
+              31: ADD -- hash: 0x6a69741994d76af9
+                27: FIELD_ACCESS -- hash: 0xe05931a42eb94c5e
                   25: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                   26: SYMBOL Field { index: 11, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                30: FIELD_ACCESS -- hash: 0xb7218577f57bd98a
+                30: FIELD_ACCESS -- hash: 0x7869638c32afd7cb
                   28: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 12 }, type_value: struct }
                   29: SYMBOL Field { index: 5, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-            49: LT -- hash: 0x44a41e4399f5b1fb
-              38: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xafbedd68e503f7f1
-                37: ADD -- hash: 0x47a7b46d42b6b5ab
-                  35: FIELD_ACCESS -- hash: 0x8d08a0d4fb4c25d7
+            49: LT -- hash: 0xc658c8b2d714ed97
+              38: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x16ed736c1a4b50dd
+                37: ADD -- hash: 0x4ff11ce819e3968
+                  35: FIELD_ACCESS -- hash: 0x4e507ee934802418
                     33: SYMBOL Var { var: Var { frame_id: 1, ty: struct, index: 5 }, type_value: struct }
                     34: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                   36: SYMBOL Var { var: Var { frame_id: 4, ty: integer, index: 19 }, type_value: integer(unknown) }
-              48: BITWISE_AND -- hash: 0x3d6e11906b146000
-                45: ADD -- hash: 0xedcebbb45d332fa1
-                  41: FIELD_ACCESS -- hash: 0x7bd0120a5399dc33
+              48: BITWISE_AND -- hash: 0x6d24fb1623e66cd1
+                45: ADD -- hash: 0x6a69741994d76af9
+                  41: FIELD_ACCESS -- hash: 0xe05931a42eb94c5e
                     39: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                     40: SYMBOL Field { index: 11, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                  44: FIELD_ACCESS -- hash: 0xb7218577f57bd98a
+                  44: FIELD_ACCESS -- hash: 0x7869638c32afd7cb
                     42: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 12 }, type_value: struct }
                     43: SYMBOL Field { index: 5, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                 47: CONST integer(-4096)

--- a/lib/src/compiler/ir/tests/testdata/13.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.cse.ir
@@ -7,7 +7,7 @@ RULE test_1
 
 RULE test_2
   16: OR -- hash: 0x5ab1605c802edf6b
-    15: MATCHES_MANY -- hash: 0x3c6728168e1bb284
+    15: MATCHES_MANY RegexSetId(0) -- hash: 0x3c6728168e1bb284
       7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/13.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.cse.ir
@@ -1,21 +1,32 @@
 RULE test_1
-  5: CONTAINS -- hash: 0x3440798238ccebd2
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
+  5: CONTAINS -- hash: 0x6cf3f481c6c2a8f5
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
     4: CONST string("foobar")
 
 RULE test_2
-  5: ICONTAINS -- hash: 0x44ba48d96f7403f2
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
-      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
-      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-    4: CONST string("foobar")
+  16: OR -- hash: 0x5ab1605c802edf6b
+    15: MATCHES_MANY -- hash: 0x3c6728168e1bb284
+      7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+        5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        6: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+    4: EQ -- hash: 0x2e8ba46ec7871b51
+      2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
+        0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
+      3: CONST integer(0)
 
 RULE test_3
-  4: MATCHES -- hash: 0x53bd9f971ea374fb
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
-      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
-      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-    3: CONST regexp(Regexp("/foo.bar/"))
+  11: OR -- hash: 0x30839e15c0f36963
+    4: MATCHES -- hash: 0x8c711a96a899321e
+      2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+        0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+      3: CONST regexp(Regexp("/foo.bar/"))
+    10: CONTAINS -- hash: 0x7c9808c06af2e50e
+      7: FIELD_ACCESS -- hash: 0x3edc21ca56e97069
+        5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        6: SYMBOL Field { index: 37, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+      9: CONST string("barbaz")
 

--- a/lib/src/compiler/ir/tests/testdata/13.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.cse.ir
@@ -6,6 +6,13 @@ RULE test_1
     4: CONST string("foobar")
 
 RULE test_2
+  5: ICONTAINS -- hash: 0x7d6dc3d8f969c115
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+    4: CONST string("foobar")
+
+RULE test_3
   16: OR -- hash: 0x5ab1605c802edf6b
     15: MATCHES_MANY RegexSetId(0) -- hash: 0x3c6728168e1bb284
       7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
@@ -17,16 +24,22 @@ RULE test_2
         1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       3: CONST integer(0)
 
-RULE test_3
-  11: OR -- hash: 0x30839e15c0f36963
+RULE test_4
+  10: MATCHES_MANY RegexSetId(1) -- hash: 0x3c6728168e1bb284
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+
+RULE test_5
+  10: OR -- hash: 0xb05e2359598bbe0c
     4: MATCHES -- hash: 0x8c711a96a899321e
       2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       3: CONST regexp(Regexp("/foo.bar/"))
-    10: CONTAINS -- hash: 0x7c9808c06af2e50e
+    9: MATCHES -- hash: 0xfc728e04038b39b7
       7: FIELD_ACCESS -- hash: 0x3edc21ca56e97069
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 37, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-      9: CONST string("barbaz")
+      8: CONST regexp(Regexp("/bar.baz/"))
 

--- a/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
@@ -7,7 +7,7 @@ RULE test_1
 
 RULE test_2
   16: OR -- hash: 0x5ab1605c802edf6b
-    15: MATCHES_MANY -- hash: 0x3c6728168e1bb284
+    15: MATCHES_MANY RegexSetId(0) -- hash: 0x3c6728168e1bb284
       7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
@@ -1,21 +1,32 @@
 RULE test_1
-  5: CONTAINS -- hash: 0x3440798238ccebd2
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
+  5: CONTAINS -- hash: 0x6cf3f481c6c2a8f5
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
     4: CONST string("foobar")
 
 RULE test_2
-  5: ICONTAINS -- hash: 0x44ba48d96f7403f2
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
-      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
-      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-    4: CONST string("foobar")
+  16: OR -- hash: 0x5ab1605c802edf6b
+    15: MATCHES_MANY -- hash: 0x3c6728168e1bb284
+      7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+        5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        6: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+    4: EQ -- hash: 0x2e8ba46ec7871b51
+      2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
+        0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
+      3: CONST integer(0)
 
 RULE test_3
-  4: MATCHES -- hash: 0x53bd9f971ea374fb
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
-      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
-      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-    3: CONST regexp(Regexp("/foo.bar/"))
+  11: OR -- hash: 0x30839e15c0f36963
+    4: MATCHES -- hash: 0x8c711a96a899321e
+      2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+        0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+      3: CONST regexp(Regexp("/foo.bar/"))
+    10: CONTAINS -- hash: 0x7c9808c06af2e50e
+      7: FIELD_ACCESS -- hash: 0x3edc21ca56e97069
+        5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        6: SYMBOL Field { index: 37, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+      9: CONST string("barbaz")
 

--- a/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.hoisting.ir
@@ -6,6 +6,13 @@ RULE test_1
     4: CONST string("foobar")
 
 RULE test_2
+  5: ICONTAINS -- hash: 0x7d6dc3d8f969c115
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+    4: CONST string("foobar")
+
+RULE test_3
   16: OR -- hash: 0x5ab1605c802edf6b
     15: MATCHES_MANY RegexSetId(0) -- hash: 0x3c6728168e1bb284
       7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
@@ -17,16 +24,22 @@ RULE test_2
         1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       3: CONST integer(0)
 
-RULE test_3
-  11: OR -- hash: 0x30839e15c0f36963
+RULE test_4
+  10: MATCHES_MANY RegexSetId(1) -- hash: 0x3c6728168e1bb284
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+
+RULE test_5
+  10: OR -- hash: 0xb05e2359598bbe0c
     4: MATCHES -- hash: 0x8c711a96a899321e
       2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       3: CONST regexp(Regexp("/foo.bar/"))
-    10: CONTAINS -- hash: 0x7c9808c06af2e50e
+    9: MATCHES -- hash: 0xfc728e04038b39b7
       7: FIELD_ACCESS -- hash: 0x3edc21ca56e97069
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 37, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-      9: CONST string("barbaz")
+      8: CONST regexp(Regexp("/bar.baz/"))
 

--- a/lib/src/compiler/ir/tests/testdata/13.in
+++ b/lib/src/compiler/ir/tests/testdata/13.in
@@ -7,10 +7,24 @@ rule test_1 {
 
 rule test_2 {
     condition:
-        test_proto2.int64_zero == 0 or test_proto2.string_foo matches /foo.bar/i or test_proto2.string_foo matches /bar.baz/
+        test_proto2.string_foo matches /foobar/i
 }
 
 rule test_3 {
     condition:
-        test_proto2.string_foo matches /foo.bar/ or test_proto2.string_bar matches /barbaz/
+        test_proto2.int64_zero == 0 or
+        test_proto2.string_foo matches /foo.bar/i or
+        test_proto2.string_foo matches /bar.baz/
+}
+
+rule test_4 {
+    condition:
+        test_proto2.string_foo matches /foo.bar/ or
+        test_proto2.string_foo matches /bar.baz/
+}
+
+rule test_5 {
+    condition:
+        test_proto2.string_foo matches /foo.bar/ or
+        test_proto2.string_bar matches /bar.baz/
 }

--- a/lib/src/compiler/ir/tests/testdata/13.in
+++ b/lib/src/compiler/ir/tests/testdata/13.in
@@ -7,10 +7,10 @@ rule test_1 {
 
 rule test_2 {
     condition:
-        test_proto2.string_foo matches /foobar/i
+        test_proto2.int64_zero == 0 or test_proto2.string_foo matches /foo.bar/i or test_proto2.string_foo matches /bar.baz/
 }
 
 rule test_3 {
     condition:
-        test_proto2.string_foo matches /foo.bar/
+        test_proto2.string_foo matches /foo.bar/ or test_proto2.string_bar matches /barbaz/
 }

--- a/lib/src/compiler/ir/tests/testdata/13.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.ir
@@ -7,7 +7,7 @@ RULE test_1
 
 RULE test_2
   16: OR -- hash: 0x5ab1605c802edf6b
-    15: MATCHES_MANY -- hash: 0x3c6728168e1bb284
+    15: MATCHES_MANY RegexSetId(0) -- hash: 0x3c6728168e1bb284
       7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/13.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.ir
@@ -1,21 +1,32 @@
 RULE test_1
-  5: CONTAINS -- hash: 0x3440798238ccebd2
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
+  5: CONTAINS -- hash: 0x6cf3f481c6c2a8f5
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
     4: CONST string("foobar")
 
 RULE test_2
-  5: ICONTAINS -- hash: 0x44ba48d96f7403f2
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
-      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
-      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-    4: CONST string("foobar")
+  16: OR -- hash: 0x5ab1605c802edf6b
+    15: MATCHES_MANY -- hash: 0x3c6728168e1bb284
+      7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+        5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        6: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+    4: EQ -- hash: 0x2e8ba46ec7871b51
+      2: FIELD_ACCESS -- hash: 0xcfb0ade44793171f
+        0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
+      3: CONST integer(0)
 
 RULE test_3
-  4: MATCHES -- hash: 0x53bd9f971ea374fb
-    2: FIELD_ACCESS -- hash: 0x25755b6a17796151
-      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
-      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-    3: CONST regexp(Regexp("/foo.bar/"))
+  11: OR -- hash: 0x30839e15c0f36963
+    4: MATCHES -- hash: 0x8c711a96a899321e
+      2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+        0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+      3: CONST regexp(Regexp("/foo.bar/"))
+    10: CONTAINS -- hash: 0x7c9808c06af2e50e
+      7: FIELD_ACCESS -- hash: 0x3edc21ca56e97069
+        5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+        6: SYMBOL Field { index: 37, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+      9: CONST string("barbaz")
 

--- a/lib/src/compiler/ir/tests/testdata/13.ir
+++ b/lib/src/compiler/ir/tests/testdata/13.ir
@@ -6,6 +6,13 @@ RULE test_1
     4: CONST string("foobar")
 
 RULE test_2
+  5: ICONTAINS -- hash: 0x7d6dc3d8f969c115
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+    4: CONST string("foobar")
+
+RULE test_3
   16: OR -- hash: 0x5ab1605c802edf6b
     15: MATCHES_MANY RegexSetId(0) -- hash: 0x3c6728168e1bb284
       7: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
@@ -17,16 +24,22 @@ RULE test_2
         1: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       3: CONST integer(0)
 
-RULE test_3
-  11: OR -- hash: 0x30839e15c0f36963
+RULE test_4
+  10: MATCHES_MANY RegexSetId(1) -- hash: 0x3c6728168e1bb284
+    2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
+      0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
+      1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
+
+RULE test_5
+  10: OR -- hash: 0xb05e2359598bbe0c
     4: MATCHES -- hash: 0x8c711a96a899321e
       2: FIELD_ACCESS -- hash: 0x89fe7b03f298d17c
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 36, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       3: CONST regexp(Regexp("/foo.bar/"))
-    10: CONTAINS -- hash: 0x7c9808c06af2e50e
+    9: MATCHES -- hash: 0xfc728e04038b39b7
       7: FIELD_ACCESS -- hash: 0x3edc21ca56e97069
         5: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         6: SYMBOL Field { index: 37, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
-      9: CONST string("barbaz")
+      8: CONST regexp(Regexp("/bar.baz/"))
 

--- a/lib/src/compiler/ir/tests/testdata/2.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/2.cse.ir
@@ -1,60 +1,60 @@
 RULE test
-  42: FOR_IN -- hash: 0xda878d9eb553a61e
+  42: FOR_IN -- hash: 0x5a8b495d9ca0365f
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
-    1: PATTERN_COUNT PatternIdx(0) -- hash: 0xc1bc033c6a64ce89
-    41: FOR_IN -- hash: 0x2c8f1ee17fe69986
+    1: PATTERN_COUNT PatternIdx(0) -- hash: 0x295099eb5fc21fe8
+    41: FOR_IN -- hash: 0xc59e62932f94ad94
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
           count: Var { frame_id: 2, ty: integer, index: 10 }
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
-      3: PATTERN_COUNT PatternIdx(1) -- hash: 0x7699aa02ceb56d76
-      40: FOR_IN -- hash: 0x178ae2b47067f224
+      3: PATTERN_COUNT PatternIdx(1) -- hash: 0xde2e40b1c012bed4
+      40: FOR_IN -- hash: 0x43fb933d283b1ad6
             n: Var { frame_id: 3, ty: integer, index: 14 }
             i: Var { frame_id: 3, ty: integer, index: 15 }
             max_count: Var { frame_id: 3, ty: integer, index: 16 }
             count: Var { frame_id: 3, ty: integer, index: 17 }
             item: Var { frame_id: 3, ty: array, index: 18 }
-        6: FIELD_ACCESS -- hash: 0x22bd483d721ed399
+        6: FIELD_ACCESS -- hash: 0x874667d74d3e43c4
           4: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           5: SYMBOL Field { index: 19, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-        39: AND -- hash: 0xff21eb12445aa4e7
-          12: LE -- hash: 0x1b9ea398e3c8553e
-            9: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+        39: AND -- hash: 0x7633aa85f81db2b
+          12: LE -- hash: 0xe9f7e368f4dece6e
+            9: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
               7: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
               8: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-            11: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+            11: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
               10: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
-          22: LE -- hash: 0x60fd6a25db3c471e
-            14: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+          22: LE -- hash: 0xe67373d7ab0aa8d1
+            14: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
               13: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
-            21: ADD -- hash: 0x24b1906c95554907
-              17: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+            21: ADD -- hash: 0xa39958692f6255bc
+              17: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
                 15: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 16: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-              20: FIELD_ACCESS -- hash: 0x58d89b393296bc3f
+              20: FIELD_ACCESS -- hash: 0x1a20794d6fcaba80
                 18: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 19: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          28: LE -- hash: 0x45ddf7f717200bc7
-            25: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+          28: LE -- hash: 0x143737c7283684f8
+            25: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
               23: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
               24: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-            27: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xa6f63684c43735a4
+            27: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xc044e9781dbd1010
               26: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 12 }, type_value: integer(unknown) }
-          38: LE -- hash: 0x92d1270c9c59b1b0
-            30: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xa6f63684c43735a4
+          38: LE -- hash: 0x184730be6c281364
+            30: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xc044e9781dbd1010
               29: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 12 }, type_value: integer(unknown) }
-            37: ADD -- hash: 0x24b1906c95554907
-              33: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+            37: ADD -- hash: 0xa39958692f6255bc
+              33: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
                 31: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 32: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-              36: FIELD_ACCESS -- hash: 0x58d89b393296bc3f
+              36: FIELD_ACCESS -- hash: 0x1a20794d6fcaba80
                 34: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 35: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
 

--- a/lib/src/compiler/ir/tests/testdata/2.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/2.hoisting.ir
@@ -1,25 +1,25 @@
 RULE test
-  44: WITH -- hash: 0xfd51d86833944c9b
-    43: PATTERN_COUNT PatternIdx(1) -- hash: 0x7699aa02ceb56d76
-    46: WITH -- hash: 0xf99994e9c3a68cb3
-      45: FIELD_ACCESS -- hash: 0x22bd483d721ed399
+  44: WITH -- hash: 0x7c91d0cccb598c8a
+    43: PATTERN_COUNT PatternIdx(1) -- hash: 0xde2e40b1c012bed4
+    46: WITH -- hash: 0x43de2be682efd642
+      45: FIELD_ACCESS -- hash: 0x874667d74d3e43c4
         4: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         5: SYMBOL Field { index: 19, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-      42: FOR_IN -- hash: 0xe8e057517cf5bf22
+      42: FOR_IN -- hash: 0x69ea51737f0ab559
             n: Var { frame_id: 1, ty: integer, index: 2 }
             i: Var { frame_id: 1, ty: integer, index: 3 }
             max_count: Var { frame_id: 1, ty: integer, index: 4 }
             count: Var { frame_id: 1, ty: integer, index: 5 }
             item: Var { frame_id: 1, ty: unknown, index: 6 }
         0: CONST integer(0)
-        1: PATTERN_COUNT PatternIdx(0) -- hash: 0xc1bc033c6a64ce89
-        48: WITH -- hash: 0x669c16b485984c27
-          47: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0xce29f774b8692af2
+        1: PATTERN_COUNT PatternIdx(0) -- hash: 0x295099eb5fc21fe8
+        48: WITH -- hash: 0xf4e938698d476707
+          47: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0xe778aa6811ef055e
             10: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 7 }, type_value: integer(unknown) }
-          50: WITH -- hash: 0xab9765e6b9c23851
-            49: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0xce29f774b8692af2
+          50: WITH -- hash: 0xaed4c90a75f90eb3
+            49: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0xe778aa6811ef055e
               13: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 7 }, type_value: integer(unknown) }
-            41: FOR_IN -- hash: 0xe5518f0bdf2d8333
+            41: FOR_IN -- hash: 0x49d99373f68e4c7
                   n: Var { frame_id: 2, ty: integer, index: 11 }
                   i: Var { frame_id: 2, ty: integer, index: 12 }
                   max_count: Var { frame_id: 2, ty: integer, index: 13 }
@@ -27,46 +27,46 @@ RULE test
                   item: Var { frame_id: 2, ty: unknown, index: 15 }
               2: CONST integer(0)
               3: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 0 }, type_value: integer(unknown) }
-              52: WITH -- hash: 0x3666334f99c17954
-                51: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0x49dc6121174a8d53
+              52: WITH -- hash: 0xb5960acd8155f7b4
+                51: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0x632b14146cd067bf
                   26: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 16 }, type_value: integer(unknown) }
-                54: WITH -- hash: 0xd26c3fe7d117b926
-                  53: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0x49dc6121174a8d53
+                54: WITH -- hash: 0x3c39252d4e265253
+                  53: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0x632b14146cd067bf
                     29: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 16 }, type_value: integer(unknown) }
-                  40: FOR_IN -- hash: 0x92c95e15a9d08618
+                  40: FOR_IN -- hash: 0x9e7b3fb228ae7b95
                         n: Var { frame_id: 3, ty: integer, index: 20 }
                         i: Var { frame_id: 3, ty: integer, index: 21 }
                         max_count: Var { frame_id: 3, ty: integer, index: 22 }
                         count: Var { frame_id: 3, ty: integer, index: 23 }
                         item: Var { frame_id: 3, ty: array, index: 24 }
                     6: SYMBOL Var { var: Var { frame_id: 0, ty: array, index: 1 }, type_value: array }
-                    39: AND -- hash: 0xfd9ea211fc88a365
-                      12: LE -- hash: 0xaae2bff322aa8faf
-                        9: FIELD_ACCESS -- hash: 0x2cfd8c09c7bab762
+                    39: AND -- hash: 0xf26f57a007df86f2
+                      12: LE -- hash: 0x683a1d546192136c
+                        9: FIELD_ACCESS -- hash: 0xee456a1e00eeb5a2
                           7: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 25 }, type_value: struct }
                           8: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                         11: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 9 }, type_value: integer(unknown) }
-                      22: LE -- hash: 0x644c1cef0467915f
+                      22: LE -- hash: 0xb98d168c82aae133
                         14: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 10 }, type_value: integer(unknown) }
-                        21: ADD -- hash: 0x108f040ec6b473d7
-                          17: FIELD_ACCESS -- hash: 0x2cfd8c09c7bab762
+                        21: ADD -- hash: 0x8f76cc0b5cc1808c
+                          17: FIELD_ACCESS -- hash: 0xee456a1e00eeb5a2
                             15: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 25 }, type_value: struct }
                             16: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                          20: FIELD_ACCESS -- hash: 0xe1db32d0280b564e
+                          20: FIELD_ACCESS -- hash: 0xa32310e4653f548f
                             18: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 25 }, type_value: struct }
                             19: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                      28: LE -- hash: 0x99689fd2d49614f8
-                        25: FIELD_ACCESS -- hash: 0x2cfd8c09c7bab762
+                      28: LE -- hash: 0x56bffd34177d98b5
+                        25: FIELD_ACCESS -- hash: 0xee456a1e00eeb5a2
                           23: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 25 }, type_value: struct }
                           24: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
                         27: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 18 }, type_value: integer(unknown) }
-                      38: LE -- hash: 0xb8db6ae5493ebfc8
+                      38: LE -- hash: 0xe1c6482c7820f9d
                         30: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 19 }, type_value: integer(unknown) }
-                        37: ADD -- hash: 0x108f040ec6b473d7
-                          33: FIELD_ACCESS -- hash: 0x2cfd8c09c7bab762
+                        37: ADD -- hash: 0x8f76cc0b5cc1808c
+                          33: FIELD_ACCESS -- hash: 0xee456a1e00eeb5a2
                             31: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 25 }, type_value: struct }
                             32: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-                          36: FIELD_ACCESS -- hash: 0xe1db32d0280b564e
+                          36: FIELD_ACCESS -- hash: 0xa32310e4653f548f
                             34: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 25 }, type_value: struct }
                             35: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
 

--- a/lib/src/compiler/ir/tests/testdata/2.ir
+++ b/lib/src/compiler/ir/tests/testdata/2.ir
@@ -1,60 +1,60 @@
 RULE test
-  42: FOR_IN -- hash: 0xda878d9eb553a61e
+  42: FOR_IN -- hash: 0x5a8b495d9ca0365f
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
-    1: PATTERN_COUNT PatternIdx(0) -- hash: 0xc1bc033c6a64ce89
-    41: FOR_IN -- hash: 0x2c8f1ee17fe69986
+    1: PATTERN_COUNT PatternIdx(0) -- hash: 0x295099eb5fc21fe8
+    41: FOR_IN -- hash: 0xc59e62932f94ad94
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
           count: Var { frame_id: 2, ty: integer, index: 10 }
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
-      3: PATTERN_COUNT PatternIdx(1) -- hash: 0x7699aa02ceb56d76
-      40: FOR_IN -- hash: 0x178ae2b47067f224
+      3: PATTERN_COUNT PatternIdx(1) -- hash: 0xde2e40b1c012bed4
+      40: FOR_IN -- hash: 0x43fb933d283b1ad6
             n: Var { frame_id: 3, ty: integer, index: 14 }
             i: Var { frame_id: 3, ty: integer, index: 15 }
             max_count: Var { frame_id: 3, ty: integer, index: 16 }
             count: Var { frame_id: 3, ty: integer, index: 17 }
             item: Var { frame_id: 3, ty: array, index: 18 }
-        6: FIELD_ACCESS -- hash: 0x22bd483d721ed399
+        6: FIELD_ACCESS -- hash: 0x874667d74d3e43c4
           4: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           5: SYMBOL Field { index: 19, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-        39: AND -- hash: 0xff21eb12445aa4e7
-          12: LE -- hash: 0x1b9ea398e3c8553e
-            9: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+        39: AND -- hash: 0x7633aa85f81db2b
+          12: LE -- hash: 0xe9f7e368f4dece6e
+            9: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
               7: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
               8: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-            11: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+            11: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
               10: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
-          22: LE -- hash: 0x60fd6a25db3c471e
-            14: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x7cb6e22690df7f1b
+          22: LE -- hash: 0xe67373d7ab0aa8d1
+            14: PATTERN_OFFSET PatternIdx(0) INDEX -- hash: 0x96059519ea655987
               13: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
-            21: ADD -- hash: 0x24b1906c95554907
-              17: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+            21: ADD -- hash: 0xa39958692f6255bc
+              17: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
                 15: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 16: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-              20: FIELD_ACCESS -- hash: 0x58d89b393296bc3f
+              20: FIELD_ACCESS -- hash: 0x1a20794d6fcaba80
                 18: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 19: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          28: LE -- hash: 0x45ddf7f717200bc7
-            25: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+          28: LE -- hash: 0x143737c7283684f8
+            25: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
               23: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
               24: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-            27: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xa6f63684c43735a4
+            27: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xc044e9781dbd1010
               26: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 12 }, type_value: integer(unknown) }
-          38: LE -- hash: 0x92d1270c9c59b1b0
-            30: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xa6f63684c43735a4
+          38: LE -- hash: 0x184730be6c281364
+            30: PATTERN_OFFSET PatternIdx(1) INDEX -- hash: 0xc044e9781dbd1010
               29: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 12 }, type_value: integer(unknown) }
-            37: ADD -- hash: 0x24b1906c95554907
-              33: FIELD_ACCESS -- hash: 0xa3faf472ce461d52
+            37: ADD -- hash: 0xa39958692f6255bc
+              33: FIELD_ACCESS -- hash: 0x6542d2870b7a1b93
                 31: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 32: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-              36: FIELD_ACCESS -- hash: 0x58d89b393296bc3f
+              36: FIELD_ACCESS -- hash: 0x1a20794d6fcaba80
                 34: SYMBOL Var { var: Var { frame_id: 3, ty: struct, index: 19 }, type_value: struct }
                 35: SYMBOL Field { index: 1, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
 

--- a/lib/src/compiler/ir/tests/testdata/3.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.cse.ir
@@ -1,12 +1,12 @@
 RULE test
-  12: OR -- hash: 0x3943b5785dde551a
-    5: EQ -- hash: 0x7e5484873ebb2659
-      3: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0xeaf33e3e6d085dc7
+  12: OR -- hash: 0xd63a6b052500bffc
+    5: EQ -- hash: 0xf6558ac091593c37
+      3: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0x1816d7edf1a573dc
         1: CONST integer(0)
         2: FILESIZE
       4: CONST string("feba6c919e3797e7778e8f2e85fa033d")
-    11: EQ -- hash: 0xcc33bf3f71c96bc5
-      9: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0xeaf33e3e6d085dc7
+    11: EQ -- hash: 0x4434c578c46781a4
+      9: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0x1816d7edf1a573dc
         7: CONST integer(0)
         8: FILESIZE
       10: CONST string("275876e34cf609db118f3d84b799a790")

--- a/lib/src/compiler/ir/tests/testdata/3.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.hoisting.ir
@@ -1,12 +1,12 @@
 RULE test
-  12: OR -- hash: 0x3943b5785dde551a
-    5: EQ -- hash: 0x7e5484873ebb2659
-      3: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0xeaf33e3e6d085dc7
+  12: OR -- hash: 0xd63a6b052500bffc
+    5: EQ -- hash: 0xf6558ac091593c37
+      3: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0x1816d7edf1a573dc
         1: CONST integer(0)
         2: FILESIZE
       4: CONST string("feba6c919e3797e7778e8f2e85fa033d")
-    11: EQ -- hash: 0xcc33bf3f71c96bc5
-      9: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0xeaf33e3e6d085dc7
+    11: EQ -- hash: 0x4434c578c46781a4
+      9: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0x1816d7edf1a573dc
         7: CONST integer(0)
         8: FILESIZE
       10: CONST string("275876e34cf609db118f3d84b799a790")

--- a/lib/src/compiler/ir/tests/testdata/3.ir
+++ b/lib/src/compiler/ir/tests/testdata/3.ir
@@ -1,12 +1,12 @@
 RULE test
-  12: OR -- hash: 0x3943b5785dde551a
-    5: EQ -- hash: 0x7e5484873ebb2659
-      3: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0xeaf33e3e6d085dc7
+  12: OR -- hash: 0xd63a6b052500bffc
+    5: EQ -- hash: 0xf6558ac091593c37
+      3: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0x1816d7edf1a573dc
         1: CONST integer(0)
         2: FILESIZE
       4: CONST string("feba6c919e3797e7778e8f2e85fa033d")
-    11: EQ -- hash: 0xcc33bf3f71c96bc5
-      9: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0xeaf33e3e6d085dc7
+    11: EQ -- hash: 0x4434c578c46781a4
+      9: FN_CALL hash.md5@offset:i,size:i@s:N32:Lu -- hash: 0x1816d7edf1a573dc
         7: CONST integer(0)
         8: FILESIZE
       10: CONST string("275876e34cf609db118f3d84b799a790")

--- a/lib/src/compiler/ir/tests/testdata/4.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.cse.ir
@@ -1,10 +1,10 @@
 RULE test
-  52: WITH -- hash: 0x3d25b3d4794433e2
-    2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20
+  52: WITH -- hash: 0x6d7701fe081d983f
+    2: FIELD_ACCESS -- hash: 0x9536d86a9309eb4b
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-    51: AND -- hash: 0xb3895dc66180b6ac
-      22: FOR_IN -- hash: 0xb5766871f0d8434f
+    51: AND -- hash: 0x9bd969653383cc22
+      22: FOR_IN -- hash: 0x2c6eaee06da3665a
             n: Var { frame_id: 2, ty: integer, index: 1 }
             i: Var { frame_id: 2, ty: integer, index: 2 }
             max_count: Var { frame_id: 2, ty: integer, index: 3 }
@@ -12,23 +12,23 @@ RULE test
             item: Var { frame_id: 2, ty: unknown, index: 5 }
         3: CONST integer(0)
         4: CONST integer(1)
-        21: AND -- hash: 0x46f1e0ca50258bf4
-          7: EQ -- hash: 0xa866a1c3637edc78
+        21: AND -- hash: 0x82951fe9ebf8c896
+          7: EQ -- hash: 0x1e7413311b1944fa
             5: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 6 }, type_value: integer(unknown) }
             6: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) }
-          13: EQ -- hash: 0x452e9b6d563a2e0e
-            11: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x261e822f79c74aad
+          13: EQ -- hash: 0x55a86ac488e1462e
+            11: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x5c8149efefc0401a
               9: CONST integer(1)
               10: CONST integer(2)
             12: CONST integer(3)
-          20: EQ -- hash: 0xb9f99fc2d3abf379
-            18: ADD -- hash: 0x2b8f1094f609e931
-              16: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+          20: EQ -- hash: 0x84cf5cf12dbe27a0
+            18: ADD -- hash: 0xf519dc2b10fbedfc
+              16: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
                 14: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                 15: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
               17: CONST integer(1)
             19: CONST float(1.0)
-      39: FOR_IN -- hash: 0x780dcdbeadf30f98
+      39: FOR_IN -- hash: 0xce4208fea0a2e539
             n: Var { frame_id: 3, ty: integer, index: 1 }
             i: Var { frame_id: 3, ty: integer, index: 2 }
             max_count: Var { frame_id: 3, ty: integer, index: 3 }
@@ -36,20 +36,20 @@ RULE test
             item: Var { frame_id: 3, ty: unknown, index: 5 }
         23: CONST integer(0)
         24: CONST integer(1)
-        38: OR -- hash: 0x49a206ca8caeb222
-          30: NE -- hash: 0xf55902e71cd37238
-            28: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x261e822f79c74aad
+        38: OR -- hash: 0x634779ad4e349e70
+          30: NE -- hash: 0x5d2d23e537a8a59
+            28: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x5c8149efefc0401a
               26: CONST integer(1)
               27: CONST integer(2)
             29: CONST integer(0)
-          37: EQ -- hash: 0xb9f99fc2d3abf379
-            35: ADD -- hash: 0x2b8f1094f609e931
-              33: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+          37: EQ -- hash: 0x84cf5cf12dbe27a0
+            35: ADD -- hash: 0xf519dc2b10fbedfc
+              33: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
                 31: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                 32: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
               34: CONST integer(1)
             36: CONST float(1.0)
-      50: FOR_IN -- hash: 0xfe0707a87971b452
+      50: FOR_IN -- hash: 0x313e311089e8c59
             n: Var { frame_id: 4, ty: integer, index: 1 }
             i: Var { frame_id: 4, ty: integer, index: 2 }
             max_count: Var { frame_id: 4, ty: integer, index: 3 }
@@ -57,10 +57,10 @@ RULE test
             item: Var { frame_id: 4, ty: unknown, index: 5 }
         40: CONST integer(0)
         41: CONST integer(1)
-        49: NOT -- hash: 0xe7ab6d2c59bb374c
-          48: EQ -- hash: 0xb9f99fc2d21d3379
-            46: ADD -- hash: 0x2b8f1094f609e931
-              44: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+        49: NOT -- hash: 0xb2812a5ab7cd6b73
+          48: EQ -- hash: 0x84cf5cf12c2f67a0
+            46: ADD -- hash: 0xf519dc2b10fbedfc
+              44: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
                 42: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                 43: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
               45: CONST integer(1)

--- a/lib/src/compiler/ir/tests/testdata/4.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.hoisting.ir
@@ -1,30 +1,30 @@
 RULE test
-  52: WITH -- hash: 0x9bec9656dce82b6d
-    2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20
+  52: WITH -- hash: 0x1acaee9d74592e85
+    2: FIELD_ACCESS -- hash: 0x9536d86a9309eb4b
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-    51: AND -- hash: 0x2eaeb74b847a4d38
-      54: WITH -- hash: 0x1146bb568254efab
-        53: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x261e822f79c74aad
+    51: AND -- hash: 0xbfa2a96d5ec5eb5a
+      54: WITH -- hash: 0x5d2d568b16aad491
+        53: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x5c8149efefc0401a
           9: CONST integer(1)
           10: CONST integer(2)
-        56: WITH -- hash: 0x58086382660011ee
-          55: EQ -- hash: 0xb06f506b571835e5
+        56: WITH -- hash: 0x6f43aacfc1ebf6d3
+          55: EQ -- hash: 0xf431fa9fe9c5a5cd
             11: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 1 }, type_value: integer(unknown) }
             12: CONST integer(3)
-          58: WITH -- hash: 0xa1db54bedd6f6be6
-            57: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+          58: WITH -- hash: 0x4587a6dd1220bf55
+            57: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
               14: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               15: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
-            60: WITH -- hash: 0x1ce3fc3e2ea805f6
-              59: ADD -- hash: 0x1f8003fe2da19d98
+            60: WITH -- hash: 0x93f86553a3dd1bcc
+              59: ADD -- hash: 0x6342ae32c04f0d80
                 16: SYMBOL Var { var: Var { frame_id: 0, ty: float, index: 3 }, type_value: float(unknown) }
                 17: CONST integer(1)
-              62: WITH -- hash: 0x6b8d39516e40d5c4
-                61: EQ -- hash: 0xe816c5b8c599086e
+              62: WITH -- hash: 0x845b7b0b5b4bd2b3
+                61: EQ -- hash: 0x2bd96fed58467857
                   18: SYMBOL Var { var: Var { frame_id: 0, ty: float, index: 4 }, type_value: float(unknown) }
                   19: CONST float(1.0)
-                22: FOR_IN -- hash: 0x7972839ab6e7e7fd
+                22: FOR_IN -- hash: 0x88b54dd178f52a83
                       n: Var { frame_id: 2, ty: integer, index: 6 }
                       i: Var { frame_id: 2, ty: integer, index: 7 }
                       max_count: Var { frame_id: 2, ty: integer, index: 8 }
@@ -32,37 +32,37 @@ RULE test
                       item: Var { frame_id: 2, ty: unknown, index: 10 }
                   3: CONST integer(0)
                   4: CONST integer(1)
-                  21: AND -- hash: 0x1f1a3d4b94bd6cf0
-                    7: EQ -- hash: 0xd0eb828214f0d7a6
+                  21: AND -- hash: 0x3c7a64c544cdef7b
+                    7: EQ -- hash: 0x46f8f3efcc8b4028
                       5: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 11 }, type_value: integer(unknown) }
                       6: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) }
                     13: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 2 }, type_value: boolean(unknown) }
                     20: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 5 }, type_value: boolean(unknown) }
-      64: WITH -- hash: 0x2e00596c13d056e8
-        63: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x261e822f79c74aad
+      64: WITH -- hash: 0x8cd2ba2f740ac463
+        63: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x5c8149efefc0401a
           26: CONST integer(1)
           27: CONST integer(2)
-        66: WITH -- hash: 0xa0cb3969e5369c8a
-          65: NE -- hash: 0x4025089ffe7b584c
+        66: WITH -- hash: 0x4e06ca45f1f850c0
+          65: NE -- hash: 0x83e7b2d49128c834
             28: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 1 }, type_value: integer(unknown) }
             29: CONST integer(0)
-          68: WITH -- hash: 0xbe545e6656880f10
-            67: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+          68: WITH -- hash: 0x12d76de8d989d928
+            67: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
               31: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               32: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
-            70: WITH -- hash: 0x7fbe51166763ccd6
-              69: ADD -- hash: 0x1f8003fe2da19d98
+            70: WITH -- hash: 0x8b79fc2b2a9a664c
+              69: ADD -- hash: 0x6342ae32c04f0d80
                 33: SYMBOL Var { var: Var { frame_id: 0, ty: float, index: 3 }, type_value: float(unknown) }
                 34: CONST integer(1)
-              72: WITH -- hash: 0x63ffb8d4a4cb6c5e
-                71: EQ -- hash: 0xe816c5b8c599086e
+              72: WITH -- hash: 0x1a531251020d8904
+                71: EQ -- hash: 0x2bd96fed58467857
                   35: SYMBOL Var { var: Var { frame_id: 0, ty: float, index: 4 }, type_value: float(unknown) }
                   36: CONST float(1.0)
-                74: WITH -- hash: 0x17995e0bce4825aa
-                  73: OR -- hash: 0xd0741b62865f08c0
+                74: WITH -- hash: 0x84af01aaa1557339
+                  73: OR -- hash: 0x46818cd03df97142
                     30: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 2 }, type_value: boolean(unknown) }
                     37: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 5 }, type_value: boolean(unknown) }
-                  39: FOR_IN -- hash: 0x2a20d32365a87a56
+                  39: FOR_IN -- hash: 0xc0a2f3d63c79049b
                         n: Var { frame_id: 3, ty: integer, index: 7 }
                         i: Var { frame_id: 3, ty: integer, index: 8 }
                         max_count: Var { frame_id: 3, ty: integer, index: 9 }
@@ -71,22 +71,22 @@ RULE test
                     23: CONST integer(0)
                     24: CONST integer(1)
                     38: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 6 }, type_value: boolean(unknown) }
-      76: WITH -- hash: 0x3b6309a759bbc3d2
-        75: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+      76: WITH -- hash: 0x10fe4080a968c37f
+        75: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
           42: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
           43: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
-        78: WITH -- hash: 0x59cd414d2af5d69f
-          77: ADD -- hash: 0x4729d17687d014e8
+        78: WITH -- hash: 0xf30ed907b91851c2
+          77: ADD -- hash: 0x8aec7bab1a7d84d0
             44: SYMBOL Var { var: Var { frame_id: 0, ty: float, index: 1 }, type_value: float(unknown) }
             45: CONST integer(1)
-          80: WITH -- hash: 0xa380abf1d2c9b2cc
-            79: EQ -- hash: 0xfc093311e38bfbf
+          80: WITH -- hash: 0xf12466569870a5fe
+            79: EQ -- hash: 0x53833d65b0e62fa7
               46: SYMBOL Var { var: Var { frame_id: 0, ty: float, index: 2 }, type_value: float(unknown) }
               47: CONST float(2.0)
-            82: WITH -- hash: 0x821acdcbe1f11e6b
-              81: NOT -- hash: 0xa950472dd0663d8b
+            82: WITH -- hash: 0xc1f03b5e40c18ebc
+              81: NOT -- hash: 0x957b6071a54f01e3
                 48: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 3 }, type_value: boolean(unknown) }
-              50: FOR_IN -- hash: 0xd8adbdd53e1ece7e
+              50: FOR_IN -- hash: 0x6f2fde8814ef58c4
                     n: Var { frame_id: 4, ty: integer, index: 5 }
                     i: Var { frame_id: 4, ty: integer, index: 6 }
                     max_count: Var { frame_id: 4, ty: integer, index: 7 }

--- a/lib/src/compiler/ir/tests/testdata/4.ir
+++ b/lib/src/compiler/ir/tests/testdata/4.ir
@@ -1,10 +1,10 @@
 RULE test
-  52: WITH -- hash: 0x3d25b3d4794433e2
-    2: FIELD_ACCESS -- hash: 0x30adb8d0b7ea7b20
+  52: WITH -- hash: 0x6d7701fe081d983f
+    2: FIELD_ACCESS -- hash: 0x9536d86a9309eb4b
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 12, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-    51: AND -- hash: 0xb3895dc66180b6ac
-      22: FOR_IN -- hash: 0xb5766871f0d8434f
+    51: AND -- hash: 0x9bd969653383cc22
+      22: FOR_IN -- hash: 0x2c6eaee06da3665a
             n: Var { frame_id: 2, ty: integer, index: 1 }
             i: Var { frame_id: 2, ty: integer, index: 2 }
             max_count: Var { frame_id: 2, ty: integer, index: 3 }
@@ -12,23 +12,23 @@ RULE test
             item: Var { frame_id: 2, ty: unknown, index: 5 }
         3: CONST integer(0)
         4: CONST integer(1)
-        21: AND -- hash: 0x46f1e0ca50258bf4
-          7: EQ -- hash: 0xa866a1c3637edc78
+        21: AND -- hash: 0x82951fe9ebf8c896
+          7: EQ -- hash: 0x1e7413311b1944fa
             5: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 6 }, type_value: integer(unknown) }
             6: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 0 }, type_value: integer(unknown) }
-          13: EQ -- hash: 0x452e9b6d563a2e0e
-            11: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x261e822f79c74aad
+          13: EQ -- hash: 0x55a86ac488e1462e
+            11: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x5c8149efefc0401a
               9: CONST integer(1)
               10: CONST integer(2)
             12: CONST integer(3)
-          20: EQ -- hash: 0xb9f99fc2d3abf379
-            18: ADD -- hash: 0x2b8f1094f609e931
-              16: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+          20: EQ -- hash: 0x84cf5cf12dbe27a0
+            18: ADD -- hash: 0xf519dc2b10fbedfc
+              16: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
                 14: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                 15: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
               17: CONST integer(1)
             19: CONST float(1.0)
-      39: FOR_IN -- hash: 0x780dcdbeadf30f98
+      39: FOR_IN -- hash: 0xce4208fea0a2e539
             n: Var { frame_id: 3, ty: integer, index: 1 }
             i: Var { frame_id: 3, ty: integer, index: 2 }
             max_count: Var { frame_id: 3, ty: integer, index: 3 }
@@ -36,20 +36,20 @@ RULE test
             item: Var { frame_id: 3, ty: unknown, index: 5 }
         23: CONST integer(0)
         24: CONST integer(1)
-        38: OR -- hash: 0x49a206ca8caeb222
-          30: NE -- hash: 0xf55902e71cd37238
-            28: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x261e822f79c74aad
+        38: OR -- hash: 0x634779ad4e349e70
+          30: NE -- hash: 0x5d2d23e537a8a59
+            28: FN_CALL test_proto2.add@a:i,b:i@i -- hash: 0x5c8149efefc0401a
               26: CONST integer(1)
               27: CONST integer(2)
             29: CONST integer(0)
-          37: EQ -- hash: 0xb9f99fc2d3abf379
-            35: ADD -- hash: 0x2b8f1094f609e931
-              33: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+          37: EQ -- hash: 0x84cf5cf12dbe27a0
+            35: ADD -- hash: 0xf519dc2b10fbedfc
+              33: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
                 31: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                 32: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
               34: CONST integer(1)
             36: CONST float(1.0)
-      50: FOR_IN -- hash: 0xfe0707a87971b452
+      50: FOR_IN -- hash: 0x313e311089e8c59
             n: Var { frame_id: 4, ty: integer, index: 1 }
             i: Var { frame_id: 4, ty: integer, index: 2 }
             max_count: Var { frame_id: 4, ty: integer, index: 3 }
@@ -57,10 +57,10 @@ RULE test
             item: Var { frame_id: 4, ty: unknown, index: 5 }
         40: CONST integer(0)
         41: CONST integer(1)
-        49: NOT -- hash: 0xe7ab6d2c59bb374c
-          48: EQ -- hash: 0xb9f99fc2d21d3379
-            46: ADD -- hash: 0x2b8f1094f609e931
-              44: FIELD_ACCESS -- hash: 0xc6f26b43ef493d46
+        49: NOT -- hash: 0xb2812a5ab7cd6b73
+          48: EQ -- hash: 0x84cf5cf12c2f67a0
+            46: ADD -- hash: 0xf519dc2b10fbedfc
+              44: FIELD_ACCESS -- hash: 0x2b7b8addca68ad72
                 42: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
                 43: SYMBOL Field { index: 10, is_root: false, type_value: float(unknown), acl: None, deprecation_notice: None }
               45: CONST integer(1)

--- a/lib/src/compiler/ir/tests/testdata/5.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/5.cse.ir
@@ -1,35 +1,35 @@
 RULE test_1
-  35: AND -- hash: 0xbcd64d309e20ba14
-    8: EQ -- hash: 0x286081a5404b9efc
-      6: FIELD_ACCESS -- hash: 0x6e1d853ba34b7fe2
-        4: LOOKUP -- hash: 0x716c67a247de6940
-          2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  35: AND -- hash: 0xfb4afd329fb07dc3
+    8: EQ -- hash: 0x496c97e53b61f654
+      6: FIELD_ACCESS -- hash: 0x6af92ddf1af8a3f2
+        4: LOOKUP -- hash: 0xb7e6fdca077aa568
+          2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           3: CONST integer(0)
         5: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       7: CONST integer(0)
-    17: EQ -- hash: 0xbeab76cd32851615
-      15: FIELD_ACCESS -- hash: 0xc403ec0c3cd58213
-        13: LOOKUP -- hash: 0x1a25f2495ba33f2c
-          11: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    17: EQ -- hash: 0xdfb78d0d299b6d6d
+      15: FIELD_ACCESS -- hash: 0xc0df94afb482a623
+        13: LOOKUP -- hash: 0x60a088711b3f7b54
+          11: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             9: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             10: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           12: CONST integer(1)
         14: SYMBOL Field { index: 2, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       16: CONST integer(1)
-    34: EQ -- hash: 0xfe0bc6da31a3fab2
-      32: ADD -- hash: 0x83a5e6847eb7227e
-        24: FIELD_ACCESS -- hash: 0x5a489e7f7434443a
-          22: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            20: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    34: EQ -- hash: 0xf94a49164359b744
+      32: ADD -- hash: 0x637f01b98f7ef769
+        24: FIELD_ACCESS -- hash: 0x57244722efe1684a
+          22: LOOKUP -- hash: 0x60a088711b3f7b54
+            20: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               18: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               19: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             21: CONST integer(1)
           23: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        31: FIELD_ACCESS -- hash: 0x78e192d2a1262100
-          29: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            27: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        31: FIELD_ACCESS -- hash: 0x75bd3b7618d34510
+          29: LOOKUP -- hash: 0x60a088711b3f7b54
+            27: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               25: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               26: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             28: CONST integer(1)
@@ -37,37 +37,37 @@ RULE test_1
       33: CONST integer(1)
 
 RULE test_2
-  35: AND -- hash: 0xa9652719fe3b73e
-    16: EQ -- hash: 0xfe0bc6da31a3fab2
-      14: ADD -- hash: 0x83a5e6847eb7227e
-        6: FIELD_ACCESS -- hash: 0x5a489e7f7434443a
-          4: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  35: AND -- hash: 0x467259e49dca9732
+    16: EQ -- hash: 0xf94a49164359b744
+      14: ADD -- hash: 0x637f01b98f7ef769
+        6: FIELD_ACCESS -- hash: 0x57244722efe1684a
+          4: LOOKUP -- hash: 0x60a088711b3f7b54
+            2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             3: CONST integer(1)
           5: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        13: FIELD_ACCESS -- hash: 0x78e192d2a1262100
-          11: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            9: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        13: FIELD_ACCESS -- hash: 0x75bd3b7618d34510
+          11: LOOKUP -- hash: 0x60a088711b3f7b54
+            9: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               7: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               8: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             10: CONST integer(1)
           12: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       15: CONST integer(1)
-    25: EQ -- hash: 0x286081a5404b9efc
-      23: FIELD_ACCESS -- hash: 0x6e1d853ba34b7fe2
-        21: LOOKUP -- hash: 0x716c67a247de6940
-          19: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    25: EQ -- hash: 0x496c97e53b61f654
+      23: FIELD_ACCESS -- hash: 0x6af92ddf1af8a3f2
+        21: LOOKUP -- hash: 0xb7e6fdca077aa568
+          19: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             17: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             18: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           20: CONST integer(0)
         22: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       24: CONST integer(0)
-    34: EQ -- hash: 0xbeab76cd32851615
-      32: FIELD_ACCESS -- hash: 0xc403ec0c3cd58213
-        30: LOOKUP -- hash: 0x1a25f2495ba33f2c
-          28: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    34: EQ -- hash: 0xdfb78d0d299b6d6d
+      32: FIELD_ACCESS -- hash: 0xc0df94afb482a623
+        30: LOOKUP -- hash: 0x60a088711b3f7b54
+          28: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             26: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             27: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           29: CONST integer(1)
@@ -75,34 +75,34 @@ RULE test_2
       33: CONST integer(1)
 
 RULE test_3
-  31: WITH -- hash: 0x1caad377fac14cec
-    2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  31: WITH -- hash: 0xd12c99d2b9385c31
+    2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    30: AND -- hash: 0x32468198de5bf3ca
-      15: EQ -- hash: 0xb7083bd21650136
-        13: ADD -- hash: 0xb37bf5c5eec49e0b
-          7: FIELD_ACCESS -- hash: 0xb2a8072a9f308424
-            5: LOOKUP -- hash: 0x483e02ee8116c648
+    30: AND -- hash: 0x12dc7234de2063ae
+      15: EQ -- hash: 0xe2720d2e43d2dad5
+        13: ADD -- hash: 0x48118390d9d2fbc
+          7: FIELD_ACCESS -- hash: 0xabb583028cf4d3ae
+            5: LOOKUP -- hash: 0x15e3054cfa75da5a
               3: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
               4: CONST integer(1)
             6: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          12: FIELD_ACCESS -- hash: 0xd140fb7dc82260ea
-            10: LOOKUP -- hash: 0x483e02ee8116c648
+          12: FIELD_ACCESS -- hash: 0xca4e7755b9e6b074
+            10: LOOKUP -- hash: 0x15e3054cfa75da5a
               8: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
               9: CONST integer(1)
             11: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         14: CONST integer(1)
-      22: EQ -- hash: 0xa7daf0142925fa40
-        20: FIELD_ACCESS -- hash: 0xc67cede6ca47bfcc
-          18: LOOKUP -- hash: 0x9f8478476d51f05c
+      22: EQ -- hash: 0xf7a23951bfcab6f
+        20: FIELD_ACCESS -- hash: 0xbf8a69beb80c0f56
+          18: LOOKUP -- hash: 0x6d297aa5e6b1046e
             16: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
             17: CONST integer(0)
           19: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         21: CONST integer(0)
-      29: EQ -- hash: 0x3e25e53c1b5f715a
-        27: FIELD_ACCESS -- hash: 0x1c6354b767d1c1fe
-          25: LOOKUP -- hash: 0x483e02ee8116c648
+      29: EQ -- hash: 0xa5c518bd0a362288
+        27: FIELD_ACCESS -- hash: 0x1570d08f55961188
+          25: LOOKUP -- hash: 0x15e3054cfa75da5a
             23: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
             24: CONST integer(1)
           26: SYMBOL Field { index: 2, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/5.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/5.hoisting.ir
@@ -1,35 +1,35 @@
 RULE test_1
-  35: AND -- hash: 0xbcd64d309e20ba14
-    8: EQ -- hash: 0x286081a5404b9efc
-      6: FIELD_ACCESS -- hash: 0x6e1d853ba34b7fe2
-        4: LOOKUP -- hash: 0x716c67a247de6940
-          2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  35: AND -- hash: 0xfb4afd329fb07dc3
+    8: EQ -- hash: 0x496c97e53b61f654
+      6: FIELD_ACCESS -- hash: 0x6af92ddf1af8a3f2
+        4: LOOKUP -- hash: 0xb7e6fdca077aa568
+          2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           3: CONST integer(0)
         5: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       7: CONST integer(0)
-    17: EQ -- hash: 0xbeab76cd32851615
-      15: FIELD_ACCESS -- hash: 0xc403ec0c3cd58213
-        13: LOOKUP -- hash: 0x1a25f2495ba33f2c
-          11: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    17: EQ -- hash: 0xdfb78d0d299b6d6d
+      15: FIELD_ACCESS -- hash: 0xc0df94afb482a623
+        13: LOOKUP -- hash: 0x60a088711b3f7b54
+          11: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             9: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             10: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           12: CONST integer(1)
         14: SYMBOL Field { index: 2, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       16: CONST integer(1)
-    34: EQ -- hash: 0xfe0bc6da31a3fab2
-      32: ADD -- hash: 0x83a5e6847eb7227e
-        24: FIELD_ACCESS -- hash: 0x5a489e7f7434443a
-          22: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            20: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    34: EQ -- hash: 0xf94a49164359b744
+      32: ADD -- hash: 0x637f01b98f7ef769
+        24: FIELD_ACCESS -- hash: 0x57244722efe1684a
+          22: LOOKUP -- hash: 0x60a088711b3f7b54
+            20: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               18: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               19: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             21: CONST integer(1)
           23: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        31: FIELD_ACCESS -- hash: 0x78e192d2a1262100
-          29: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            27: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        31: FIELD_ACCESS -- hash: 0x75bd3b7618d34510
+          29: LOOKUP -- hash: 0x60a088711b3f7b54
+            27: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               25: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               26: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             28: CONST integer(1)
@@ -37,37 +37,37 @@ RULE test_1
       33: CONST integer(1)
 
 RULE test_2
-  35: AND -- hash: 0xa9652719fe3b73e
-    16: EQ -- hash: 0xfe0bc6da31a3fab2
-      14: ADD -- hash: 0x83a5e6847eb7227e
-        6: FIELD_ACCESS -- hash: 0x5a489e7f7434443a
-          4: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  35: AND -- hash: 0x467259e49dca9732
+    16: EQ -- hash: 0xf94a49164359b744
+      14: ADD -- hash: 0x637f01b98f7ef769
+        6: FIELD_ACCESS -- hash: 0x57244722efe1684a
+          4: LOOKUP -- hash: 0x60a088711b3f7b54
+            2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             3: CONST integer(1)
           5: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        13: FIELD_ACCESS -- hash: 0x78e192d2a1262100
-          11: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            9: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        13: FIELD_ACCESS -- hash: 0x75bd3b7618d34510
+          11: LOOKUP -- hash: 0x60a088711b3f7b54
+            9: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               7: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               8: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             10: CONST integer(1)
           12: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       15: CONST integer(1)
-    25: EQ -- hash: 0x286081a5404b9efc
-      23: FIELD_ACCESS -- hash: 0x6e1d853ba34b7fe2
-        21: LOOKUP -- hash: 0x716c67a247de6940
-          19: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    25: EQ -- hash: 0x496c97e53b61f654
+      23: FIELD_ACCESS -- hash: 0x6af92ddf1af8a3f2
+        21: LOOKUP -- hash: 0xb7e6fdca077aa568
+          19: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             17: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             18: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           20: CONST integer(0)
         22: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       24: CONST integer(0)
-    34: EQ -- hash: 0xbeab76cd32851615
-      32: FIELD_ACCESS -- hash: 0xc403ec0c3cd58213
-        30: LOOKUP -- hash: 0x1a25f2495ba33f2c
-          28: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    34: EQ -- hash: 0xdfb78d0d299b6d6d
+      32: FIELD_ACCESS -- hash: 0xc0df94afb482a623
+        30: LOOKUP -- hash: 0x60a088711b3f7b54
+          28: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             26: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             27: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           29: CONST integer(1)
@@ -75,34 +75,34 @@ RULE test_2
       33: CONST integer(1)
 
 RULE test_3
-  31: WITH -- hash: 0x1caad377fac14cec
-    2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  31: WITH -- hash: 0xd12c99d2b9385c31
+    2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    30: AND -- hash: 0x32468198de5bf3ca
-      15: EQ -- hash: 0xb7083bd21650136
-        13: ADD -- hash: 0xb37bf5c5eec49e0b
-          7: FIELD_ACCESS -- hash: 0xb2a8072a9f308424
-            5: LOOKUP -- hash: 0x483e02ee8116c648
+    30: AND -- hash: 0x12dc7234de2063ae
+      15: EQ -- hash: 0xe2720d2e43d2dad5
+        13: ADD -- hash: 0x48118390d9d2fbc
+          7: FIELD_ACCESS -- hash: 0xabb583028cf4d3ae
+            5: LOOKUP -- hash: 0x15e3054cfa75da5a
               3: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
               4: CONST integer(1)
             6: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          12: FIELD_ACCESS -- hash: 0xd140fb7dc82260ea
-            10: LOOKUP -- hash: 0x483e02ee8116c648
+          12: FIELD_ACCESS -- hash: 0xca4e7755b9e6b074
+            10: LOOKUP -- hash: 0x15e3054cfa75da5a
               8: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
               9: CONST integer(1)
             11: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         14: CONST integer(1)
-      22: EQ -- hash: 0xa7daf0142925fa40
-        20: FIELD_ACCESS -- hash: 0xc67cede6ca47bfcc
-          18: LOOKUP -- hash: 0x9f8478476d51f05c
+      22: EQ -- hash: 0xf7a23951bfcab6f
+        20: FIELD_ACCESS -- hash: 0xbf8a69beb80c0f56
+          18: LOOKUP -- hash: 0x6d297aa5e6b1046e
             16: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
             17: CONST integer(0)
           19: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         21: CONST integer(0)
-      29: EQ -- hash: 0x3e25e53c1b5f715a
-        27: FIELD_ACCESS -- hash: 0x1c6354b767d1c1fe
-          25: LOOKUP -- hash: 0x483e02ee8116c648
+      29: EQ -- hash: 0xa5c518bd0a362288
+        27: FIELD_ACCESS -- hash: 0x1570d08f55961188
+          25: LOOKUP -- hash: 0x15e3054cfa75da5a
             23: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
             24: CONST integer(1)
           26: SYMBOL Field { index: 2, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/5.ir
+++ b/lib/src/compiler/ir/tests/testdata/5.ir
@@ -1,35 +1,35 @@
 RULE test_1
-  35: AND -- hash: 0xbcd64d309e20ba14
-    8: EQ -- hash: 0x286081a5404b9efc
-      6: FIELD_ACCESS -- hash: 0x6e1d853ba34b7fe2
-        4: LOOKUP -- hash: 0x716c67a247de6940
-          2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  35: AND -- hash: 0xfb4afd329fb07dc3
+    8: EQ -- hash: 0x496c97e53b61f654
+      6: FIELD_ACCESS -- hash: 0x6af92ddf1af8a3f2
+        4: LOOKUP -- hash: 0xb7e6fdca077aa568
+          2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           3: CONST integer(0)
         5: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       7: CONST integer(0)
-    17: EQ -- hash: 0xbeab76cd32851615
-      15: FIELD_ACCESS -- hash: 0xc403ec0c3cd58213
-        13: LOOKUP -- hash: 0x1a25f2495ba33f2c
-          11: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    17: EQ -- hash: 0xdfb78d0d299b6d6d
+      15: FIELD_ACCESS -- hash: 0xc0df94afb482a623
+        13: LOOKUP -- hash: 0x60a088711b3f7b54
+          11: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             9: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             10: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           12: CONST integer(1)
         14: SYMBOL Field { index: 2, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       16: CONST integer(1)
-    34: EQ -- hash: 0xfe0bc6da31a3fab2
-      32: ADD -- hash: 0x83a5e6847eb7227e
-        24: FIELD_ACCESS -- hash: 0x5a489e7f7434443a
-          22: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            20: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    34: EQ -- hash: 0xf94a49164359b744
+      32: ADD -- hash: 0x637f01b98f7ef769
+        24: FIELD_ACCESS -- hash: 0x57244722efe1684a
+          22: LOOKUP -- hash: 0x60a088711b3f7b54
+            20: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               18: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               19: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             21: CONST integer(1)
           23: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        31: FIELD_ACCESS -- hash: 0x78e192d2a1262100
-          29: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            27: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        31: FIELD_ACCESS -- hash: 0x75bd3b7618d34510
+          29: LOOKUP -- hash: 0x60a088711b3f7b54
+            27: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               25: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               26: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             28: CONST integer(1)
@@ -37,37 +37,37 @@ RULE test_1
       33: CONST integer(1)
 
 RULE test_2
-  35: AND -- hash: 0xa9652719fe3b73e
-    16: EQ -- hash: 0xfe0bc6da31a3fab2
-      14: ADD -- hash: 0x83a5e6847eb7227e
-        6: FIELD_ACCESS -- hash: 0x5a489e7f7434443a
-          4: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  35: AND -- hash: 0x467259e49dca9732
+    16: EQ -- hash: 0xf94a49164359b744
+      14: ADD -- hash: 0x637f01b98f7ef769
+        6: FIELD_ACCESS -- hash: 0x57244722efe1684a
+          4: LOOKUP -- hash: 0x60a088711b3f7b54
+            2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             3: CONST integer(1)
           5: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-        13: FIELD_ACCESS -- hash: 0x78e192d2a1262100
-          11: LOOKUP -- hash: 0x1a25f2495ba33f2c
-            9: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+        13: FIELD_ACCESS -- hash: 0x75bd3b7618d34510
+          11: LOOKUP -- hash: 0x60a088711b3f7b54
+            9: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
               7: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
               8: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             10: CONST integer(1)
           12: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       15: CONST integer(1)
-    25: EQ -- hash: 0x286081a5404b9efc
-      23: FIELD_ACCESS -- hash: 0x6e1d853ba34b7fe2
-        21: LOOKUP -- hash: 0x716c67a247de6940
-          19: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    25: EQ -- hash: 0x496c97e53b61f654
+      23: FIELD_ACCESS -- hash: 0x6af92ddf1af8a3f2
+        21: LOOKUP -- hash: 0xb7e6fdca077aa568
+          19: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             17: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             18: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           20: CONST integer(0)
         22: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
       24: CONST integer(0)
-    34: EQ -- hash: 0xbeab76cd32851615
-      32: FIELD_ACCESS -- hash: 0xc403ec0c3cd58213
-        30: LOOKUP -- hash: 0x1a25f2495ba33f2c
-          28: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    34: EQ -- hash: 0xdfb78d0d299b6d6d
+      32: FIELD_ACCESS -- hash: 0xc0df94afb482a623
+        30: LOOKUP -- hash: 0x60a088711b3f7b54
+          28: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             26: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             27: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           29: CONST integer(1)
@@ -75,34 +75,34 @@ RULE test_2
       33: CONST integer(1)
 
 RULE test_3
-  31: WITH -- hash: 0x1caad377fac14cec
-    2: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  31: WITH -- hash: 0xd12c99d2b9385c31
+    2: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
       0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       1: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    30: AND -- hash: 0x32468198de5bf3ca
-      15: EQ -- hash: 0xb7083bd21650136
-        13: ADD -- hash: 0xb37bf5c5eec49e0b
-          7: FIELD_ACCESS -- hash: 0xb2a8072a9f308424
-            5: LOOKUP -- hash: 0x483e02ee8116c648
+    30: AND -- hash: 0x12dc7234de2063ae
+      15: EQ -- hash: 0xe2720d2e43d2dad5
+        13: ADD -- hash: 0x48118390d9d2fbc
+          7: FIELD_ACCESS -- hash: 0xabb583028cf4d3ae
+            5: LOOKUP -- hash: 0x15e3054cfa75da5a
               3: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
               4: CONST integer(1)
             6: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
-          12: FIELD_ACCESS -- hash: 0xd140fb7dc82260ea
-            10: LOOKUP -- hash: 0x483e02ee8116c648
+          12: FIELD_ACCESS -- hash: 0xca4e7755b9e6b074
+            10: LOOKUP -- hash: 0x15e3054cfa75da5a
               8: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
               9: CONST integer(1)
             11: SYMBOL Field { index: 3, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         14: CONST integer(1)
-      22: EQ -- hash: 0xa7daf0142925fa40
-        20: FIELD_ACCESS -- hash: 0xc67cede6ca47bfcc
-          18: LOOKUP -- hash: 0x9f8478476d51f05c
+      22: EQ -- hash: 0xf7a23951bfcab6f
+        20: FIELD_ACCESS -- hash: 0xbf8a69beb80c0f56
+          18: LOOKUP -- hash: 0x6d297aa5e6b1046e
             16: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
             17: CONST integer(0)
           19: SYMBOL Field { index: 0, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }
         21: CONST integer(0)
-      29: EQ -- hash: 0x3e25e53c1b5f715a
-        27: FIELD_ACCESS -- hash: 0x1c6354b767d1c1fe
-          25: LOOKUP -- hash: 0x483e02ee8116c648
+      29: EQ -- hash: 0xa5c518bd0a362288
+        27: FIELD_ACCESS -- hash: 0x1570d08f55961188
+          25: LOOKUP -- hash: 0x15e3054cfa75da5a
             23: SYMBOL Var { var: Var { frame_id: 1, ty: array, index: 0 }, type_value: array }
             24: CONST integer(1)
           26: SYMBOL Field { index: 2, is_root: false, type_value: integer(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/6.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.cse.ir
@@ -1,22 +1,22 @@
 RULE test
-  19: OR -- hash: 0x15c1b9fd8bb07934
-    9: AND -- hash: 0x4f03f88669200ec7
-      3: EQ -- hash: 0x6636f0caaaf0ce1
-        1: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xd9c315b7872786ad
+  19: OR -- hash: 0x49fa8d3e1c1d2dd3
+    9: AND -- hash: 0xd8afbc7967f97eaf
+      3: EQ -- hash: 0x3cc636cd1ca8024e
+        1: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xff5b08d53ac01266
           0: CONST integer(0)
         2: CONST integer(23117)
-      8: EQ -- hash: 0x23d5cb37154e6e05
-        6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x114d562bc44dc92b
-          5: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x70d97345f01748c4
+      8: EQ -- hash: 0xd7285d892ff19ace
+        6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xc0c7a1735e97f90d
+          5: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x96716663a7afd47d
             4: CONST integer(60)
         7: CONST integer(17744)
-    18: AND -- hash: 0xeb59fd3df0f925fc
-      13: EQ -- hash: 0x8bd5c0fe8f781437
-        11: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xe55cf41d41f52588
+    18: AND -- hash: 0x916e2b5f19b600ff
+      13: EQ -- hash: 0xc23888bf017109a4
+        11: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xaf4e73af58db142
           10: CONST integer(0)
         12: CONST integer(1179403647)
-      17: NE -- hash: 0x303c2970e8fcb487
-        15: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xd9c315b7872786ad
+      17: NE -- hash: 0x669ef1315ef5a9f4
+        15: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xff5b08d53ac01266
           14: CONST integer(0)
         16: CONST integer(0)
 

--- a/lib/src/compiler/ir/tests/testdata/6.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.hoisting.ir
@@ -1,22 +1,22 @@
 RULE test
-  19: OR -- hash: 0x15c1b9fd8bb07934
-    9: AND -- hash: 0x4f03f88669200ec7
-      3: EQ -- hash: 0x6636f0caaaf0ce1
-        1: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xd9c315b7872786ad
+  19: OR -- hash: 0x49fa8d3e1c1d2dd3
+    9: AND -- hash: 0xd8afbc7967f97eaf
+      3: EQ -- hash: 0x3cc636cd1ca8024e
+        1: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xff5b08d53ac01266
           0: CONST integer(0)
         2: CONST integer(23117)
-      8: EQ -- hash: 0x23d5cb37154e6e05
-        6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x114d562bc44dc92b
-          5: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x70d97345f01748c4
+      8: EQ -- hash: 0xd7285d892ff19ace
+        6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xc0c7a1735e97f90d
+          5: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x96716663a7afd47d
             4: CONST integer(60)
         7: CONST integer(17744)
-    18: AND -- hash: 0xeb59fd3df0f925fc
-      13: EQ -- hash: 0x8bd5c0fe8f781437
-        11: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xe55cf41d41f52588
+    18: AND -- hash: 0x916e2b5f19b600ff
+      13: EQ -- hash: 0xc23888bf017109a4
+        11: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xaf4e73af58db142
           10: CONST integer(0)
         12: CONST integer(1179403647)
-      17: NE -- hash: 0x303c2970e8fcb487
-        15: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xd9c315b7872786ad
+      17: NE -- hash: 0x669ef1315ef5a9f4
+        15: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xff5b08d53ac01266
           14: CONST integer(0)
         16: CONST integer(0)
 

--- a/lib/src/compiler/ir/tests/testdata/6.ir
+++ b/lib/src/compiler/ir/tests/testdata/6.ir
@@ -1,22 +1,22 @@
 RULE test
-  19: OR -- hash: 0x15c1b9fd8bb07934
-    9: AND -- hash: 0x4f03f88669200ec7
-      3: EQ -- hash: 0x6636f0caaaf0ce1
-        1: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xd9c315b7872786ad
+  19: OR -- hash: 0x49fa8d3e1c1d2dd3
+    9: AND -- hash: 0xd8afbc7967f97eaf
+      3: EQ -- hash: 0x3cc636cd1ca8024e
+        1: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xff5b08d53ac01266
           0: CONST integer(0)
         2: CONST integer(23117)
-      8: EQ -- hash: 0x23d5cb37154e6e05
-        6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x114d562bc44dc92b
-          5: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x70d97345f01748c4
+      8: EQ -- hash: 0xd7285d892ff19ace
+        6: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xc0c7a1735e97f90d
+          5: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0x96716663a7afd47d
             4: CONST integer(60)
         7: CONST integer(17744)
-    18: AND -- hash: 0xeb59fd3df0f925fc
-      13: EQ -- hash: 0x8bd5c0fe8f781437
-        11: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xe55cf41d41f52588
+    18: AND -- hash: 0x916e2b5f19b600ff
+      13: EQ -- hash: 0xc23888bf017109a4
+        11: FN_CALL uint32@offset:i@i:R0:4294967295u -- hash: 0xaf4e73af58db142
           10: CONST integer(0)
         12: CONST integer(1179403647)
-      17: NE -- hash: 0x303c2970e8fcb487
-        15: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xd9c315b7872786ad
+      17: NE -- hash: 0x669ef1315ef5a9f4
+        15: FN_CALL uint16@offset:i@i:R0:65535u -- hash: 0xff5b08d53ac01266
           14: CONST integer(0)
         16: CONST integer(0)
 

--- a/lib/src/compiler/ir/tests/testdata/7.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.cse.ir
@@ -1,5 +1,5 @@
 RULE test_1
-  13: FOR_IN -- hash: 0x759f60f5a7f015eb
+  13: FOR_IN -- hash: 0x33ca0ee64aa93dd6
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,21 +7,21 @@ RULE test_1
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    12: EQ -- hash: 0x5c8fc30a843d9a50
-      10: FIELD_ACCESS -- hash: 0x3ec51a750647f9a8
-        6: LOOKUP -- hash: 0x491138f2e72b9f66
-          4: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    12: EQ -- hash: 0x8904697095cb76ab
+      10: FIELD_ACCESS -- hash: 0x34d90f741707c780
+        6: LOOKUP -- hash: 0x7e699c8d78b13901
+          4: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             2: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             3: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
-        9: LOOKUP -- hash: 0x1bd1e557c8168259
+        9: LOOKUP -- hash: 0x8cb8293be3610855
           7: SYMBOL Field { index: 6, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           8: CONST integer(0)
       11: CONST integer(0)
 
 RULE test_2
-  7: DEFINED -- hash: 0x1d49f5b40894ff06
-    6: FOR_IN -- hash: 0xd90605d04c83c3bc
+  7: DEFINED -- hash: 0x83920828745c61d7
+    6: FOR_IN -- hash: 0xa875318ff67c24a4
           n: Var { frame_id: 1, ty: integer, index: 0 }
           i: Var { frame_id: 1, ty: integer, index: 1 }
           max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -29,26 +29,26 @@ RULE test_2
           item: Var { frame_id: 1, ty: unknown, index: 4 }
       0: CONST integer(0)
       1: CONST integer(10)
-      5: EQ -- hash: 0x73a8684f978b75a
-        3: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee
+      5: EQ -- hash: 0x2cd279a2ad114313
+        3: FN_CALL test_proto2.undef_i64@@iu -- hash: 0x27b4fb38ce4fcd4d
         4: CONST integer(0)
 
 RULE test_3
-  18: OR -- hash: 0xc03b2943bc74ac56
-    5: CONTAINS -- hash: 0x9b34a06a5c144733
-      3: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+  18: OR -- hash: 0x296ac0215c519821
+    5: CONTAINS -- hash: 0xe79cb207bd3992e5
+      3: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         2: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       4: CONST string("foo")
-    11: CONTAINS -- hash: 0x9b34a06a5c144733
-      9: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+    11: CONTAINS -- hash: 0xe79cb207bd3992e5
+      9: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         6: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         7: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         8: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       10: CONST string("foo")
-    17: CONTAINS -- hash: 0xbab99c5006e37037
-      15: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+    17: CONTAINS -- hash: 0x721aded6408bbea
+      15: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         12: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         13: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         14: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/7.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.hoisting.ir
@@ -1,9 +1,9 @@
 RULE test_1
-  15: WITH -- hash: 0x26996efd3ba8f777
-    14: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+  15: WITH -- hash: 0xbde03d097f7ede1
+    14: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
       2: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
       3: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
-    13: FOR_IN -- hash: 0xd8cf702c9fb77c65
+    13: FOR_IN -- hash: 0xc64e600939c50740
           n: Var { frame_id: 1, ty: integer, index: 1 }
           i: Var { frame_id: 1, ty: integer, index: 2 }
           max_count: Var { frame_id: 1, ty: integer, index: 3 }
@@ -11,25 +11,25 @@ RULE test_1
           item: Var { frame_id: 1, ty: unknown, index: 5 }
       0: CONST integer(0)
       1: CONST integer(1)
-      12: EQ -- hash: 0xd80669f7f1fbbe8
-        10: FIELD_ACCESS -- hash: 0x269db08d3f80f808
-          6: LOOKUP -- hash: 0xbc92506a3c451e95
+      12: EQ -- hash: 0xa8c03d82477d27bd
+        10: FIELD_ACCESS -- hash: 0x8ec5c4d884e08cef
+          6: LOOKUP -- hash: 0x6902899869d87c84
             4: SYMBOL Var { var: Var { frame_id: 0, ty: array, index: 0 }, type_value: array }
             5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 6 }, type_value: integer(unknown) }
-          9: LOOKUP -- hash: 0x1bd1e557c8168259
+          9: LOOKUP -- hash: 0x8cb8293be3610855
             7: SYMBOL Field { index: 6, is_root: false, type_value: array, acl: None, deprecation_notice: None }
             8: CONST integer(0)
         11: CONST integer(0)
 
 RULE test_2
-  7: DEFINED -- hash: 0xcf8d327a66b02ccd
-    9: WITH -- hash: 0xaeb8e5d7e9b9a04f
-      8: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee
-      11: WITH -- hash: 0x3696d4a61d1b6729
-        10: EQ -- hash: 0xca17973246e0efca
+  7: DEFINED -- hash: 0xcb28b3121bed9db
+    9: WITH -- hash: 0x2cdfa770a16582a3
+      8: FN_CALL test_proto2.undef_i64@@iu -- hash: 0x27b4fb38ce4fcd4d
+      11: WITH -- hash: 0xc33384ebfd4dca39
+        10: EQ -- hash: 0xdda4166d98e5fb3
           3: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 0 }, type_value: integer(unknown) }
           4: CONST integer(0)
-        6: FOR_IN -- hash: 0x5aa37f3747d0aa75
+        6: FOR_IN -- hash: 0xf1259fea1ea134ba
               n: Var { frame_id: 1, ty: integer, index: 2 }
               i: Var { frame_id: 1, ty: integer, index: 3 }
               max_count: Var { frame_id: 1, ty: integer, index: 4 }
@@ -40,21 +40,21 @@ RULE test_2
           5: SYMBOL Var { var: Var { frame_id: 0, ty: boolean, index: 1 }, type_value: boolean(unknown) }
 
 RULE test_3
-  18: OR -- hash: 0xc03b2943bc74ac56
-    5: CONTAINS -- hash: 0x9b34a06a5c144733
-      3: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+  18: OR -- hash: 0x296ac0215c519821
+    5: CONTAINS -- hash: 0xe79cb207bd3992e5
+      3: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         2: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       4: CONST string("foo")
-    11: CONTAINS -- hash: 0x9b34a06a5c144733
-      9: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+    11: CONTAINS -- hash: 0xe79cb207bd3992e5
+      9: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         6: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         7: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         8: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       10: CONST string("foo")
-    17: CONTAINS -- hash: 0xbab99c5006e37037
-      15: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+    17: CONTAINS -- hash: 0x721aded6408bbea
+      15: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         12: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         13: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         14: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/7.ir
+++ b/lib/src/compiler/ir/tests/testdata/7.ir
@@ -1,5 +1,5 @@
 RULE test_1
-  13: FOR_IN -- hash: 0x759f60f5a7f015eb
+  13: FOR_IN -- hash: 0x33ca0ee64aa93dd6
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,21 +7,21 @@ RULE test_1
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    12: EQ -- hash: 0x5c8fc30a843d9a50
-      10: FIELD_ACCESS -- hash: 0x3ec51a750647f9a8
-        6: LOOKUP -- hash: 0x491138f2e72b9f66
-          4: FIELD_ACCESS -- hash: 0x54b6d37d2b917356
+    12: EQ -- hash: 0x8904697095cb76ab
+      10: FIELD_ACCESS -- hash: 0x34d90f741707c780
+        6: LOOKUP -- hash: 0x7e699c8d78b13901
+          4: FIELD_ACCESS -- hash: 0xb93ff31706b0e381
             2: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
             3: SYMBOL Field { index: 49, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
-        9: LOOKUP -- hash: 0x1bd1e557c8168259
+        9: LOOKUP -- hash: 0x8cb8293be3610855
           7: SYMBOL Field { index: 6, is_root: false, type_value: array, acl: None, deprecation_notice: None }
           8: CONST integer(0)
       11: CONST integer(0)
 
 RULE test_2
-  7: DEFINED -- hash: 0x1d49f5b40894ff06
-    6: FOR_IN -- hash: 0xd90605d04c83c3bc
+  7: DEFINED -- hash: 0x83920828745c61d7
+    6: FOR_IN -- hash: 0xa875318ff67c24a4
           n: Var { frame_id: 1, ty: integer, index: 0 }
           i: Var { frame_id: 1, ty: integer, index: 1 }
           max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -29,26 +29,26 @@ RULE test_2
           item: Var { frame_id: 1, ty: unknown, index: 4 }
       0: CONST integer(0)
       1: CONST integer(10)
-      5: EQ -- hash: 0x73a8684f978b75a
-        3: FN_CALL test_proto2.undef_i64@@iu -- hash: 0xc0206489d8f27bee
+      5: EQ -- hash: 0x2cd279a2ad114313
+        3: FN_CALL test_proto2.undef_i64@@iu -- hash: 0x27b4fb38ce4fcd4d
         4: CONST integer(0)
 
 RULE test_3
-  18: OR -- hash: 0xc03b2943bc74ac56
-    5: CONTAINS -- hash: 0x9b34a06a5c144733
-      3: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+  18: OR -- hash: 0x296ac0215c519821
+    5: CONTAINS -- hash: 0xe79cb207bd3992e5
+      3: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         0: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         1: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         2: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       4: CONST string("foo")
-    11: CONTAINS -- hash: 0x9b34a06a5c144733
-      9: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+    11: CONTAINS -- hash: 0xe79cb207bd3992e5
+      9: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         6: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         7: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         8: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }
       10: CONST string("foo")
-    17: CONTAINS -- hash: 0xbab99c5006e37037
-      15: FIELD_ACCESS -- hash: 0xa68ef47d7e9f1bf3
+    17: CONTAINS -- hash: 0x721aded6408bbea
+      15: FIELD_ACCESS -- hash: 0x63bc9bc95d660aee
         12: SYMBOL Field { index: 0, is_root: true, type_value: struct, acl: None, deprecation_notice: None }
         13: SYMBOL Field { index: 44, is_root: false, type_value: struct, acl: None, deprecation_notice: None }
         14: SYMBOL Field { index: 5, is_root: false, type_value: string(unknown), acl: None, deprecation_notice: None }

--- a/lib/src/compiler/ir/tests/testdata/8.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/8.cse.ir
@@ -1,5 +1,5 @@
 RULE test_1
-  14: FOR_IN -- hash: 0x2975ab1e0c45cad2
+  14: FOR_IN -- hash: 0xcff1e20451055391
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,7 +7,7 @@ RULE test_1
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    13: FOR_IN -- hash: 0x990f4f186d5fca26
+    13: FOR_IN -- hash: 0x8f04881f0c313ede
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
@@ -15,18 +15,18 @@ RULE test_1
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
       3: CONST integer(1)
-      12: EQ -- hash: 0x1b5c74ae4e96f61c
-        8: MUL -- hash: 0xfd31adad45ac8007
-          6: ADD -- hash: 0x9bbcc7ec2223cfaa
+      12: EQ -- hash: 0xeb807bdffaa380d7
+        8: MUL -- hash: 0xbde422737d04274c
+          6: ADD -- hash: 0x11ca3959d9be382c
             4: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
             5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           7: CONST integer(2)
-        11: MINUS -- hash: 0x37f1e6e59410ac3e
-          10: MINUS -- hash: 0x7bfa27511215f1a0
+        11: MINUS -- hash: 0x241d002968f97096
+          10: MINUS -- hash: 0x68254094e6feb5f8
             9: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 12 }, type_value: integer(unknown) }
 
 RULE test_2
-  10: FOR_IN -- hash: 0x4c3499ae038d8175
+  10: FOR_IN -- hash: 0x5fa30afbd11d7a2a
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -34,7 +34,7 @@ RULE test_2
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    9: FOR_IN -- hash: 0x674dd5f463dfb138
+    9: FOR_IN -- hash: 0x4cf5fa0e0fbbad81
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
@@ -42,8 +42,8 @@ RULE test_2
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
       3: CONST integer(1)
-      8: EQ -- hash: 0xa8cddb464348c98b
-        6: ADD -- hash: 0x9bbcc7ec2223cfaa
+      8: EQ -- hash: 0x6980500c7aa070d0
+        6: ADD -- hash: 0x11ca3959d9be382c
           4: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
         7: CONST integer(0)

--- a/lib/src/compiler/ir/tests/testdata/8.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/8.hoisting.ir
@@ -1,5 +1,5 @@
 RULE test_1
-  14: FOR_IN -- hash: 0x3bf7816fc6e844fb
+  14: FOR_IN -- hash: 0x52bf5e8df23693d7
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,13 +7,13 @@ RULE test_1
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    16: WITH -- hash: 0x56950fcd25158f42
-      15: MUL -- hash: 0xfd31adad45ac8007
-        6: ADD -- hash: 0x9bbcc7ec2223cfaa
+    16: WITH -- hash: 0x41fbd3788d9217a0
+      15: MUL -- hash: 0xbde422737d04274c
+        6: ADD -- hash: 0x11ca3959d9be382c
           4: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
         7: CONST integer(2)
-      13: FOR_IN -- hash: 0xc514c2a7ae5ff351
+      13: FOR_IN -- hash: 0xff1c8ed74a0073b8
             n: Var { frame_id: 2, ty: integer, index: 8 }
             i: Var { frame_id: 2, ty: integer, index: 9 }
             max_count: Var { frame_id: 2, ty: integer, index: 10 }
@@ -21,14 +21,14 @@ RULE test_1
             item: Var { frame_id: 2, ty: unknown, index: 12 }
         2: CONST integer(0)
         3: CONST integer(1)
-        12: EQ -- hash: 0x86f8c6f0fdfe253
+        12: EQ -- hash: 0x1900d160247f7f84
           8: SYMBOL Var { var: Var { frame_id: 0, ty: integer, index: 7 }, type_value: integer(unknown) }
-          11: MINUS -- hash: 0xe0ab718cabd58229
-            10: MINUS -- hash: 0x24b3b1f825dac78c
+          11: MINUS -- hash: 0xccd68ad07cbe4681
+            10: MINUS -- hash: 0x10decb3bfac38be4
               9: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 13 }, type_value: integer(unknown) }
 
 RULE test_2
-  10: FOR_IN -- hash: 0x4c3499ae038d8175
+  10: FOR_IN -- hash: 0x5fa30afbd11d7a2a
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -36,7 +36,7 @@ RULE test_2
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    9: FOR_IN -- hash: 0x674dd5f463dfb138
+    9: FOR_IN -- hash: 0x4cf5fa0e0fbbad81
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
@@ -44,8 +44,8 @@ RULE test_2
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
       3: CONST integer(1)
-      8: EQ -- hash: 0xa8cddb464348c98b
-        6: ADD -- hash: 0x9bbcc7ec2223cfaa
+      8: EQ -- hash: 0x6980500c7aa070d0
+        6: ADD -- hash: 0x11ca3959d9be382c
           4: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
         7: CONST integer(0)

--- a/lib/src/compiler/ir/tests/testdata/8.ir
+++ b/lib/src/compiler/ir/tests/testdata/8.ir
@@ -1,5 +1,5 @@
 RULE test_1
-  14: FOR_IN -- hash: 0x2975ab1e0c45cad2
+  14: FOR_IN -- hash: 0xcff1e20451055391
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -7,7 +7,7 @@ RULE test_1
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    13: FOR_IN -- hash: 0x990f4f186d5fca26
+    13: FOR_IN -- hash: 0x8f04881f0c313ede
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
@@ -15,18 +15,18 @@ RULE test_1
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
       3: CONST integer(1)
-      12: EQ -- hash: 0x1b5c74ae4e96f61c
-        8: MUL -- hash: 0xfd31adad45ac8007
-          6: ADD -- hash: 0x9bbcc7ec2223cfaa
+      12: EQ -- hash: 0xeb807bdffaa380d7
+        8: MUL -- hash: 0xbde422737d04274c
+          6: ADD -- hash: 0x11ca3959d9be382c
             4: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
             5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           7: CONST integer(2)
-        11: MINUS -- hash: 0x37f1e6e59410ac3e
-          10: MINUS -- hash: 0x7bfa27511215f1a0
+        11: MINUS -- hash: 0x241d002968f97096
+          10: MINUS -- hash: 0x68254094e6feb5f8
             9: SYMBOL Var { var: Var { frame_id: 2, ty: integer, index: 12 }, type_value: integer(unknown) }
 
 RULE test_2
-  10: FOR_IN -- hash: 0x4c3499ae038d8175
+  10: FOR_IN -- hash: 0x5fa30afbd11d7a2a
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
@@ -34,7 +34,7 @@ RULE test_2
         item: Var { frame_id: 1, ty: unknown, index: 4 }
     0: CONST integer(0)
     1: CONST integer(1)
-    9: FOR_IN -- hash: 0x674dd5f463dfb138
+    9: FOR_IN -- hash: 0x4cf5fa0e0fbbad81
           n: Var { frame_id: 2, ty: integer, index: 7 }
           i: Var { frame_id: 2, ty: integer, index: 8 }
           max_count: Var { frame_id: 2, ty: integer, index: 9 }
@@ -42,8 +42,8 @@ RULE test_2
           item: Var { frame_id: 2, ty: unknown, index: 11 }
       2: CONST integer(0)
       3: CONST integer(1)
-      8: EQ -- hash: 0xa8cddb464348c98b
-        6: ADD -- hash: 0x9bbcc7ec2223cfaa
+      8: EQ -- hash: 0x6980500c7aa070d0
+        6: ADD -- hash: 0x11ca3959d9be382c
           4: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
           5: SYMBOL Var { var: Var { frame_id: 1, ty: integer, index: 5 }, type_value: integer(unknown) }
         7: CONST integer(0)

--- a/lib/src/compiler/ir/tests/testdata/9.cse.ir
+++ b/lib/src/compiler/ir/tests/testdata/9.cse.ir
@@ -1,28 +1,28 @@
 RULE test_1
-  7: AND -- hash: 0xe5cafaa8d88f6647
-    0: PATTERN_MATCH PatternIdx(0) -- hash: 0xf292d5de83aa2bcc
-    3: EQ -- hash: 0xdd02cd4d9c8dcff4
-      1: PATTERN_COUNT PatternIdx(0) -- hash: 0xc1bc033c6a64ce89
+  7: AND -- hash: 0xc5b3f5bfb52edf4f
+    0: PATTERN_MATCH PatternIdx(0) -- hash: 0x5a276c8d75077d2b
+    3: EQ -- hash: 0x29ac06b50265bae
+      1: PATTERN_COUNT PatternIdx(0) -- hash: 0x295099eb5fc21fe8
       2: CONST integer(1)
-    6: EQ -- hash: 0x7f7928e1f3fa117b
-      4: PATTERN_OFFSET PatternIdx(0) -- hash: 0x90e5309a511f7146
+    6: EQ -- hash: 0xa5111bffa7929d34
+      4: PATTERN_OFFSET PatternIdx(0) -- hash: 0xf879c749467cc2a4
       5: CONST integer(0)
 
 RULE test_2
-  1: PATTERN_MATCH PatternIdx(0) AT -- hash: 0xd5e7410730122f97
+  1: PATTERN_MATCH PatternIdx(0) AT -- hash: 0xfb7f3424e7aabb50
     0: CONST integer(0)
 
 RULE test_3
-  6: FOR_OF -- hash: 0x9efd07789e3b338f
+  6: FOR_OF -- hash: 0x38da77c23a5f1b4e
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: integer, index: 4 }
-    5: OR -- hash: 0xda1fd5ef5cd9baa8
-      1: PATTERN_MATCH Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } AT -- hash: 0x8f6f481cddaae626
+    5: OR -- hash: 0x9da4149814c75f48
+      1: PATTERN_MATCH Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } AT -- hash: 0x1951a046c05c8a50
         0: CONST integer(0)
-      4: GT -- hash: 0xf6c07a35e19896a9
-        2: PATTERN_COUNT Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } -- hash: 0x4a5032b534929583
+      4: GT -- hash: 0x80a2d25fc44a3ad3
+        2: PATTERN_COUNT Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } -- hash: 0x1f3792db5a762e26
         3: CONST integer(0)
 

--- a/lib/src/compiler/ir/tests/testdata/9.hoisting.ir
+++ b/lib/src/compiler/ir/tests/testdata/9.hoisting.ir
@@ -1,28 +1,28 @@
 RULE test_1
-  7: AND -- hash: 0xe5cafaa8d88f6647
-    0: PATTERN_MATCH PatternIdx(0) -- hash: 0xf292d5de83aa2bcc
-    3: EQ -- hash: 0xdd02cd4d9c8dcff4
-      1: PATTERN_COUNT PatternIdx(0) -- hash: 0xc1bc033c6a64ce89
+  7: AND -- hash: 0xc5b3f5bfb52edf4f
+    0: PATTERN_MATCH PatternIdx(0) -- hash: 0x5a276c8d75077d2b
+    3: EQ -- hash: 0x29ac06b50265bae
+      1: PATTERN_COUNT PatternIdx(0) -- hash: 0x295099eb5fc21fe8
       2: CONST integer(1)
-    6: EQ -- hash: 0x7f7928e1f3fa117b
-      4: PATTERN_OFFSET PatternIdx(0) -- hash: 0x90e5309a511f7146
+    6: EQ -- hash: 0xa5111bffa7929d34
+      4: PATTERN_OFFSET PatternIdx(0) -- hash: 0xf879c749467cc2a4
       5: CONST integer(0)
 
 RULE test_2
-  1: PATTERN_MATCH PatternIdx(0) AT -- hash: 0xd5e7410730122f97
+  1: PATTERN_MATCH PatternIdx(0) AT -- hash: 0xfb7f3424e7aabb50
     0: CONST integer(0)
 
 RULE test_3
-  6: FOR_OF -- hash: 0x9efd07789e3b338f
+  6: FOR_OF -- hash: 0x38da77c23a5f1b4e
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: integer, index: 4 }
-    5: OR -- hash: 0xda1fd5ef5cd9baa8
-      1: PATTERN_MATCH Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } AT -- hash: 0x8f6f481cddaae626
+    5: OR -- hash: 0x9da4149814c75f48
+      1: PATTERN_MATCH Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } AT -- hash: 0x1951a046c05c8a50
         0: CONST integer(0)
-      4: GT -- hash: 0xf6c07a35e19896a9
-        2: PATTERN_COUNT Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } -- hash: 0x4a5032b534929583
+      4: GT -- hash: 0x80a2d25fc44a3ad3
+        2: PATTERN_COUNT Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } -- hash: 0x1f3792db5a762e26
         3: CONST integer(0)
 

--- a/lib/src/compiler/ir/tests/testdata/9.ir
+++ b/lib/src/compiler/ir/tests/testdata/9.ir
@@ -1,28 +1,28 @@
 RULE test_1
-  7: AND -- hash: 0xe5cafaa8d88f6647
-    0: PATTERN_MATCH PatternIdx(0) -- hash: 0xf292d5de83aa2bcc
-    3: EQ -- hash: 0xdd02cd4d9c8dcff4
-      1: PATTERN_COUNT PatternIdx(0) -- hash: 0xc1bc033c6a64ce89
+  7: AND -- hash: 0xc5b3f5bfb52edf4f
+    0: PATTERN_MATCH PatternIdx(0) -- hash: 0x5a276c8d75077d2b
+    3: EQ -- hash: 0x29ac06b50265bae
+      1: PATTERN_COUNT PatternIdx(0) -- hash: 0x295099eb5fc21fe8
       2: CONST integer(1)
-    6: EQ -- hash: 0x7f7928e1f3fa117b
-      4: PATTERN_OFFSET PatternIdx(0) -- hash: 0x90e5309a511f7146
+    6: EQ -- hash: 0xa5111bffa7929d34
+      4: PATTERN_OFFSET PatternIdx(0) -- hash: 0xf879c749467cc2a4
       5: CONST integer(0)
 
 RULE test_2
-  1: PATTERN_MATCH PatternIdx(0) AT -- hash: 0xd5e7410730122f97
+  1: PATTERN_MATCH PatternIdx(0) AT -- hash: 0xfb7f3424e7aabb50
     0: CONST integer(0)
 
 RULE test_3
-  6: FOR_OF -- hash: 0x9efd07789e3b338f
+  6: FOR_OF -- hash: 0x38da77c23a5f1b4e
         n: Var { frame_id: 1, ty: integer, index: 0 }
         i: Var { frame_id: 1, ty: integer, index: 1 }
         max_count: Var { frame_id: 1, ty: integer, index: 2 }
         count: Var { frame_id: 1, ty: integer, index: 3 }
         item: Var { frame_id: 1, ty: integer, index: 4 }
-    5: OR -- hash: 0xda1fd5ef5cd9baa8
-      1: PATTERN_MATCH Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } AT -- hash: 0x8f6f481cddaae626
+    5: OR -- hash: 0x9da4149814c75f48
+      1: PATTERN_MATCH Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } AT -- hash: 0x1951a046c05c8a50
         0: CONST integer(0)
-      4: GT -- hash: 0xf6c07a35e19896a9
-        2: PATTERN_COUNT Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } -- hash: 0x4a5032b534929583
+      4: GT -- hash: 0x80a2d25fc44a3ad3
+        2: PATTERN_COUNT Var { var: Var { frame_id: 1, ty: integer, index: 4 }, type_value: integer(unknown) } -- hash: 0x1f3792db5a762e26
         3: CONST integer(0)
 

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -1535,7 +1535,6 @@ impl Compiler<'_> {
             loop_iteration_multiplier: 1,
             regex_sets: &mut self.regex_sets,
             regexp_pool: &mut self.regexp_pool,
-            current_namespace_id: self.current_namespace.id,
         };
 
         // Convert the patterns from AST to IR. This populates the
@@ -2791,17 +2790,6 @@ impl From<RegexSetId> for i32 {
     fn from(value: RegexSetId) -> Self {
         value.0
     }
-}
-
-/// Canonical representation of an immutable target expression (such as a
-/// structure field access) that is matched against regular expressions.
-///
-/// This enum provides a safe, side-effect-free canonical identifier used
-/// during AST-to-IR translation to group multiple regular expressions
-/// matching the exact same target expression.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub(crate) enum MatchTarget {
-    FieldAccess(NamespaceId, Vec<i32>),
 }
 
 /// ID associated to each pattern.

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -299,7 +299,7 @@ pub struct Compiler<'a> {
 
     /// Similar to `ident_pool` but for regular expressions found in rule
     /// conditions.
-    regexp_pool: StringPool<RegexId>,
+    regex_pool: StringPool<RegexId>,
 
     /// Similar to `ident_pool` but for string literals found in the source
     /// code. As literal strings in YARA can contain arbitrary bytes, a pool
@@ -501,7 +501,7 @@ impl<'a> Compiler<'a> {
             root_struct: Struct::new().make_root(),
             report_builder: ReportBuilder::new(),
             lit_pool: BStringPool::new(),
-            regexp_pool: StringPool::new(),
+            regex_pool: StringPool::new(),
             patterns: FxHashMap::default(),
             ir_writer: None,
             linters: Vec::new(),
@@ -799,7 +799,7 @@ impl<'a> Compiler<'a> {
             ac: None,
             num_patterns: self.next_pattern_id.0 as usize,
             ident_pool: self.ident_pool,
-            regexp_pool: self.regexp_pool,
+            regex_pool: self.regex_pool,
             lit_pool: self.lit_pool,
             imported_modules: self.imported_modules,
             rules: self.rules,
@@ -1534,7 +1534,7 @@ impl Compiler<'_> {
             features: &self.features,
             loop_iteration_multiplier: 1,
             regex_sets: &mut self.regex_sets,
-            regexp_pool: &mut self.regexp_pool,
+            regex_pool: &mut self.regex_pool,
         };
 
         // Convert the patterns from AST to IR. This populates the
@@ -1830,7 +1830,7 @@ impl Compiler<'_> {
         let mut ctx = EmitContext {
             current_rule: self.rules.last_mut().unwrap(),
             lit_pool: &mut self.lit_pool,
-            regexp_pool: &mut self.regexp_pool,
+            regex_pool: &mut self.regex_pool,
             wasm_symbols: &self.wasm_symbols,
             wasm_exports: &self.wasm_exports,
             exception_handler_stack: Vec::new(),

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -1552,6 +1552,7 @@ impl Compiler<'_> {
             loop_iteration_multiplier: 1,
             matches_by_target: &mut self.matches_by_target,
             regexp_pool: &mut self.regexp_pool,
+            current_namespace_id: self.current_namespace.id,
         };
 
         // Convert the patterns from AST to IR. This populates the
@@ -2681,6 +2682,13 @@ impl From<LiteralId> for u64 {
 #[serde(transparent)]
 pub(crate) struct NamespaceId(i32);
 
+impl From<i32> for NamespaceId {
+    #[inline]
+    fn from(v: i32) -> Self {
+        Self(v)
+    }
+}
+
 /// ID associated to each rule.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub(crate) struct RuleId(i32);
@@ -2810,7 +2818,7 @@ impl From<RegexSetId> for i32 {
 /// matching the exact same target expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum MatchTarget {
-    FieldAccess(Vec<i32>),
+    FieldAccess(NamespaceId, Vec<i32>),
 }
 
 /// ID associated to each pattern.

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -416,6 +416,9 @@ pub struct Compiler<'a> {
     /// Linters applied to each rule during compilation. The linters are added
     /// to the compiler using [`Compiler::add_linter`]:
     linters: Vec<Box<dyn linters::Linter + 'a>>,
+
+    /// Tracks regular expressions matched against specific canonical targets across all rules.
+    matches_by_target: FxHashMap<MatchTarget, FxHashSet<RegexpId>>,
 }
 
 impl<'a> Compiler<'a> {
@@ -505,6 +508,7 @@ impl<'a> Compiler<'a> {
             include_dirs: None,
             includes_enabled: true,
             include_stack: Vec::new(),
+            matches_by_target: FxHashMap::default(),
         }
     }
 
@@ -787,6 +791,22 @@ impl<'a> Compiler<'a> {
         )
         .expect("failed to serialize global variables");
 
+        let mut regex_sets = rustc_hash::FxHashMap::default();
+        let mut regexp_to_set = rustc_hash::FxHashMap::default();
+        let mut next_set_id = 0;
+
+        for (_, re_ids) in self.matches_by_target {
+            if re_ids.len() > 1 {
+                let set_id = RegexSetId(next_set_id);
+                next_set_id += 1;
+                let sorted_re_ids: Vec<RegexpId> = re_ids.into_iter().collect();
+                for (index, &re_id) in sorted_re_ids.iter().enumerate() {
+                    regexp_to_set.insert(re_id, (set_id, index));
+                }
+                regex_sets.insert(set_id, sorted_re_ids);
+            }
+        }
+
         let mut rules = Rules {
             serialized_globals,
             wasm_mod,
@@ -805,6 +825,8 @@ impl<'a> Compiler<'a> {
             re_code: self.re_code,
             warnings: self.warnings.into(),
             filesize_bounds: self.filesize_bounds,
+            regex_sets,
+            regexp_to_set,
         };
 
         rules.build_ac_automaton();
@@ -1528,6 +1550,8 @@ impl Compiler<'_> {
             for_of_depth: 0,
             features: &self.features,
             loop_iteration_multiplier: 1,
+            matches_by_target: &mut self.matches_by_target,
+            regexp_pool: &mut self.regexp_pool,
         };
 
         // Convert the patterns from AST to IR. This populates the
@@ -2700,7 +2724,7 @@ impl From<RuleId> for i32 {
 }
 
 /// ID associated to each regexp used in a rule condition.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub(crate) struct RegexpId(i32);
 
 impl From<i32> for RegexpId {
@@ -2743,6 +2767,38 @@ impl From<RegexpId> for u32 {
     fn from(value: RegexpId) -> Self {
         value.0.try_into().unwrap()
     }
+}
+
+/// ID associated to each RegexSet.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RegexSetId(i32);
+
+impl From<i32> for RegexSetId {
+    #[inline]
+    fn from(value: i32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<RegexSetId> for usize {
+    #[inline]
+    fn from(value: RegexSetId) -> Self {
+        value.0 as usize
+    }
+}
+
+impl From<RegexSetId> for i32 {
+    #[inline]
+    fn from(value: RegexSetId) -> Self {
+        value.0
+    }
+}
+
+/// Canonical representation of a target expression (like a field access) that is matched against
+/// regular expressions.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub(crate) enum MatchTarget {
+    FieldAccess(Vec<i32>),
 }
 
 /// ID associated to each pattern.

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -417,8 +417,8 @@ pub struct Compiler<'a> {
     /// to the compiler using [`Compiler::add_linter`]:
     linters: Vec<Box<dyn linters::Linter + 'a>>,
 
-    /// Tracks regular expressions matched against specific canonical targets across all rules.
-    matches_by_target: FxHashMap<MatchTarget, FxHashSet<RegexId>>,
+    /// Grouped RegexSets constructed during IR creation for or-expressions.
+    pub(crate) regex_sets: FxHashMap<RegexSetId, Vec<RegexId>>,
 }
 
 impl<'a> Compiler<'a> {
@@ -508,7 +508,7 @@ impl<'a> Compiler<'a> {
             include_dirs: None,
             includes_enabled: true,
             include_stack: Vec::new(),
-            matches_by_target: FxHashMap::default(),
+            regex_sets: FxHashMap::default(),
         }
     }
 
@@ -791,22 +791,6 @@ impl<'a> Compiler<'a> {
         )
         .expect("failed to serialize global variables");
 
-        let mut regex_sets = rustc_hash::FxHashMap::default();
-        let mut regexp_to_set = rustc_hash::FxHashMap::default();
-        let mut next_set_id = 0;
-
-        for (_, re_ids) in self.matches_by_target {
-            if re_ids.len() > 1 {
-                let set_id = RegexSetId(next_set_id);
-                next_set_id += 1;
-                let sorted_re_ids: Vec<RegexId> = re_ids.into_iter().collect();
-                for (index, &re_id) in sorted_re_ids.iter().enumerate() {
-                    regexp_to_set.insert(re_id, (set_id, index));
-                }
-                regex_sets.insert(set_id, sorted_re_ids);
-            }
-        }
-
         let mut rules = Rules {
             serialized_globals,
             wasm_mod,
@@ -825,8 +809,7 @@ impl<'a> Compiler<'a> {
             re_code: self.re_code,
             warnings: self.warnings.into(),
             filesize_bounds: self.filesize_bounds,
-            regex_sets,
-            regexp_to_set,
+            regex_sets: self.regex_sets,
         };
 
         rules.build_ac_automaton();
@@ -1550,7 +1533,7 @@ impl Compiler<'_> {
             for_of_depth: 0,
             features: &self.features,
             loop_iteration_multiplier: 1,
-            matches_by_target: &mut self.matches_by_target,
+            regex_sets: &mut self.regex_sets,
             regexp_pool: &mut self.regexp_pool,
             current_namespace_id: self.current_namespace.id,
         };

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -299,7 +299,7 @@ pub struct Compiler<'a> {
 
     /// Similar to `ident_pool` but for regular expressions found in rule
     /// conditions.
-    regexp_pool: StringPool<RegexpId>,
+    regexp_pool: StringPool<RegexId>,
 
     /// Similar to `ident_pool` but for string literals found in the source
     /// code. As literal strings in YARA can contain arbitrary bytes, a pool
@@ -418,7 +418,7 @@ pub struct Compiler<'a> {
     linters: Vec<Box<dyn linters::Linter + 'a>>,
 
     /// Tracks regular expressions matched against specific canonical targets across all rules.
-    matches_by_target: FxHashMap<MatchTarget, FxHashSet<RegexpId>>,
+    matches_by_target: FxHashMap<MatchTarget, FxHashSet<RegexId>>,
 }
 
 impl<'a> Compiler<'a> {
@@ -799,7 +799,7 @@ impl<'a> Compiler<'a> {
             if re_ids.len() > 1 {
                 let set_id = RegexSetId(next_set_id);
                 next_set_id += 1;
-                let sorted_re_ids: Vec<RegexpId> = re_ids.into_iter().collect();
+                let sorted_re_ids: Vec<RegexId> = re_ids.into_iter().collect();
                 for (index, &re_id) in sorted_re_ids.iter().enumerate() {
                     regexp_to_set.insert(re_id, (set_id, index));
                 }
@@ -2724,53 +2724,61 @@ impl From<RuleId> for i32 {
 }
 
 /// ID associated to each regexp used in a rule condition.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub(crate) struct RegexpId(i32);
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub(crate) struct RegexId(i32);
 
-impl From<i32> for RegexpId {
+impl From<i32> for RegexId {
     #[inline]
     fn from(value: i32) -> Self {
         Self(value)
     }
 }
 
-impl From<u32> for RegexpId {
+impl From<u32> for RegexId {
     #[inline]
     fn from(value: u32) -> Self {
         Self(value.try_into().unwrap())
     }
 }
 
-impl From<i64> for RegexpId {
+impl From<i64> for RegexId {
     #[inline]
     fn from(value: i64) -> Self {
         Self(value.try_into().unwrap())
     }
 }
 
-impl From<RegexpId> for usize {
+impl From<RegexId> for usize {
     #[inline]
-    fn from(value: RegexpId) -> Self {
+    fn from(value: RegexId) -> Self {
         value.0 as usize
     }
 }
 
-impl From<RegexpId> for i32 {
+impl From<RegexId> for i32 {
     #[inline]
-    fn from(value: RegexpId) -> Self {
+    fn from(value: RegexId) -> Self {
         value.0
     }
 }
 
-impl From<RegexpId> for u32 {
+impl From<RegexId> for u32 {
     #[inline]
-    fn from(value: RegexpId) -> Self {
+    fn from(value: RegexId) -> Self {
         value.0.try_into().unwrap()
     }
 }
 
-/// ID associated to each RegexSet.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+/// ID associated to each grouped `RegexSet`.
+///
+/// When compiling multiple rules, identical string expressions (such as a
+/// specific field access like `vt.net.domain.raw`) are frequently matched
+/// against multiple distinct regular expressions. To optimize these
+/// evaluations, the compiler identifies identical targets, assigns them a
+/// unique `RegexSetId`, and groups all their associated regular expressions
+/// together. At runtime, the entire set is evaluated simultaneously in a
+/// single pass.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub(crate) struct RegexSetId(i32);
 
 impl From<i32> for RegexSetId {
@@ -2794,8 +2802,12 @@ impl From<RegexSetId> for i32 {
     }
 }
 
-/// Canonical representation of a target expression (like a field access) that is matched against
-/// regular expressions.
+/// Canonical representation of an immutable target expression (such as a
+/// structure field access) that is matched against regular expressions.
+///
+/// This enum provides a safe, side-effect-free canonical identifier used
+/// during AST-to-IR translation to group multiple regular expressions
+/// matching the exact same target expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum MatchTarget {
     FieldAccess(Vec<i32>),

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -164,16 +164,6 @@ pub struct Rules {
     /// in the source code, allowing them to be compiled into a unified
     /// set automata for single-pass evaluation.
     pub(in crate::compiler) regex_sets: FxHashMap<RegexSetId, Vec<RegexId>>,
-
-    /// Fast runtime mapping from an individual `RegexpId` to its grouped
-    /// set membership.
-    ///
-    /// The tuple holds the associated `RegexSetId` and the specific 0-based
-    /// index of this regular expression inside the compiled set. This allows
-    /// the scanner to instantly locate the cached short-circuiting boolean
-    /// match result without performing sequential evaluations.
-    pub(in crate::compiler) regexp_to_set:
-        FxHashMap<RegexId, (RegexSetId, usize)>,
 }
 
 impl Rules {
@@ -392,20 +382,6 @@ impl Rules {
             .unwrap_or_else(|err| {
                 panic!("error compiling RegexSet: {:#?}", err)
             })
-    }
-
-    /// Returns the number of patterns in a given RegexSet.
-    #[inline]
-    pub(crate) fn num_patterns_in_set(&self, set_id: RegexSetId) -> usize {
-        self.regex_sets.get(&set_id).unwrap().len()
-    }
-
-    /// Returns the mapping from RegexpId to its set membership and index.
-    #[inline]
-    pub(crate) fn regexp_to_set(
-        &self,
-    ) -> &FxHashMap<RegexId, (RegexSetId, usize)> {
-        &self.regexp_to_set
     }
 
     /// Returns a sub-pattern by [`SubPatternId`].

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -155,6 +155,12 @@ pub struct Rules {
     /// serialized rules won't have any warnings.
     #[serde(skip)]
     pub(in crate::compiler) warnings: Vec<Warning>,
+
+    /// Grouped RegexSet definitions. Keys are RegexSetId, values are lists of RegexpId.
+    pub(in crate::compiler) regex_sets: FxHashMap<crate::compiler::RegexSetId, Vec<crate::compiler::RegexpId>>,
+
+    /// Maps each grouped RegexpId to its set membership and index.
+    pub(in crate::compiler) regexp_to_set: FxHashMap<crate::compiler::RegexpId, (crate::compiler::RegexSetId, usize)>,
 }
 
 impl Rules {
@@ -348,6 +354,40 @@ impl Rules {
             .unwrap_or_else(|err| {
                 panic!("error compiling regex `{}`: {:#?}", re.as_str(), err)
             })
+    }
+
+    /// Returns a compiled multi-pattern `RegexSet` for a given `RegexSetId`.
+    #[inline]
+    pub(crate) fn get_regex_set(&self, set_id: crate::compiler::RegexSetId) -> regex::bytes::RegexSet {
+        let re_ids = self.regex_sets.get(&set_id).unwrap();
+        let mut patterns = Vec::with_capacity(re_ids.len());
+
+        for &re_id in re_ids {
+            let re = types::Regexp::new(self.regexp_pool.get(re_id).unwrap());
+            let parser = re::parser::Parser::new()
+                .relaxed_re_syntax(self.relaxed_re_syntax);
+            let hir = parser.parse(&re).unwrap().into_inner();
+            patterns.push(hir.to_string());
+        }
+
+        regex::bytes::RegexSetBuilder::new(patterns)
+            .size_limit(50 * 1024 * 1024)
+            .build()
+            .unwrap_or_else(|err| {
+                panic!("error compiling RegexSet: {:#?}", err)
+            })
+    }
+
+    /// Returns the number of patterns in a given RegexSet.
+    #[inline]
+    pub(crate) fn num_patterns_in_set(&self, set_id: crate::compiler::RegexSetId) -> usize {
+        self.regex_sets.get(&set_id).unwrap().len()
+    }
+
+    /// Returns the mapping from RegexpId to its set membership and index.
+    #[inline]
+    pub(crate) fn regexp_to_set(&self) -> &FxHashMap<crate::compiler::RegexpId, (crate::compiler::RegexSetId, usize)> {
+        &self.regexp_to_set
     }
 
     /// Returns a sub-pattern by [`SubPatternId`].

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -387,7 +387,7 @@ impl Rules {
         }
 
         regex::bytes::RegexSetBuilder::new(patterns)
-            .size_limit(50 * 1024 * 1024)
+            .size_limit(1024 * 1024 * 1024)
             .build()
             .unwrap_or_else(|err| {
                 panic!("error compiling RegexSet: {:#?}", err)

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -18,8 +18,8 @@ use crate::compiler::errors::SerializationError;
 use crate::compiler::report::CodeLoc;
 use crate::compiler::warnings::Warning;
 use crate::compiler::{
-    IdentId, Imports, LiteralId, NamespaceId, PatternId, RegexpId, RuleId,
-    SubPattern, SubPatternId,
+    IdentId, Imports, LiteralId, NamespaceId, PatternId, RegexId, RegexSetId,
+    RuleId, SubPattern, SubPatternId,
 };
 use crate::models::PatternKind;
 use crate::re::{BckCodeLoc, FwdCodeLoc, RegexpAtom};
@@ -56,10 +56,10 @@ pub struct Rules {
     pub(in crate::compiler) ident_pool: StringPool<IdentId>,
 
     /// Pool with the regular expressions used in the rules conditions. Each
-    /// regular expression has its own [`RegexpId`]. Regular expressions
+    /// regular expression has its own [`RegexId`]. Regular expressions
     /// include the starting and ending slashes (`/`), and the modifiers
     /// `i` and `s` if present (e.g: `/foobar/`, `/foo/i`, `/bar/s`).
-    pub(in crate::compiler) regexp_pool: StringPool<RegexpId>,
+    pub(in crate::compiler) regexp_pool: StringPool<RegexId>,
 
     /// If `true`, the regular expressions in `regexp_pool` are allowed to
     /// contain invalid escape sequences.
@@ -156,11 +156,24 @@ pub struct Rules {
     #[serde(skip)]
     pub(in crate::compiler) warnings: Vec<Warning>,
 
-    /// Grouped RegexSet definitions. Keys are RegexSetId, values are lists of RegexpId.
-    pub(in crate::compiler) regex_sets: FxHashMap<crate::compiler::RegexSetId, Vec<crate::compiler::RegexpId>>,
+    /// Grouped `RegexSet` persistent definitions.
+    ///
+    /// Populated during `Compiler::build`, each entry maps a unique
+    /// `RegexSetId` to an ordered list of `RegexpId`s. All regular
+    /// expressions in a given set match the exact same target expression
+    /// in the source code, allowing them to be compiled into a unified
+    /// set automata for single-pass evaluation.
+    pub(in crate::compiler) regex_sets: FxHashMap<RegexSetId, Vec<RegexId>>,
 
-    /// Maps each grouped RegexpId to its set membership and index.
-    pub(in crate::compiler) regexp_to_set: FxHashMap<crate::compiler::RegexpId, (crate::compiler::RegexSetId, usize)>,
+    /// Fast runtime mapping from an individual `RegexpId` to its grouped
+    /// set membership.
+    ///
+    /// The tuple holds the associated `RegexSetId` and the specific 0-based
+    /// index of this regular expression inside the compiled set. This allows
+    /// the scanner to instantly locate the cached short-circuiting boolean
+    /// match result without performing sequential evaluations.
+    pub(in crate::compiler) regexp_to_set:
+        FxHashMap<RegexId, (RegexSetId, usize)>,
 }
 
 impl Rules {
@@ -328,13 +341,13 @@ impl Rules {
         self.rules.get(rule_id.0 as usize).unwrap()
     }
 
-    /// Returns a regular expression by [`RegexpId`].
+    /// Returns a regular expression by [`RegexId`].
     ///
     /// # Panics
     ///
-    /// If no regular expression with such [`RegexpId`] exists.
+    /// If no regular expression with such [`RegexId`] exists.
     #[inline]
-    pub(crate) fn get_regexp(&self, regexp_id: RegexpId) -> Regex {
+    pub(crate) fn get_regexp(&self, regexp_id: RegexId) -> Regex {
         let re = types::Regexp::new(self.regexp_pool.get(regexp_id).unwrap());
 
         let parser = re::parser::Parser::new()
@@ -358,7 +371,10 @@ impl Rules {
 
     /// Returns a compiled multi-pattern `RegexSet` for a given `RegexSetId`.
     #[inline]
-    pub(crate) fn get_regex_set(&self, set_id: crate::compiler::RegexSetId) -> regex::bytes::RegexSet {
+    pub(crate) fn get_regex_set(
+        &self,
+        set_id: RegexSetId,
+    ) -> regex::bytes::RegexSet {
         let re_ids = self.regex_sets.get(&set_id).unwrap();
         let mut patterns = Vec::with_capacity(re_ids.len());
 
@@ -380,13 +396,15 @@ impl Rules {
 
     /// Returns the number of patterns in a given RegexSet.
     #[inline]
-    pub(crate) fn num_patterns_in_set(&self, set_id: crate::compiler::RegexSetId) -> usize {
+    pub(crate) fn num_patterns_in_set(&self, set_id: RegexSetId) -> usize {
         self.regex_sets.get(&set_id).unwrap().len()
     }
 
     /// Returns the mapping from RegexpId to its set membership and index.
     #[inline]
-    pub(crate) fn regexp_to_set(&self) -> &FxHashMap<crate::compiler::RegexpId, (crate::compiler::RegexSetId, usize)> {
+    pub(crate) fn regexp_to_set(
+        &self,
+    ) -> &FxHashMap<RegexId, (RegexSetId, usize)> {
         &self.regexp_to_set
     }
 

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -59,9 +59,9 @@ pub struct Rules {
     /// regular expression has its own [`RegexId`]. Regular expressions
     /// include the starting and ending slashes (`/`), and the modifiers
     /// `i` and `s` if present (e.g: `/foobar/`, `/foo/i`, `/bar/s`).
-    pub(in crate::compiler) regexp_pool: StringPool<RegexId>,
+    pub(in crate::compiler) regex_pool: StringPool<RegexId>,
 
-    /// If `true`, the regular expressions in `regexp_pool` are allowed to
+    /// If `true`, the regular expressions in `regex_pool` are allowed to
     /// contain invalid escape sequences.
     pub(in crate::compiler) relaxed_re_syntax: bool,
 
@@ -338,7 +338,7 @@ impl Rules {
     /// If no regular expression with such [`RegexId`] exists.
     #[inline]
     pub(crate) fn get_regexp(&self, regexp_id: RegexId) -> Regex {
-        let re = types::Regexp::new(self.regexp_pool.get(regexp_id).unwrap());
+        let re = types::Regexp::new(self.regex_pool.get(regexp_id).unwrap());
 
         let parser = re::parser::Parser::new()
             .relaxed_re_syntax(self.relaxed_re_syntax);
@@ -369,7 +369,7 @@ impl Rules {
         let mut patterns = Vec::with_capacity(re_ids.len());
 
         for &re_id in re_ids {
-            let re = types::Regexp::new(self.regexp_pool.get(re_id).unwrap());
+            let re = types::Regexp::new(self.regex_pool.get(re_id).unwrap());
             let parser = re::parser::Parser::new()
                 .relaxed_re_syntax(self.relaxed_re_syntax);
             let hir = parser.parse(&re).unwrap().into_inner();

--- a/lib/src/modules/cuckoo/mod.rs
+++ b/lib/src/modules/cuckoo/mod.rs
@@ -1,4 +1,4 @@
-use crate::compiler::RegexpId;
+use crate::compiler::RegexId;
 use crate::modules::prelude::*;
 use crate::modules::protos::cuckoo::*;
 
@@ -48,7 +48,7 @@ fn main(_data: &[u8], meta: Option<&[u8]>) -> Result<Cuckoo, ModuleError> {
 /// Returns true if the Cuckoo report contains a DNS lookup where the domain
 /// matches the given regular expression.
 #[module_export(name = "network.dns_lookup")]
-fn network_dns_lookup_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn network_dns_lookup_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -67,7 +67,7 @@ fn network_dns_lookup_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
 /// Returns true if the Cuckoo report contains an HTTP request (either, GET,
 /// or any other method) to some URI that matches the given regular expression.
 #[module_export(name = "network.http_request")]
-fn network_http_request_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn network_http_request_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -86,7 +86,7 @@ fn network_http_request_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
 /// Returns true if the Cuckoo report contains an HTTP GET request to some URI
 /// that matches the given regular expression.
 #[module_export(name = "network.http_get")]
-fn network_http_get_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn network_http_get_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -108,7 +108,7 @@ fn network_http_get_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
 /// Returns true if the Cuckoo report contains an HTTP POST request to some URI
 /// that matches the given regular expression.
 #[module_export(name = "network.http_post")]
-fn network_http_post_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn network_http_post_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -130,7 +130,7 @@ fn network_http_post_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
 /// Returns true if the Cuckoo report contains an HTTP where the User-Agent
 /// header matches the given regular expression.
 #[module_export(name = "network.http_user_agent")]
-fn network_http_user_agent_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn network_http_user_agent_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -150,7 +150,7 @@ fn network_http_user_agent_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
 /// destination `port` where the destination domain matches the given regular
 /// expression
 #[module_export(name = "network.tcp")]
-fn network_tcp_ri(ctx: &ScanContext, dst_re: RegexpId, port: i64) -> i64 {
+fn network_tcp_ri(ctx: &ScanContext, dst_re: RegexId, port: i64) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -176,7 +176,7 @@ fn network_tcp_ri(ctx: &ScanContext, dst_re: RegexpId, port: i64) -> i64 {
 /// destination `port` where the destination domain matches the given regular
 /// expression
 #[module_export(name = "network.udp")]
-fn network_udp_ri(ctx: &ScanContext, dst_re: RegexpId, port: i64) -> i64 {
+fn network_udp_ri(ctx: &ScanContext, dst_re: RegexId, port: i64) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -199,7 +199,7 @@ fn network_udp_ri(ctx: &ScanContext, dst_re: RegexpId, port: i64) -> i64 {
 /// Returns true if the Cuckoo report contains an HTTP request where the Host
 /// header matches the given regular expression.
 #[module_export(name = "network.host")]
-fn network_host_r(ctx: &ScanContext, re: RegexpId) -> i64 {
+fn network_host_r(ctx: &ScanContext, re: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.network.as_ref())
@@ -216,7 +216,7 @@ fn network_host_r(ctx: &ScanContext, re: RegexpId) -> i64 {
 /// Returns true if the Cuckoo contains some mutex operation where the name
 /// of the mutex matches the given regular expression.
 #[module_export(name = "sync.mutex")]
-fn sync_mutex_r(ctx: &ScanContext, mutex_re: RegexpId) -> i64 {
+fn sync_mutex_r(ctx: &ScanContext, mutex_re: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.behavior.as_ref())
@@ -235,7 +235,7 @@ fn sync_mutex_r(ctx: &ScanContext, mutex_re: RegexpId) -> i64 {
 /// Returns true if the Cuckoo contains some file access operation where the
 /// file path matches the given regular expression.
 #[module_export(name = "filesystem.file_access")]
-fn filesystem_file_access_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn filesystem_file_access_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.behavior.as_ref())
@@ -254,7 +254,7 @@ fn filesystem_file_access_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
 /// Returns true if the Cuckoo contains some registry access operation where
 /// the registry key matches the given regular expression.
 #[module_export(name = "registry.key_access")]
-fn registry_key_access_r(ctx: &ScanContext, regexp_id: RegexpId) -> i64 {
+fn registry_key_access_r(ctx: &ScanContext, regexp_id: RegexId) -> i64 {
     get_local()
         .as_ref()
         .and_then(|local| local.behavior.as_ref())

--- a/lib/src/modules/pe/mod.rs
+++ b/lib/src/modules/pe/mod.rs
@@ -16,7 +16,7 @@ use nom::character::complete::u8;
 use nom::combinator::map;
 use nom::number::complete::{le_u16, le_u32};
 
-use crate::compiler::RegexpId;
+use crate::compiler::RegexId;
 use crate::modules::prelude::*;
 use crate::modules::protos::pe::*;
 use crate::types::Struct;
@@ -321,7 +321,6 @@ fn rich_version(ctx: &mut ScanContext, version: i64) -> Option<i64> {
     rich_version_impl(ctx.module_output::<PE>()?, None, Some(version))
 }
 
-
 /// Returns the number of toolid records matching the given toolid and version.
 #[module_export(name = "rich_signature.version")]
 fn rich_version_toolid(
@@ -433,8 +432,8 @@ fn standard_imports_ordinal(
 #[module_export(name = "imports")]
 fn standard_imports_regexp(
     ctx: &ScanContext,
-    dll_name: RegexpId,
-    func_name: RegexpId,
+    dll_name: RegexId,
+    func_name: RegexId,
 ) -> Option<i64> {
     imports_impl(
         ctx,
@@ -519,8 +518,8 @@ fn imports_ordinal(
 fn imports_regexp(
     ctx: &ScanContext,
     import_flags: i64,
-    dll_name: RegexpId,
-    func_name: RegexpId,
+    dll_name: RegexId,
+    func_name: RegexId,
 ) -> Option<i64> {
     imports_impl(
         ctx,
@@ -620,7 +619,7 @@ fn exports_ordinal(ctx: &ScanContext, ordinal: i64) -> Option<bool> {
 /// Returns true if the PE file exports a function with a name that matches
 /// the given regular expression.
 #[module_export(name = "exports")]
-fn exports_regexp(ctx: &ScanContext, func_name: RegexpId) -> Option<bool> {
+fn exports_regexp(ctx: &ScanContext, func_name: RegexId) -> Option<bool> {
     let (found, _) = exports_impl(ctx, MatchCriteria::Regexp(func_name))?;
     Some(found)
 }
@@ -649,10 +648,7 @@ fn exports_index_ordinal(ctx: &ScanContext, ordinal: i64) -> Option<i64> {
 /// Returns true if the PE file exports a function with a name that matches
 /// the given regular expression.
 #[module_export(name = "exports_index")]
-fn exports_index_regexp(
-    ctx: &ScanContext,
-    func_name: RegexpId,
-) -> Option<i64> {
+fn exports_index_regexp(ctx: &ScanContext, func_name: RegexId) -> Option<i64> {
     match exports_impl(ctx, MatchCriteria::Regexp(func_name)) {
         Some((true, position)) => Some(position as i64),
         _ => None,
@@ -718,7 +714,7 @@ fn valid_on(
 
 enum MatchCriteria<'a> {
     Any,
-    Regexp(RegexpId),
+    Regexp(RegexId),
     Name(&'a BStr),
     Ordinal(i64),
 }

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -24,7 +24,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::compiler::{
-    NamespaceId, PatternId, RegexId, RuleId, Rules, SubPattern,
+    NamespaceId, PatternId, RegexId, RegexSetId, RuleId, Rules, SubPattern,
     SubPatternAtom, SubPatternFlags, SubPatternId,
 };
 use crate::errors::VariableError;
@@ -146,11 +146,11 @@ pub(crate) struct ScanContext<'r, 'd> {
     /// aborted due to a timeout.
     pub deadline: u64,
     /// Hash map that serves as a cache for regexps used in expressions like
-    /// `some_var matches /foobar/`. Compiling a regexp is a expensive
+    /// `some_var matches /foobar/`. Compiling a regexp is an expensive
     /// operation. Instead of compiling the regexp each time the expression
     /// is evaluated, it is compiled the first time and stored in this hash
     /// map.
-    pub regexp_cache: RefCell<FxHashMap<RegexId, Regex>>,
+    pub regex_cache: RefCell<FxHashMap<RegexId, Regex>>,
     /// Persistent cache for grouped `RegexSet` automata.
     ///
     /// Like individual regular expressions, compiling a multi-pattern
@@ -158,9 +158,8 @@ pub(crate) struct ScanContext<'r, 'd> {
     /// automata lazily upon the very first match request and preserves the
     /// compiled automata across all subsequent scans performed by the
     /// scanner instance.
-    pub regex_set_cache: RefCell<
-        FxHashMap<crate::compiler::RegexSetId, regex::bytes::RegexSet>,
-    >,
+    pub regex_set_cache:
+        RefCell<FxHashMap<RegexSetId, regex::bytes::RegexSet>>,
     /// Engines for custom base64 alphabets used by base64 string modifiers.
     ///
     /// These engines are derived from rule literals and reused across scans.
@@ -290,7 +289,7 @@ impl ScanContext<'_, '_> {
         regexp_id: RegexId,
         haystack: &[u8],
     ) -> bool {
-        self.regexp_cache
+        self.regex_cache
             .borrow_mut()
             .entry(regexp_id)
             .or_insert_with(|| self.compiled_rules.get_regexp(regexp_id))
@@ -1910,7 +1909,7 @@ pub fn create_wasm_store_and_ctx<'r>(
             compiled_rules: rules,
         },
         deadline: 0,
-        regexp_cache: RefCell::new(FxHashMap::default()),
+        regex_cache: RefCell::new(FxHashMap::default()),
         regex_set_cache: RefCell::new(FxHashMap::default()),
         vm: VM {
             pike_vm: PikeVM::new(rules.re_code()),

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -24,7 +24,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::compiler::{
-    NamespaceId, PatternId, RegexpId, RuleId, Rules, SubPattern,
+    NamespaceId, PatternId, RegexId, RuleId, Rules, SubPattern,
     SubPatternAtom, SubPatternFlags, SubPatternId,
 };
 use crate::errors::VariableError;
@@ -150,11 +150,30 @@ pub(crate) struct ScanContext<'r, 'd> {
     /// operation. Instead of compiling the regexp each time the expression
     /// is evaluated, it is compiled the first time and stored in this hash
     /// map.
-    pub regexp_cache: RefCell<FxHashMap<RegexpId, Regex>>,
-    /// Persistent cache for grouped RegexSet automata. Preserved across scans.
-    pub regex_set_cache: RefCell<FxHashMap<crate::compiler::RegexSetId, regex::bytes::RegexSet>>,
-    /// Scan-specific cache for evaluated RegexSet match results. Cleared on reset.
-    pub regex_set_results: RefCell<FxHashMap<crate::compiler::RegexSetId, Vec<bool>>>,
+    pub regexp_cache: RefCell<FxHashMap<RegexId, Regex>>,
+    /// Persistent cache for grouped `RegexSet` automata.
+    ///
+    /// Like individual regular expressions, compiling a multi-pattern
+    /// `RegexSet` is an expensive operation. This cache compiles the set
+    /// automata lazily upon the very first match request and preserves the
+    /// compiled automata across all subsequent scans performed by the
+    /// scanner instance.
+    pub regex_set_cache: RefCell<
+        FxHashMap<crate::compiler::RegexSetId, regex::bytes::RegexSet>,
+    >,
+
+    /// Scan-specific cache for evaluated `RegexSet` short-circuiting match
+    /// results.
+    ///
+    /// When the first regular expression belonging to a set is requested
+    /// during a scan, the entire set is matched simultaneously against the
+    /// current haystack. The matching pattern indices are recorded in this
+    /// boolean vector. Subsequent requests for other regular expressions in
+    /// the same set instantly read their result from this vector without
+    /// re-evaluating any string matching. This cache is completely cleared
+    /// on every call to `ScanContext::reset()`.
+    pub regex_set_results:
+        RefCell<FxHashMap<crate::compiler::RegexSetId, Vec<bool>>>,
     /// Engines for custom base64 alphabets used by base64 string modifiers.
     ///
     /// These engines are derived from rule literals and reused across scans.
@@ -277,29 +296,50 @@ impl ScanContext<'_, '_> {
         self.wasm.store_mut()
     }
 
-    /// Returns true of the regexp identified by the given [`RegexpId`]
-    /// matches `haystack`.
+    /// Returns true if the regular expression identified by the given
+    /// [`RegexId`] matches `haystack`.
+    ///
+    /// This method implements an advanced short-circuiting optimization
+    /// for grouped regular expressions:
+    /// 1. If the requested `RegexpId` belongs to a compiled `RegexSet`, it
+    ///    checks the scan-specific results cache.
+    /// 2. If the set has not been evaluated for the current scan yet, the
+    ///    entire multi-pattern automata is executed simultaneously against
+    ///    the haystack, and all matching indices are cached in an in-memory
+    ///    boolean vector.
+    /// 3. The specific boolean result for this regular expression is
+    ///    returned instantly from the cached vector.
+    /// 4. If the regular expression is not grouped, it falls back to
+    ///    standard individual execution and caching.
     pub(crate) fn regexp_matches(
         &self,
-        regexp_id: RegexpId,
+        regexp_id: RegexId,
         haystack: &[u8],
     ) -> bool {
-        if let Some(&(set_id, index_in_set)) = self.compiled_rules.regexp_to_set().get(&regexp_id) {
+        if let Some(&(set_id, index_in_set)) =
+            self.compiled_rules.regexp_to_set().get(&regexp_id)
+        {
             let mut results_cache = self.regex_set_results.borrow_mut();
 
-            let matched_bits = results_cache.entry(set_id).or_insert_with(|| {
-                let mut automata_cache = self.regex_set_cache.borrow_mut();
-                let regex_set = automata_cache.entry(set_id).or_insert_with(|| {
-                    self.compiled_rules.get_regex_set(set_id)
-                });
+            let matched_bits =
+                results_cache.entry(set_id).or_insert_with(|| {
+                    let mut automata_cache = self.regex_set_cache.borrow_mut();
+                    let regex_set =
+                        automata_cache.entry(set_id).or_insert_with(|| {
+                            self.compiled_rules.get_regex_set(set_id)
+                        });
 
-                let set_matches = regex_set.matches(haystack);
-                let mut bits = vec![false; self.compiled_rules.num_patterns_in_set(set_id)];
-                for m in set_matches.into_iter() {
-                    bits[m] = true;
-                }
-                bits
-            });
+                    let set_matches = regex_set.matches(haystack);
+                    let mut bits = vec![
+                        false;
+                        self.compiled_rules
+                            .num_patterns_in_set(set_id)
+                    ];
+                    for m in set_matches.into_iter() {
+                        bits[m] = true;
+                    }
+                    bits
+                });
 
             return matched_bits[index_in_set];
         }

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -151,6 +151,10 @@ pub(crate) struct ScanContext<'r, 'd> {
     /// is evaluated, it is compiled the first time and stored in this hash
     /// map.
     pub regexp_cache: RefCell<FxHashMap<RegexpId, Regex>>,
+    /// Persistent cache for grouped RegexSet automata. Preserved across scans.
+    pub regex_set_cache: RefCell<FxHashMap<crate::compiler::RegexSetId, regex::bytes::RegexSet>>,
+    /// Scan-specific cache for evaluated RegexSet match results. Cleared on reset.
+    pub regex_set_results: RefCell<FxHashMap<crate::compiler::RegexSetId, Vec<bool>>>,
     /// Engines for custom base64 alphabets used by base64 string modifiers.
     ///
     /// These engines are derived from rule literals and reused across scans.
@@ -280,6 +284,26 @@ impl ScanContext<'_, '_> {
         regexp_id: RegexpId,
         haystack: &[u8],
     ) -> bool {
+        if let Some(&(set_id, index_in_set)) = self.compiled_rules.regexp_to_set().get(&regexp_id) {
+            let mut results_cache = self.regex_set_results.borrow_mut();
+
+            let matched_bits = results_cache.entry(set_id).or_insert_with(|| {
+                let mut automata_cache = self.regex_set_cache.borrow_mut();
+                let regex_set = automata_cache.entry(set_id).or_insert_with(|| {
+                    self.compiled_rules.get_regex_set(set_id)
+                });
+
+                let set_matches = regex_set.matches(haystack);
+                let mut bits = vec![false; self.compiled_rules.num_patterns_in_set(set_id)];
+                for m in set_matches.into_iter() {
+                    bits[m] = true;
+                }
+                bits
+            });
+
+            return matched_bits[index_in_set];
+        }
+
         self.regexp_cache
             .borrow_mut()
             .entry(regexp_id)
@@ -511,6 +535,7 @@ impl ScanContext<'_, '_> {
         let num_patterns = self.compiled_rules.num_patterns();
 
         self.scan_state = ScanState::Idle;
+        self.regex_set_results.borrow_mut().clear();
 
         // Free all runtime objects left around by previous scans.
         self.runtime_objects.clear();
@@ -1887,6 +1912,8 @@ pub fn create_wasm_store_and_ctx<'r>(
         },
         deadline: 0,
         regexp_cache: RefCell::new(FxHashMap::default()),
+        regex_set_cache: RefCell::new(FxHashMap::default()),
+        regex_set_results: RefCell::new(FxHashMap::default()),
         vm: VM {
             pike_vm: PikeVM::new(rules.re_code()),
             fast_vm: FastVM::new(rules.re_code()),

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -161,19 +161,6 @@ pub(crate) struct ScanContext<'r, 'd> {
     pub regex_set_cache: RefCell<
         FxHashMap<crate::compiler::RegexSetId, regex::bytes::RegexSet>,
     >,
-
-    /// Scan-specific cache for evaluated `RegexSet` short-circuiting match
-    /// results.
-    ///
-    /// When the first regular expression belonging to a set is requested
-    /// during a scan, the entire set is matched simultaneously against the
-    /// current haystack. The matching pattern indices are recorded in this
-    /// boolean vector. Subsequent requests for other regular expressions in
-    /// the same set instantly read their result from this vector without
-    /// re-evaluating any string matching. This cache is completely cleared
-    /// on every call to `ScanContext::reset()`.
-    pub regex_set_results:
-        RefCell<FxHashMap<crate::compiler::RegexSetId, Vec<bool>>>,
     /// Engines for custom base64 alphabets used by base64 string modifiers.
     ///
     /// These engines are derived from rule literals and reused across scans.
@@ -298,57 +285,30 @@ impl ScanContext<'_, '_> {
 
     /// Returns true if the regular expression identified by the given
     /// [`RegexId`] matches `haystack`.
-    ///
-    /// This method implements an advanced short-circuiting optimization
-    /// for grouped regular expressions:
-    /// 1. If the requested `RegexpId` belongs to a compiled `RegexSet`, it
-    ///    checks the scan-specific results cache.
-    /// 2. If the set has not been evaluated for the current scan yet, the
-    ///    entire multi-pattern automata is executed simultaneously against
-    ///    the haystack, and all matching indices are cached in an in-memory
-    ///    boolean vector.
-    /// 3. The specific boolean result for this regular expression is
-    ///    returned instantly from the cached vector.
-    /// 4. If the regular expression is not grouped, it falls back to
-    ///    standard individual execution and caching.
     pub(crate) fn regexp_matches(
         &self,
         regexp_id: RegexId,
         haystack: &[u8],
     ) -> bool {
-        if let Some(&(set_id, index_in_set)) =
-            self.compiled_rules.regexp_to_set().get(&regexp_id)
-        {
-            let mut results_cache = self.regex_set_results.borrow_mut();
-
-            let matched_bits =
-                results_cache.entry(set_id).or_insert_with(|| {
-                    let mut automata_cache = self.regex_set_cache.borrow_mut();
-                    let regex_set =
-                        automata_cache.entry(set_id).or_insert_with(|| {
-                            self.compiled_rules.get_regex_set(set_id)
-                        });
-
-                    let set_matches = regex_set.matches(haystack);
-                    let mut bits = vec![
-                        false;
-                        self.compiled_rules
-                            .num_patterns_in_set(set_id)
-                    ];
-                    for m in set_matches.into_iter() {
-                        bits[m] = true;
-                    }
-                    bits
-                });
-
-            return matched_bits[index_in_set];
-        }
-
         self.regexp_cache
             .borrow_mut()
             .entry(regexp_id)
             .or_insert_with(|| self.compiled_rules.get_regexp(regexp_id))
             .is_match(haystack)
+    }
+
+    /// Returns true if any regular expression belonging to the given
+    /// [`RegexSetId`] matches `haystack`.
+    pub(crate) fn regex_set_matches(
+        &self,
+        set_id: crate::compiler::RegexSetId,
+        haystack: &[u8],
+    ) -> bool {
+        let mut automata_cache = self.regex_set_cache.borrow_mut();
+        let regex_set = automata_cache
+            .entry(set_id)
+            .or_insert_with(|| self.compiled_rules.get_regex_set(set_id));
+        regex_set.is_match(haystack)
     }
 
     /// Returns the protobuf struct produced by a module.
@@ -575,7 +535,6 @@ impl ScanContext<'_, '_> {
         let num_patterns = self.compiled_rules.num_patterns();
 
         self.scan_state = ScanState::Idle;
-        self.regex_set_results.borrow_mut().clear();
 
         // Free all runtime objects left around by previous scans.
         self.runtime_objects.clear();
@@ -1953,7 +1912,6 @@ pub fn create_wasm_store_and_ctx<'r>(
         deadline: 0,
         regexp_cache: RefCell::new(FxHashMap::default()),
         regex_set_cache: RefCell::new(FxHashMap::default()),
-        regex_set_results: RefCell::new(FxHashMap::default()),
         vm: VM {
             pike_vm: PikeVM::new(rules.re_code()),
             fast_vm: FastVM::new(rules.re_code()),

--- a/lib/src/scanner/tests.rs
+++ b/lib/src/scanner/tests.rs
@@ -927,3 +927,30 @@ fn max_scan_size() {
         0
     );
 }
+
+#[cfg(feature = "test_proto2-module")]
+#[test]
+fn regex_set_optimization() {
+    let rules = crate::compile(
+        r#"
+        import "test_proto2"
+        rule test {
+            condition:
+                test_proto2.string_foo matches /foo/ and
+                test_proto2.string_foo matches /bar/
+        }
+        rule test_match {
+            condition:
+                test_proto2.string_foo matches /foo/ or
+                test_proto2.string_foo matches /bar/
+        }
+        "#,
+    )
+    .unwrap();
+
+    let mut scanner = crate::Scanner::new(&rules);
+    let results = scanner.scan(b"").unwrap();
+
+    let matching_rules: Vec<_> = results.matching_rules().map(|r| r.identifier().to_string()).collect();
+    assert_eq!(matching_rules, vec!["test_match"]);
+}

--- a/lib/src/scanner/tests.rs
+++ b/lib/src/scanner/tests.rs
@@ -951,6 +951,7 @@ fn regex_set_optimization() {
     let mut scanner = crate::Scanner::new(&rules);
     let results = scanner.scan(b"").unwrap();
 
-    let matching_rules: Vec<_> = results.matching_rules().map(|r| r.identifier().to_string()).collect();
+    let matching_rules: Vec<_> =
+        results.matching_rules().map(|r| r.identifier().to_string()).collect();
     assert_eq!(matching_rules, vec!["test_match"]);
 }

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -89,7 +89,7 @@ use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec};
 use yara_x_macros::wasm_export;
 
-use crate::compiler::{LiteralId, PatternId, RegexpId, RuleId};
+use crate::compiler::{LiteralId, PatternId, RegexId, RuleId};
 use crate::modules::BUILTIN_MODULES;
 use crate::scanner::{RuntimeObjectHandle, ScanContext};
 use crate::types::{
@@ -354,10 +354,10 @@ impl WasmArg<LiteralId> for ValRaw {
     }
 }
 
-impl WasmArg<RegexpId> for ValRaw {
+impl WasmArg<RegexId> for ValRaw {
     #[inline]
-    fn raw_into(self, _: &mut ScanContext) -> RegexpId {
-        RegexpId::from(self.get_i32())
+    fn raw_into(self, _: &mut ScanContext) -> RegexId {
+        RegexId::from(self.get_i32())
     }
 }
 
@@ -604,7 +604,7 @@ fn type_id_to_wasmtime(
         return &[ValType::I32];
     } else if type_id == TypeId::of::<RuleId>() {
         return &[ValType::I32];
-    } else if type_id == TypeId::of::<RegexpId>() {
+    } else if type_id == TypeId::of::<RegexId>() {
         return &[ValType::I32];
     } else if type_id == TypeId::of::<()>() {
         return &[];
@@ -1623,7 +1623,7 @@ pub(crate) fn str_len(
 pub(crate) fn str_matches(
     caller: &mut Caller<'_, ScanContext>,
     lhs: RuntimeString,
-    rhs: RegexpId,
+    rhs: RegexId,
 ) -> bool {
     let ctx = caller.data();
     ctx.regexp_matches(rhs, lhs.as_bstr(ctx))

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -1629,6 +1629,19 @@ pub(crate) fn str_matches(
     ctx.regexp_matches(rhs, lhs.as_bstr(ctx))
 }
 
+#[wasm_export(sync = "none")]
+pub(crate) fn str_matches_regex_set(
+    caller: &mut Caller<'_, ScanContext>,
+    lhs: RuntimeString,
+    regex_set: i32,
+) -> bool {
+    let ctx = caller.data();
+    ctx.regex_set_matches(
+        crate::compiler::RegexSetId::from(regex_set),
+        lhs.as_bstr(ctx),
+    )
+}
+
 macro_rules! gen_int_fn {
     ($name:ident, $return_type:ty, $from_fn:ident, $min:expr, $max:expr) => {
         #[wasm_export(public = true, sync = "none")]

--- a/macros/src/wasm_export.rs
+++ b/macros/src/wasm_export.rs
@@ -76,7 +76,7 @@ impl<'ast> FuncSignatureParser<'ast> {
             "bool" => Ok(Cow::Borrowed("b")),
 
             "PatternId" | "RuleId" => Ok(Cow::Borrowed("i")),
-            "RegexpId" => Ok(Cow::Borrowed("r")),
+            "RegexId" => Ok(Cow::Borrowed("r")),
             "Rc" => Ok(Cow::Borrowed("i")),
             "RuntimeObjectHandle" => Ok(Cow::Borrowed("i")),
             "RuntimeString" => Ok(Cow::Borrowed("s")),


### PR DESCRIPTION
When writing complex YARA rules, it is incredibly common to evaluate a single variable or structure field access (e.g., `vt.net.domain.raw`) against dozens of distinct regular expressions within an or condition. Previously, YARA-X evaluated each of these match operations sequentially.

This PR introduces an advanced compile-time and runtime optimization that detects identical match targets within `or` conditions, groups their regular expressions into a single multi-pattern `RegexSet`, and evaluates the entire set simultaneously in a single pass.
