### PR TITLE
chore: go fix

### DIFF
--- a/go/compiler_test.go
+++ b/go/compiler_test.go
@@ -27,8 +27,8 @@ func TestNamespaces(t *testing.T) {
 func TestGlobals(t *testing.T) {
 	c, err := NewCompiler()
 	assert.NoError(t, err)
-	x := map[string]interface{}{"a": map[string]interface{}{"a": "b"}, "b": "d"}
-	y := []interface{}{"z"}
+	x := map[string]any{"a": map[string]any{"a": "b"}, "b": "d"}
+	y := []any{"z"}
 
 	c.DefineGlobal("test_hashmap", x)
 	c.DefineGlobal("A", "b")
@@ -43,7 +43,7 @@ func TestGlobals(t *testing.T) {
 	assert.Len(t, ScanResults.MatchingRules(), 3)
 
 	s.SetGlobal("A", "c")
-	s.SetGlobal("test_arr", []interface{}{"f"})
+	s.SetGlobal("test_arr", []any{"f"})
 	ScanResults, _ = s.Scan([]byte{})
 	assert.Len(t, ScanResults.MatchingRules(), 1)
 }
@@ -151,7 +151,7 @@ func TestSerialization(t *testing.T) {
 func TestVariables(t *testing.T) {
 	r, _ := Compile(
 		"rule test { condition: var == 1234 }",
-		Globals(map[string]interface{}{"var": 1234}))
+		Globals(map[string]any{"var": 1234}))
 
 	scanResults, _ := NewScanner(r).Scan([]byte{})
 	assert.Len(t, scanResults.MatchingRules(), 1)

--- a/go/scanner_test.go
+++ b/go/scanner_test.go
@@ -51,7 +51,7 @@ func TestScanner2(t *testing.T) {
 func TestScanner3(t *testing.T) {
 	r, _ := Compile(
 		`rule t { condition: var_bool }`,
-		Globals(map[string]interface{}{"var_bool": true}))
+		Globals(map[string]any{"var_bool": true}))
 
 	s := NewScanner(r)
 	scanResults, _ := s.Scan([]byte{})
@@ -65,7 +65,7 @@ func TestScanner3(t *testing.T) {
 func TestScanner4(t *testing.T) {
 	r, _ := Compile(
 		`rule t { condition: var_int == 1}`,
-		Globals(map[string]interface{}{"var_int": 0}))
+		Globals(map[string]any{"var_int": 0}))
 
 	s := NewScanner(r)
 	scanResults, _ := s.Scan([]byte{})
@@ -84,7 +84,6 @@ func TestScanner4(t *testing.T) {
 	assert.Len(t, scanResults.MatchingRules(), 1)
 }
 
-
 func TestScanFile(t *testing.T) {
 	r, _ := Compile(`rule t { strings: $bar = "bar" condition: $bar }`)
 	s := NewScanner(r)
@@ -102,7 +101,6 @@ func TestScanFile(t *testing.T) {
 	matchingRules := scanResults.MatchingRules()
 	assert.Len(t, matchingRules, 1)
 }
-
 
 func TestScannerTimeout(t *testing.T) {
 	r, _ := Compile("rule t { strings: $a = /a(.*)*a/ condition: $a }")


### PR DESCRIPTION
Go recently updated `go fix`: https://go.dev/blog/gofix

- Ran `go fix ./...` on `go` directory 
- Ran tests with go 1.18 and 1.26