### PR TITLE
ci: test recent versions of go and python

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ '1.19', '1.20', '1.21.x', '1.22.x', '1.23.x', '1.24.x', '1.25.x' ]
+        go-version: [ '1.19', '1.20', '1.21.x', '1.22.x', '1.23.x', '1.24.x', '1.25.x', '1.26.x' ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
CI: Expanding tests to more recent versions of Go and Python

Python 3.9 went end-of-life on Halloween in 2025 and all Go versions prior to 1.25 went end-of-life on or before February 11th, 2026. I didn't feel comfortable deprecating support for older versions in a PR focused on CI tests.