### PR TITLE
fix: rename binary release archives from `.gz` to `.tar.gz`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
                ./target/${{ matrix.target }}/release-lto/yara_x_capi.dll.lib \
                ./target/${{ matrix.target }}/release-lto/yara_x_capi.dll
         else
-            tar czf $pkgname.gz -C target/${{ matrix.target }}/release-lto yr      
+            tar czf $pkgname.tar.gz -C target/${{ matrix.target }}/release-lto yr
         fi
 
     - name: Upload artifacts


### PR DESCRIPTION
Release archives for non-Windows targets are gzip-compressed TAR files (`tar czf`) but were being named with a `.gz` extension, causing interoperability issues with tooling that infers format from the extension.

The artifact upload and release steps use glob patterns (`yara-x-*`) and are unaffected. Windows `.zip` builds are unaffected. Downstream consumers fetching assets by exact filename will need to update from `.gz` -> `.tar.gz`.