### PR TITLE
fix: issues in atom extraction from regular expressions.

### DIFF
--- a/lib/src/re/thompson/compiler.rs
+++ b/lib/src/re/thompson/compiler.rs
@@ -1876,47 +1876,48 @@ fn concat_seq(seqs: &[Seq]) -> Option<Seq> {
         _ => {}
     }
 
+    // Count of the number of sequences at the tail that can be empty.
+    // For instance, if we have sequences [s1, s2, s3], the result will
+    // be 2 if both s2 and s3 can be empty.
+    let empty_tail = seqs
+        .iter()
+        .rev()
+        .map_while(|seq| {
+            if matches!(seq.min_literal_len(), Some(x) if x == 0) {
+                Some(seq)
+            } else {
+                None
+            }
+        })
+        .count();
+
+    // The sequences that can be empty at the tail won't be candidates for
+    // concatenation.
+    let seqs_considered = seqs.len() - empty_tail;
+
+    let mut seqs_added = 0;
     let mut total_min_literal_len = 0;
     let mut result = Seq::singleton(hir::literal::Literal::exact(vec![]));
-    let mut all_required_added = true;
 
-    for (j, seq) in seqs.iter().enumerate() {
-        let remaining_can_be_empty =
-            seqs[j..].iter().all(|s| s.min_literal_len() == Some(0));
-        if remaining_can_be_empty {
-            all_required_added = false;
-            break;
-        }
-
+    for seq in seqs.iter().take(seqs_considered) {
         match seq.min_literal_len() {
             Some(min_literal_len) => {
                 // If the cross product of `result` with `seq` produces too many
                 // literals, stop trying to add more sequences to the result and
                 // return what we have so far.
                 match result.max_cross_len(seq) {
-                    None => {
-                        all_required_added = false;
-                        break;
-                    }
-                    Some(len) if len > MAX_ATOMS_PER_REGEXP => {
-                        all_required_added = false;
-                        break;
-                    }
+                    None => break,
+                    Some(len) if len > MAX_ATOMS_PER_REGEXP => break,
                     _ => {}
                 }
 
                 result.cross_forward(&mut seq.clone());
+                seqs_added += 1;
                 total_min_literal_len += min_literal_len;
 
-                // The desired atom length has been reached, don't process
+                // The desired atom length as been reached, don't process
                 // more sequences.
                 if total_min_literal_len >= DESIRED_ATOM_SIZE {
-                    let remaining_can_be_empty = seqs[j + 1..]
-                        .iter()
-                        .all(|s| s.min_literal_len() == Some(0));
-                    if !remaining_can_be_empty {
-                        all_required_added = false;
-                    }
                     break;
                 }
 
@@ -1925,25 +1926,16 @@ fn concat_seq(seqs: &[Seq]) -> Option<Seq> {
                 // can add to it and can quit early. Note that this also includes
                 // infinite sequences.
                 if result.is_inexact() {
-                    let remaining_can_be_empty = seqs[j + 1..]
-                        .iter()
-                        .all(|s| s.min_literal_len() == Some(0));
-                    if !remaining_can_be_empty {
-                        all_required_added = false;
-                    }
                     break;
                 }
             }
-            None => {
-                all_required_added = false;
-                break;
-            }
+            None => break,
         }
     }
 
-    // If there are sequences that were not added to the result, and they
-    // were required (not all of them could be empty), the result is inexact.
-    if !all_required_added {
+    // If there are sequences that were not added to the result, the result
+    // is inexact.
+    if seqs_added < seqs.len() {
         result.make_inexact();
     }
 

--- a/lib/src/re/thompson/compiler.rs
+++ b/lib/src/re/thompson/compiler.rs
@@ -6,6 +6,7 @@ More specifically, the compiler produces two instruction sequences, one that
 matches the regexp left-to-right, and another one that matches right-to-left.
 */
 
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::fmt::{Display, Formatter};
@@ -2030,21 +2031,39 @@ fn seq_to_atoms(seq: Seq) -> Option<Vec<Atom>> {
     atoms.dedup();
 
     // For any pair of atoms, if one is a prefix of the other, the shorter
-    // one must be made inexact to allow the longer one to match greedily
-    // via the VM if necessary.
-    for i in 0..atoms.len() {
-        let is_prefix_of_other = (0..atoms.len()).any(|j| {
-            i != j && atoms[j].as_ref().starts_with(atoms[i].as_ref())
-        });
-        if is_prefix_of_other {
-            atoms[i].make_inexact();
+    // one must be made inexact, and the longer one can be completely removed.
+    //
+    // Since the atoms are sorted lexicographically, any prefix of an atom
+    // must be adjacent to it in the sorted list.
+    let mut to_make_inexact = Vec::new();
+    let mut to_remove = Vec::new();
+
+    for ((atom_idx, atom), (next_idx, next)) in
+        atoms.iter().map(|atom| atom.as_ref()).enumerate().tuple_windows()
+    {
+        if atom == next {
+            // If they have the same bytes, the exact one (which sorts
+            // after the inexact one) must be removed.
+            to_remove.push(next_idx);
+        } else if next.starts_with(atom) {
+            // If the next atom contains the current one as a prefix,
+            // the next one must be removed and the current one marked
+            // as inexact.
+            to_make_inexact.push(atom_idx);
+            to_remove.push(next_idx);
         }
     }
 
-    // Since atoms with different exactness may have become identical
-    // after make_inexact(), sort and dedup again.
-    atoms.sort();
-    atoms.dedup();
+    for idx in to_make_inexact {
+        atoms[idx].make_inexact();
+    }
+
+    // Since to_remove was populated in ascending order, by iterating it
+    // in reverse order we get indexes in descending order to safely remove
+    // elements without index shifting.
+    for idx in to_remove.into_iter().rev() {
+        atoms.remove(idx);
+    }
 
     Some(atoms)
 }

--- a/lib/src/re/thompson/compiler.rs
+++ b/lib/src/re/thompson/compiler.rs
@@ -1876,29 +1876,47 @@ fn concat_seq(seqs: &[Seq]) -> Option<Seq> {
         _ => {}
     }
 
-    let mut seqs_added = 0;
     let mut total_min_literal_len = 0;
     let mut result = Seq::singleton(hir::literal::Literal::exact(vec![]));
+    let mut all_required_added = true;
 
-    for seq in seqs.iter() {
+    for (j, seq) in seqs.iter().enumerate() {
+        let remaining_can_be_empty =
+            seqs[j..].iter().all(|s| s.min_literal_len() == Some(0));
+        if remaining_can_be_empty {
+            all_required_added = false;
+            break;
+        }
+
         match seq.min_literal_len() {
             Some(min_literal_len) => {
                 // If the cross product of `result` with `seq` produces too many
                 // literals, stop trying to add more sequences to the result and
                 // return what we have so far.
                 match result.max_cross_len(seq) {
-                    None => break,
-                    Some(len) if len > MAX_ATOMS_PER_REGEXP => break,
+                    None => {
+                        all_required_added = false;
+                        break;
+                    }
+                    Some(len) if len > MAX_ATOMS_PER_REGEXP => {
+                        all_required_added = false;
+                        break;
+                    }
                     _ => {}
                 }
 
                 result.cross_forward(&mut seq.clone());
-                seqs_added += 1;
                 total_min_literal_len += min_literal_len;
 
-                // The desired atom length as been reached, don't process
+                // The desired atom length has been reached, don't process
                 // more sequences.
                 if total_min_literal_len >= DESIRED_ATOM_SIZE {
+                    let remaining_can_be_empty = seqs[j + 1..]
+                        .iter()
+                        .all(|s| s.min_literal_len() == Some(0));
+                    if !remaining_can_be_empty {
+                        all_required_added = false;
+                    }
                     break;
                 }
 
@@ -1907,16 +1925,25 @@ fn concat_seq(seqs: &[Seq]) -> Option<Seq> {
                 // can add to it and can quit early. Note that this also includes
                 // infinite sequences.
                 if result.is_inexact() {
+                    let remaining_can_be_empty = seqs[j + 1..]
+                        .iter()
+                        .all(|s| s.min_literal_len() == Some(0));
+                    if !remaining_can_be_empty {
+                        all_required_added = false;
+                    }
                     break;
                 }
             }
-            None => break,
+            None => {
+                all_required_added = false;
+                break;
+            }
         }
     }
 
-    // If there are sequences that were not added to the result, the result
-    // is inexact.
-    if seqs_added < seqs.len() {
+    // If there are sequences that were not added to the result, and they
+    // were required (not all of them could be empty), the result is inexact.
+    if !all_required_added {
         result.make_inexact();
     }
 
@@ -2007,6 +2034,23 @@ fn seq_to_atoms(seq: Seq) -> Option<Vec<Atom>> {
     // `regex-syntax`'s `Seq::dedup()` only removes consecutive duplicates.
     // The Cartesian product can produce identical literals that are not
     // consecutive, so we must sort and dedup here to remove them.
+    atoms.sort();
+    atoms.dedup();
+
+    // For any pair of atoms, if one is a prefix of the other, the shorter
+    // one must be made inexact to allow the longer one to match greedily
+    // via the VM if necessary.
+    for i in 0..atoms.len() {
+        let is_prefix_of_other = (0..atoms.len()).any(|j| {
+            i != j && atoms[j].as_ref().starts_with(atoms[i].as_ref())
+        });
+        if is_prefix_of_other {
+            atoms[i].make_inexact();
+        }
+    }
+
+    // Since atoms with different exactness may have become identical
+    // after make_inexact(), sort and dedup again.
     atoms.sort();
     atoms.dedup();
 

--- a/lib/src/re/thompson/tests.rs
+++ b/lib/src/re/thompson/tests.rs
@@ -890,15 +890,11 @@ fn re_code_17() {
         vec![
             RegexpAtom {
                 atom: Atom::inexact(vec![]),
-                code_loc: CodeLoc { fwd: 0, bck_seq_id: 0, bck: 0x4A },
+                code_loc: CodeLoc { fwd: 0x0D, bck_seq_id: 0, bck: 0x41 },
             },
             RegexpAtom {
                 atom: Atom::inexact(vec![0x61, 0x62, 0x63]),
-                code_loc: CodeLoc { fwd: 0, bck_seq_id: 0, bck: 0x4A },
-            },
-            RegexpAtom {
-                atom: Atom::inexact(vec![0x61, 0x62, 0x63, 0x61]),
-                code_loc: CodeLoc { fwd: 0, bck_seq_id: 0, bck: 0x4A },
+                code_loc: CodeLoc { fwd: 0x13, bck_seq_id: 0, bck: 0x4A },
             },
         ],
         // Epsilon closure starting at forward code 0.
@@ -1336,7 +1332,6 @@ fn re_atoms() {
         r#"ab.*cd"#,
         vec![
             Atom::inexact(b"ab"),
-            Atom::exact("abcd"),
         ]
     );
 

--- a/lib/src/re/thompson/tests.rs
+++ b/lib/src/re/thompson/tests.rs
@@ -1573,4 +1573,3 @@ fn re_no_duplicate_atoms() {
         "Atoms vector contains duplicates"
     );
 }
-

--- a/lib/src/re/thompson/tests.rs
+++ b/lib/src/re/thompson/tests.rs
@@ -887,7 +887,6 @@ fn re_code_17() {
 00049: LIT 0x61
 0004a: MATCH
 "#,
-        // Atoms
         vec![
             RegexpAtom {
                 atom: Atom::inexact(vec![]),
@@ -1521,6 +1520,13 @@ fn re_atoms() {
         v
     });
 
+    assert_re_atoms!(r#"(com|net)[^{}]{0,100}"#, {
+        vec![
+            Atom::inexact(b"com"),
+            Atom::inexact(b"net"),
+        ]
+    });
+
     assert_re_atoms!(
         r#"(?s)abc.d(((xy|xz)w.)|[a-c])(((xy|xz)w.)|[a-c])"#,
         vec![Atom::inexact(b"abc")]
@@ -1572,3 +1578,4 @@ fn re_no_duplicate_atoms() {
         "Atoms vector contains duplicates"
     );
 }
+

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -1355,15 +1355,7 @@ fn regexp_patterns_1() {
     pattern_match!(r#"/a(.*)*/"#, b"a", b"a");
     pattern_match!(r#"/a(.*){2}/"#, b"a", b"a");
     pattern_match!(r#"/a(.*){2,4}/"#, b"a", b"a");
-
-    // TODO: known issue related to exact atoms. The matching string
-    // should be "abbb" and not "abb". When the `exact-atoms` feature
-    // is disabled it works correctly.
-    #[cfg(not(feature = "exact-atoms"))]
     pattern_match!(r#"/a(bb|b)b/"#, b"abbbbbbbb", b"abbb");
-    #[cfg(feature = "exact-atoms")]
-    pattern_match!(r#"/a(bb|b)b/"#, b"abbbbbbbb", b"abb");
-
     pattern_match!(r#"/a(b|bb)b/"#, b"abbbbbbbb", b"abb");
 
     pattern_match!(


### PR DESCRIPTION
This PR optimizes the atom extraction process to prevent generating an excessive number of atoms for patterns with optional suffixes. It also fixes a bug where exact prefix atoms could prematurely match and bypass the regex VM, leading to incorrect (non-greedy) match results.

# Summary of Changes

1. Modified `concat_seq` in lib/src/re/thompson/compiler.rs to identify and ignore optional sequences at the tail of the concatenation when extracting candidate atoms. For example, in `(com|net)[^{}]{0,100}`, the `[^{}]{0,100}` suffix is optional and can be empty. We now stop concatenating before this suffix, avoiding the generation of a massive number of atoms.
If any tail sequences are skipped, the resulting atoms are correctly marked as inexact to force the regex VM to run and verify the optional suffix.

2. If a shorter atom is a prefix of a longer atom (e.g., `ab` and `abc`), the shorter one is made inexact. This forces the engine to run the regex VM to ensure greedy matching (e.g., matching `abbb` instead of stopping at `abb` for `/a(bb|b)b/)`. Since the shorter inexact atom will trigger the VM to match the longer path anyway, the longer atom (e.g., `abc`) is redundant and is completely removed from the set. If two atoms have the same bytes but different exactness (one exact and one inexact), the exact one is removed.

