### PR TITLE
perf: share compiled RegexSet cache across scanners

### DIFF
--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -814,6 +814,7 @@ impl<'a> Compiler<'a> {
             warnings: self.warnings.into(),
             filesize_bounds: self.filesize_bounds,
             regex_sets: self.regex_sets,
+            compiled_regex_sets: Default::default(),
             fast_scan_patterns: self.fast_scan_patterns,
         };
 

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -818,6 +818,7 @@ impl<'a> Compiler<'a> {
             fast_scan_patterns: self.fast_scan_patterns,
         };
 
+        rules.init_regex_set_cache();
         rules.build_ac_automaton();
         rules
     }

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io::{BufWriter, Read, Write};
 use std::ops::{Bound, RangeBounds};
 use std::slice::Iter;
+use std::sync::OnceLock;
 #[cfg(feature = "logging")]
 use std::time::Instant;
 
@@ -164,6 +165,16 @@ pub struct Rules {
     /// in the source code, allowing them to be compiled into a unified
     /// set automata for single-pass evaluation.
     pub(in crate::compiler) regex_sets: FxHashMap<RegexSetId, Vec<RegexId>>,
+
+    /// Lazily compiled `RegexSet` automata shared by all scanners using these
+    /// rules.
+    ///
+    /// The definitions in `regex_sets` are serialized with the rules, but the
+    /// compiled automata are runtime-only. Sharing this cache at the `Rules`
+    /// level avoids rebuilding the same `RegexSet` once per scanner/thread.
+    #[serde(skip)]
+    pub(in crate::compiler) compiled_regex_sets:
+        OnceLock<FxHashMap<RegexSetId, OnceLock<regex::bytes::RegexSet>>>,
 
     /// BitVec where the N-th bit indicates whether the pattern with
     /// PatternId = N is a fast-scan pattern.
@@ -375,7 +386,25 @@ impl Rules {
     pub(crate) fn get_regex_set(
         &self,
         set_id: RegexSetId,
-    ) -> regex::bytes::RegexSet {
+    ) -> &regex::bytes::RegexSet {
+        let compiled_regex_sets = self.compiled_regex_sets.get_or_init(|| {
+            let mut regex_sets = FxHashMap::default();
+            regex_sets.reserve(self.regex_sets.len());
+            for &set_id in self.regex_sets.keys() {
+                regex_sets.insert(set_id, OnceLock::new());
+            }
+            regex_sets
+        });
+
+        let regex_set = compiled_regex_sets
+            .get(&set_id)
+            .unwrap_or_else(|| panic!("invalid RegexSetId: {set_id:?}"));
+
+        regex_set.get_or_init(|| self.build_regex_set(set_id))
+    }
+
+    /// Builds the `RegexSet` automaton for a given [`RegexSetId`].
+    fn build_regex_set(&self, set_id: RegexSetId) -> regex::bytes::RegexSet {
         let re_ids = self.regex_sets.get(&set_id).unwrap();
         let mut patterns = Vec::with_capacity(re_ids.len());
 

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -170,11 +170,12 @@ pub struct Rules {
     /// rules.
     ///
     /// The definitions in `regex_sets` are serialized with the rules, but the
-    /// compiled automata are runtime-only. Sharing this cache at the `Rules`
-    /// level avoids rebuilding the same `RegexSet` once per scanner/thread.
+    /// compiled automata are runtime-only. The vector is initialized when the
+    /// [`Rules`] are built or deserialized, while each individual `RegexSet`
+    /// is compiled lazily on first use.
     #[serde(skip)]
     pub(in crate::compiler) compiled_regex_sets:
-        OnceLock<FxHashMap<RegexSetId, OnceLock<regex::bytes::RegexSet>>>,
+        Vec<OnceLock<regex::bytes::RegexSet>>,
 
     /// BitVec where the N-th bit indicates whether the pattern with
     /// PatternId = N is a fast-scan pattern.
@@ -279,6 +280,7 @@ impl Rules {
             info!("WASM build time: {:?}", Instant::elapsed(&start));
         }
 
+        rules.init_regex_set_cache();
         rules.build_ac_automaton();
 
         Ok(rules)
@@ -381,23 +383,21 @@ impl Rules {
             })
     }
 
+    /// Initializes the runtime-only cache for compiled `RegexSet` automata.
+    pub(in crate::compiler) fn init_regex_set_cache(&mut self) {
+        self.compiled_regex_sets =
+            (0..self.regex_sets.len()).map(|_| OnceLock::new()).collect();
+    }
+
     /// Returns a compiled multi-pattern `RegexSet` for a given `RegexSetId`.
     #[inline]
     pub(crate) fn get_regex_set(
         &self,
         set_id: RegexSetId,
     ) -> &regex::bytes::RegexSet {
-        let compiled_regex_sets = self.compiled_regex_sets.get_or_init(|| {
-            let mut regex_sets = FxHashMap::default();
-            regex_sets.reserve(self.regex_sets.len());
-            for &set_id in self.regex_sets.keys() {
-                regex_sets.insert(set_id, OnceLock::new());
-            }
-            regex_sets
-        });
-
-        let regex_set = compiled_regex_sets
-            .get(&set_id)
+        let regex_set = self
+            .compiled_regex_sets
+            .get(usize::from(set_id))
             .unwrap_or_else(|| panic!("invalid RegexSetId: {set_id:?}"));
 
         regex_set.get_or_init(|| self.build_regex_set(set_id))

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -24,7 +24,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::compiler::{
-    NamespaceId, PatternId, RegexId, RegexSetId, RuleId, Rules, SubPattern,
+    NamespaceId, PatternId, RegexId, RuleId, Rules, SubPattern,
     SubPatternAtom, SubPatternFlags, SubPatternId,
 };
 use crate::errors::VariableError;
@@ -153,15 +153,6 @@ pub struct ScanContext<'r, 'd> {
     /// is evaluated, it is compiled the first time and stored in this hash
     /// map.
     pub(crate) regex_cache: RefCell<FxHashMap<RegexId, Regex>>,
-    /// Persistent cache for grouped `RegexSet` automata.
-    ///
-    /// Like individual regular expressions, compiling a multi-pattern
-    /// `RegexSet` is an expensive operation. This cache compiles the set
-    /// automata lazily upon the very first match request and preserves the
-    /// compiled automata across all subsequent scans performed by the
-    /// scanner instance.
-    pub(crate) regex_set_cache:
-        RefCell<FxHashMap<RegexSetId, regex::bytes::RegexSet>>,
     /// Engines for custom base64 alphabets used by base64 string modifiers.
     ///
     /// These engines are derived from rule literals and reused across scans.
@@ -306,11 +297,7 @@ impl ScanContext<'_, '_> {
         set_id: crate::compiler::RegexSetId,
         haystack: &[u8],
     ) -> bool {
-        let mut automata_cache = self.regex_set_cache.borrow_mut();
-        let regex_set = automata_cache
-            .entry(set_id)
-            .or_insert_with(|| self.compiled_rules.get_regex_set(set_id));
-        regex_set.is_match(haystack)
+        self.compiled_rules.get_regex_set(set_id).is_match(haystack)
     }
 
     /// Returns the protobuf struct produced by a module.
@@ -1919,7 +1906,6 @@ pub fn create_wasm_store_and_ctx<'r>(
         },
         deadline: 0,
         regex_cache: RefCell::new(FxHashMap::default()),
-        regex_set_cache: RefCell::new(FxHashMap::default()),
         vm: VM {
             pike_vm: PikeVM::new(rules.re_code()),
             fast_vm: FastVM::new(rules.re_code()),


### PR DESCRIPTION
# Optimize RegexSet Compilation and Reuse Across Scanners

## Overview

This PR improves the lifecycle management of `RegexSet` compilation by moving compiled automata from scanner-local caches to a shared cache associated with `Rules`.

Previously, `RegexSet` instances were lazily compiled inside each `Scanner` through `ScanContext::regex_set_matches()`. While this avoided unnecessary upfront work, it introduced duplicated compilation costs when multiple scanners operated on the same ruleset.

## Previous Behavior

When a `RegexSet` was first used during scanning:

1. The scanner-local cache was checked.
2. If absent, `CompiledRules::get_regex_set()` was invoked.
3. Each regex belonging to the set was reconstructed.
4. The regex was parsed into HIR.
5. The HIR was converted back into a string representation.
6. `regex::bytes::RegexSetBuilder` reparsed those strings and built a new automaton.

This workflow resulted in:

* First-scan latency spikes.
* Duplicate `RegexSet` compilation across scanners.
* Redundant automata construction in multi-threaded CLI workloads.
* Additional allocations and parsing overhead caused by the HIR → string → parse cycle.

## New Approach

Compiled `RegexSet` instances are now stored at the `Rules` level and shared across scanners.

Conceptually:

```rust
struct Rules {
    regex_sets: FxHashMap<RegexSetId, Vec<RegexId>>,
    compiled_regex_sets: Vec<OnceLock<Arc<regex::bytes::RegexSet>>>,
}
```

The first scanner requesting a given `RegexSet` performs the compilation and stores the result in a shared cache. Subsequent scanners reuse the already-built automaton through an `Arc`, eliminating redundant compilation work.

## Benefits

### Reduced Cold-Scan Latency

The first file that triggers a grouped regex no longer incurs repeated compilation costs across scanners.

### Shared Automata Across Threads

Parallel scans executed by the CLI can reuse the same compiled `RegexSet` instead of rebuilding identical automata in multiple workers.

### Lower CPU Consumption

Compilation is performed once per ruleset rather than once per scanner instance.

### Better Scalability for Long-Lived Services

Applications that create multiple scanners from the same `Rules` object benefit from improved reuse and lower memory churn.

## Future Opportunities

This change lays the groundwork for additional optimizations around regex compilation.

A remaining source of overhead is the current workflow:

```rust
HIR -> String -> RegexSetBuilder -> Parse Again
```

Future work could explore direct construction of grouped automata from HIR representations, similar to how individual regexes can be compiled through:

```rust
regex_automata::meta::Builder::build_from_hir(...)
```

Avoiding reparsing would further reduce allocations and compilation overhead for large regex groups.

## Expected Impact

Workloads with:

* Large rule sets
* Heavy usage of grouped `matches`
* Parallel CLI scanning
* Multiple scanners sharing the same rules

should observe lower startup overhead, reduced CPU utilization, and improved scan throughput due to more efficient automata reuse.