### PR TITLE
fix: stack overflow when compiling rules if YARA-X uses `musl`

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -104,7 +104,7 @@ parallel-compilation = ["wasmtime/parallel-compilation"]
 # compiled directly to native host machine instructions at runtime. This yields
 # maximum execution performance but requires executable memory pages (which may
 # be restricted in sandbox/secure environments) and is limited to architectures
-#natively supported by Cranelift.
+# natively supported by Cranelift.
 #
 # Enabling the `pulley` feature tells wasmtime to interpret the conditions using
 # the portable Pulley bytecode instruction virtual machine instead. This 

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -621,9 +621,7 @@ where
 {
     let bytes: Option<&[u8]> = Deserialize::deserialize(deserializer)?;
     let module = if let Some(bytes) = bytes {
-        unsafe {
-            wasm::runtime::Module::deserialize(wasm::get_engine(), bytes).ok()
-        }
+        wasm::runtime::Module::deserialize(wasm::get_engine(), bytes).ok()
     } else {
         None
     };

--- a/lib/src/wasm/runtime/common.rs
+++ b/lib/src/wasm/runtime/common.rs
@@ -793,7 +793,7 @@ impl<B: RuntimeBackend> Module<B> {
     ///
     /// Custom runtimes simply rebuild the module from raw WASM bytes, while
     /// the native runtime preserves Wasmtime's unsafe deserialization API.
-    pub unsafe fn deserialize(engine: &Engine, bytes: &[u8]) -> Result<Self> {
+    pub fn deserialize(engine: &Engine, bytes: &[u8]) -> Result<Self> {
         Self::from_binary(engine, bytes)
     }
 }

--- a/lib/src/wasm/runtime/native.rs
+++ b/lib/src/wasm/runtime/native.rs
@@ -10,9 +10,54 @@ pub use wasmtime::Caller;
 /// Wasmtime types re-exported by the native runtime.
 pub(crate) use wasmtime::{
     AsContext, AsContextMut, Config, Engine, Extern, FuncType, Global,
-    GlobalType, Instance, Memory, MemoryType, Module, Mutability, OptLevel,
+    GlobalType, Instance, Memory, MemoryType, Mutability, OptLevel,
     Store, TypedFunc, Val, ValRaw, ValType,
 };
+
+#[derive(Clone)]
+pub(crate) struct Module(pub(crate) wasmtime::Module);
+
+impl Module {
+    pub fn from_binary(
+        engine: &wasmtime::Engine,
+        binary: &[u8],
+    ) -> wasmtime::Result<Self> {
+        let binary = binary.to_vec();
+        let engine = engine.clone();
+        std::thread::Builder::new()
+            .name("yara-x-wasm-compiler".to_string())
+            .stack_size(8 * 1024 * 1024) // 8MB stack size
+            .spawn(move || {
+                wasmtime::Module::from_binary(&engine, &binary).map(Module)
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    pub unsafe fn deserialize(
+        engine: &wasmtime::Engine,
+        bytes: impl AsRef<[u8]>,
+    ) -> wasmtime::Result<Self> {
+        let bytes = bytes.as_ref().to_vec();
+        let engine = engine.clone();
+        std::thread::Builder::new()
+            .name("yara-x-wasm-deserializer".to_string())
+            .stack_size(8 * 1024 * 1024) // 8MB stack size
+            .spawn(move || {
+                unsafe {
+                    wasmtime::Module::deserialize(&engine, &bytes).map(Module)
+                }
+            })
+            .unwrap()
+            .join()
+            .unwrap()
+    }
+
+    pub fn serialize(&self) -> wasmtime::Result<Vec<u8>> {
+        self.0.serialize()
+    }
+}
 
 /// Thin wrapper around [`wasmtime::Linker`] with a backend-neutral API.
 pub(crate) struct Linker<T>(wasmtime::Linker<T>);
@@ -80,7 +125,7 @@ impl<T: 'static> Linker<T> {
         module: &Module,
     ) -> Result<Instance, SerializationError> {
         self.0
-            .instantiate(store, module)
+            .instantiate(store, &module.0)
             .map_err(|e| SerializationError::InvalidWASM(anyhow!(e)))
     }
 }

--- a/lib/src/wasm/runtime/native.rs
+++ b/lib/src/wasm/runtime/native.rs
@@ -3,10 +3,13 @@
 //! This adapter exists only to normalize a couple of APIs so the rest of the
 //! crate can talk to native and custom runtimes through the same interface.
 
+use std::mem::transmute;
+
 use crate::errors::SerializationError;
 use anyhow::anyhow;
-use std::mem::transmute;
+
 pub use wasmtime::Caller;
+
 /// Wasmtime types re-exported by the native runtime.
 pub(crate) use wasmtime::{
     AsContext, AsContextMut, Config, Engine, Extern, FuncType, Global,
@@ -15,43 +18,34 @@ pub(crate) use wasmtime::{
 };
 
 #[derive(Clone)]
-pub(crate) struct Module(pub(crate) wasmtime::Module);
+pub(crate) struct Module(wasmtime::Module);
 
 impl Module {
     pub fn from_binary(
-        engine: &wasmtime::Engine,
+        engine: &Engine,
         binary: &[u8],
     ) -> wasmtime::Result<Self> {
-        let binary = binary.to_vec();
-        let engine = engine.clone();
-        std::thread::Builder::new()
-            .name("yara-x-wasm-compiler".to_string())
-            .stack_size(8 * 1024 * 1024) // 8MB stack size
-            .spawn(move || {
-                wasmtime::Module::from_binary(&engine, &binary).map(Module)
-            })
-            .unwrap()
-            .join()
-            .unwrap()
+        std::thread::scope(|s| {
+            std::thread::Builder::new()
+                .name("yara-x-wasm-compiler".to_string())
+                .stack_size(8 * 1024 * 1024) // 8MB stack size
+                .spawn_scoped(s, || {
+                    wasmtime::Module::from_binary(engine, binary).map(Module)
+                })
+                .unwrap()
+                .join()
+                .unwrap()
+        })
     }
 
-    pub unsafe fn deserialize(
-        engine: &wasmtime::Engine,
+    pub fn deserialize(
+        engine: &Engine,
         bytes: impl AsRef<[u8]>,
     ) -> wasmtime::Result<Self> {
-        let bytes = bytes.as_ref().to_vec();
-        let engine = engine.clone();
-        std::thread::Builder::new()
-            .name("yara-x-wasm-deserializer".to_string())
-            .stack_size(8 * 1024 * 1024) // 8MB stack size
-            .spawn(move || unsafe {
-                wasmtime::Module::deserialize(&engine, &bytes).map(Module)
-            })
-            .unwrap()
-            .join()
-            .unwrap()
+        unsafe { wasmtime::Module::deserialize(engine, bytes).map(Module) }
     }
 
+    #[allow(dead_code)]
     pub fn serialize(&self) -> wasmtime::Result<Vec<u8>> {
         self.0.serialize()
     }
@@ -71,7 +65,7 @@ pub(crate) type TrampolineResult = wasmtime::Result<()>;
 
 impl<T: 'static> Linker<T> {
     /// Creates a new linker.
-    pub fn new(engine: &Engine) -> Self {
+    pub fn new(engine: &wasmtime::Engine) -> Self {
         Self(wasmtime::Linker::new(engine))
     }
 

--- a/lib/src/wasm/runtime/native.rs
+++ b/lib/src/wasm/runtime/native.rs
@@ -25,17 +25,27 @@ impl Module {
         engine: &Engine,
         binary: &[u8],
     ) -> wasmtime::Result<Self> {
-        std::thread::scope(|s| {
-            std::thread::Builder::new()
-                .name("yara-x-wasm-compiler".to_string())
-                .stack_size(8 * 1024 * 1024) // 8MB stack size
-                .spawn_scoped(s, || {
-                    wasmtime::Module::from_binary(engine, binary).map(Module)
-                })
-                .unwrap()
-                .join()
-                .unwrap()
-        })
+        if cfg!(target_env = "musl") {
+            // Under musl, the default stack size for threads can be very small
+            // (typically 128 KB), which is insufficient for the deep call stacks
+            // required by Wasmtime/Cranelift during WebAssembly compilation.
+            // To avoid stack overflow crashes, we compile the WebAssembly module
+            // in a separate thread with a guaranteed 8 MB stack size.
+            std::thread::scope(|s| {
+                std::thread::Builder::new()
+                    .name("yara-x-wasm-compiler".to_string())
+                    .stack_size(8 * 1024 * 1024) // 8MB stack size
+                    .spawn_scoped(s, || {
+                        wasmtime::Module::from_binary(engine, binary)
+                            .map(Module)
+                    })
+                    .unwrap()
+                    .join()
+                    .unwrap()
+            })
+        } else {
+            wasmtime::Module::from_binary(engine, binary).map(Module)
+        }
     }
 
     pub fn deserialize(

--- a/lib/src/wasm/runtime/native.rs
+++ b/lib/src/wasm/runtime/native.rs
@@ -10,8 +10,8 @@ pub use wasmtime::Caller;
 /// Wasmtime types re-exported by the native runtime.
 pub(crate) use wasmtime::{
     AsContext, AsContextMut, Config, Engine, Extern, FuncType, Global,
-    GlobalType, Instance, Memory, MemoryType, Mutability, OptLevel,
-    Store, TypedFunc, Val, ValRaw, ValType,
+    GlobalType, Instance, Memory, MemoryType, Mutability, OptLevel, Store,
+    TypedFunc, Val, ValRaw, ValType,
 };
 
 #[derive(Clone)]
@@ -44,10 +44,8 @@ impl Module {
         std::thread::Builder::new()
             .name("yara-x-wasm-deserializer".to_string())
             .stack_size(8 * 1024 * 1024) // 8MB stack size
-            .spawn(move || {
-                unsafe {
-                    wasmtime::Module::deserialize(&engine, &bytes).map(Module)
-                }
+            .spawn(move || unsafe {
+                wasmtime::Module::deserialize(&engine, &bytes).map(Module)
             })
             .unwrap()
             .join()


### PR DESCRIPTION
When using `musl` instead of `glibc`, the default stack size for threads can be very small (typically 128 KB), which is insufficient for the deep call stacks required by Wasmtime/Cranelift during WebAssembly compilation. To avoid stack overflow crashes, we compile the WebAssembly module in a separate thread with a guaranteed 8 MB stack size.