### PR TITLE
chore: go testifylint

### DIFF
--- a/go/compiler.go
+++ b/go/compiler.go
@@ -28,7 +28,7 @@ type CompileOption func(c *Compiler) error
 //
 // Valid value types include: int, int32, int64, bool, string, float32 and
 // float64.
-func Globals(vars map[string]interface{}) CompileOption {
+func Globals(vars map[string]any) CompileOption {
 	return func(c *Compiler) error {
 		for ident, value := range vars {
 			c.vars[ident] = value
@@ -289,7 +289,7 @@ type Compiler struct {
 	includesEnabled       bool
 	ignoredModules        map[string]bool
 	bannedModules         map[string]bannedModule
-	vars                  map[string]interface{}
+	vars                  map[string]any
 	features              []string
 	includeDirs           []string
 	maxWarnings           *int
@@ -301,7 +301,7 @@ func NewCompiler(opts ...CompileOption) (*Compiler, error) {
 		includesEnabled: true,
 		ignoredModules:  make(map[string]bool),
 		bannedModules:   make(map[string]bannedModule),
-		vars:            make(map[string]interface{}),
+		vars:            make(map[string]any),
 		features:        make([]string, 0),
 		includeDirs:     make([]string, 0),
 	}
@@ -558,7 +558,7 @@ func (c *Compiler) DefineGlobal(ident string, value interface{}) error {
 		ret = C.int(C.yrx_compiler_define_global_float(c.cCompiler, cIdent, C.double(v)))
 	case float64:
 		ret = C.int(C.yrx_compiler_define_global_float(c.cCompiler, cIdent, C.double(v)))
-	case map[string]interface{}, []interface{}:
+	case map[string]any, []any:
 		jsonStr, err := json.Marshal(v)
 		if err != nil {
 			return fmt.Errorf("failed to marshal '%s' to json: '%v'", ident, err)

--- a/go/compiler.go
+++ b/go/compiler.go
@@ -2,6 +2,7 @@ package yara_x
 
 // #include <yara_x.h>
 import "C"
+
 import (
 	"encoding/json"
 	"errors"

--- a/go/compiler_test.go
+++ b/go/compiler_test.go
@@ -3,16 +3,16 @@ package yara_x
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNamespaces(t *testing.T) {
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.NewNamespace("foo")
 	c.AddSource("rule test { condition: true }")
@@ -26,7 +26,7 @@ func TestNamespaces(t *testing.T) {
 
 func TestGlobals(t *testing.T) {
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	x := map[string]any{"a": map[string]any{"a": "b"}, "b": "d"}
 	y := []any{"z"}
 
@@ -54,7 +54,7 @@ func TestUnsupportedModules(t *testing.T) {
 		rule test { condition: true }`,
 		IgnoreModule("unsupported_module"))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	scanResults, _ := r.Scan([]byte{})
 	assert.Len(t, scanResults.MatchingRules(), 1)
 }
@@ -85,8 +85,8 @@ func TestDisabledIncludes(t *testing.T) {
 }
 
 func TestIncludes(t *testing.T) {
-	file, err := ioutil.TempFile("", "prefix")
-	assert.NoError(t, err)
+	file, err := os.CreateTemp(t.TempDir(), "prefix")
+	require.NoError(t, err)
 
 	defer os.Remove(file.Name())
 
@@ -94,14 +94,14 @@ func TestIncludes(t *testing.T) {
 		fmt.Sprintf(`include "%s"`, file.Name()),
 		IncludeDir(os.TempDir()))
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRelaxedReSyntax(t *testing.T) {
 	r, err := Compile(`
 		rule test { strings: $a = /\Release/ condition: $a }`,
 		RelaxedReSyntax(true))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	scanResults, _ := r.Scan([]byte("Release"))
 	assert.Len(t, scanResults.MatchingRules(), 1)
 }
@@ -110,7 +110,7 @@ func TestConditionOptimization(t *testing.T) {
 	_, err := Compile(`
 		rule test { condition: true }`,
 		ConditionOptimization(true))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestErrorOnSlowPattern(t *testing.T) {
@@ -129,14 +129,14 @@ func TestErrorOnSlowLoop(t *testing.T) {
 
 func TestSerialization(t *testing.T) {
 	r, err := Compile("rule test { condition: true }")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var buf bytes.Buffer
 
 	// Write rules into buffer
 	n, err := r.WriteTo(&buf)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, buf.Bytes(), int(n))
 
 	// Read rules from buffer
@@ -157,7 +157,7 @@ func TestVariables(t *testing.T) {
 	assert.Len(t, scanResults.MatchingRules(), 1)
 
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.DefineGlobal("var", 1234)
 	c.AddSource("rule test { condition: var == 1234 }")
@@ -177,7 +177,7 @@ func TestVariables(t *testing.T) {
 	c.DefineGlobal("var", false)
 	c.AddSource("rule test { condition: var }")
 	scanResults, _ = NewScanner(c.Build()).Scan([]byte{})
-	assert.Len(t, scanResults.MatchingRules(), 0)
+	assert.Empty(t, scanResults.MatchingRules())
 
 	c.DefineGlobal("var", "foo")
 	c.AddSource("rule test { condition: var == \"foo\" }")
@@ -207,26 +207,26 @@ func TestCompilerFeatures(t *testing.T) {
 	rules := `import "test_proto2" rule test { condition: test_proto2.requires_foo_and_bar }`
 
 	_, err := Compile(rules)
-	assert.EqualError(t, err, `error[E100]: foo is required
+	require.EqualError(t, err, `error[E100]: foo is required
  --> line:1:57
   |
 1 | import "test_proto2" rule test { condition: test_proto2.requires_foo_and_bar }
   |                                                         ^^^^^^^^^^^^^^^^^^^^ this field was used without foo`)
 
 	_, err = Compile(rules, WithFeature("foo"))
-	assert.EqualError(t, err, `error[E100]: bar is required
+	require.EqualError(t, err, `error[E100]: bar is required
  --> line:1:57
   |
 1 | import "test_proto2" rule test { condition: test_proto2.requires_foo_and_bar }
   |                                                         ^^^^^^^^^^^^^^^^^^^^ this field was used without bar`)
 
 	_, err = Compile(rules, WithFeature("foo"), WithFeature("bar"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestErrors(t *testing.T) {
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.AddSource("rule test_1 { condition: true }")
 	assert.Equal(t, []CompileError{}, c.Errors())
@@ -291,13 +291,13 @@ func TestErrors(t *testing.T) {
 
 func TestRules(t *testing.T) {
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.AddSource(`rule test_1 : tag1 tag2 {
       condition:
         true
 	}`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.AddSource(`rule test_2 {
       meta:
@@ -308,7 +308,7 @@ func TestRules(t *testing.T) {
       condition:
         true
 	}`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rules := c.Build()
 	assert.Equal(t, 2, rules.Count())
@@ -324,7 +324,7 @@ func TestRules(t *testing.T) {
 	assert.Equal(t, []string{"tag1", "tag2"}, slice[0].Tags())
 	assert.Equal(t, []string{}, slice[1].Tags())
 
-	assert.Len(t, slice[0].Metadata(), 0)
+	assert.Empty(t, slice[0].Metadata())
 	assert.Len(t, slice[1].Metadata(), 4)
 
 	assert.Equal(t, "foo", slice[1].Metadata()[0].Identifier())
@@ -342,7 +342,7 @@ func TestRules(t *testing.T) {
 
 func TestImportsIter(t *testing.T) {
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.AddSource(`
 	import "pe"
@@ -351,7 +351,7 @@ func TestImportsIter(t *testing.T) {
 			condition:
 				true
 	}`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rules := c.Build()
 	imports := rules.Imports()
@@ -363,7 +363,7 @@ func TestImportsIter(t *testing.T) {
 
 func TestWarnings(t *testing.T) {
 	c, err := NewCompiler()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	c.AddSource("rule test { strings: $a = {01 [0-1][0-1] 02 } condition: $a }")
 

--- a/go/example_test.go
+++ b/go/example_test.go
@@ -50,7 +50,6 @@ func Example_compilerAndScanner() {
 		condition:
 		$bar
 	}`)
-
 	if err != nil {
 		panic(err)
 	}

--- a/go/main.go
+++ b/go/main.go
@@ -266,7 +266,7 @@ type Pattern struct {
 // Metadata represents a metadata in a Rule.
 type Metadata struct {
 	identifier string
-	value      interface{}
+	value      any
 }
 
 // Match contains information about the offset where a match occurred and
@@ -358,7 +358,7 @@ func (m *Metadata) Identifier() string {
 }
 
 // Value associated to the metadata.
-func (m *Metadata) Value() interface{} {
+func (m *Metadata) Value() any {
 	return m.value
 }
 
@@ -474,7 +474,7 @@ func metadataCallback(metadata *C.YRX_METADATA, handle C.uintptr_t) {
 		panic("matchCallback didn't receive a *[]Metadata")
 	}
 
-	var value interface{}
+	var value any
 
 	switch metadata.value_type {
 	case C.YRX_I64:

--- a/go/scanner.go
+++ b/go/scanner.go
@@ -31,9 +31,7 @@ import (
 	"runtime/cgo"
 	"time"
 	"unsafe"
-)
 
-import (
 	"google.golang.org/protobuf/proto"
 )
 
@@ -163,7 +161,7 @@ func (s *Scanner) SetGlobal(ident string, value interface{}) error {
 		ret = C.int(C.yrx_scanner_set_global_str(s.cScanner, cIdent, cValue))
 	case float64:
 		ret = C.int(C.yrx_scanner_set_global_float(s.cScanner, cIdent, C.double(v)))
-	case map[string]interface{}, []interface{}:
+	case map[string]any, []any:
 		jsonStr, err := json.Marshal(v)
 		if err != nil {
 			return fmt.Errorf("failed to marshal '%s' to json: '%v'", ident, err)
@@ -358,17 +356,17 @@ func (s *Scanner) SlowestRules(n int) []ProfilingInfo {
 	return profilingInfo
 }
 
-/// ClearProfilingData resets the profiling data collected during rule execution
-/// across scanned files. Use it to start a new profiling session, ensuring the
-/// results reflect only the data gathered after this method is called.
+// ClearProfilingData resets the profiling data collected during rule execution
+// across scanned files. Use it to start a new profiling session, ensuring the
+// results reflect only the data gathered after this method is called.
 //
 // In order to use this function, the YARA-X C library must be built with
 // support for rules profiling by enabling the `rules-profiling` feature.
 // Otherwise, calling this function will cause a panic.
 func (s *Scanner) ClearProfilingData() {
-  if C.yrx_scanner_clear_profiling_data(s.cScanner) == C.YRX_NOT_SUPPORTED {
-     panic("ClearProfilingData requires that the YARA-X C library is built with the `rules-profiling` feature")
-  }
+	if C.yrx_scanner_clear_profiling_data(s.cScanner) == C.YRX_NOT_SUPPORTED {
+		panic("ClearProfilingData requires that the YARA-X C library is built with the `rules-profiling` feature")
+	}
 }
 
 // Destroy destroys the scanner.

--- a/go/scanner.go
+++ b/go/scanner.go
@@ -314,7 +314,8 @@ func slowestRulesCallback(
 	rule *C.char,
 	patternMatchingTime C.double,
 	conditionExecTime C.double,
-	handle C.uintptr_t) {
+	handle C.uintptr_t,
+) {
 	h := cgo.Handle(handle)
 	profilingInfo, ok := h.Value().(*[]ProfilingInfo)
 	if !ok {

--- a/go/scanner_test.go
+++ b/go/scanner_test.go
@@ -2,11 +2,13 @@ package yara_x
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScanner1(t *testing.T) {
@@ -18,7 +20,7 @@ func TestScanner1(t *testing.T) {
 	assert.Len(t, matchingRules, 1)
 	assert.Equal(t, "t", matchingRules[0].Identifier())
 	assert.Equal(t, "default", matchingRules[0].Namespace())
-	assert.Len(t, matchingRules[0].Patterns(), 0)
+	assert.Empty(t, matchingRules[0].Patterns())
 
 	scanResults, _ = s.Scan(nil)
 	matchingRules = scanResults.MatchingRules()
@@ -26,7 +28,7 @@ func TestScanner1(t *testing.T) {
 	assert.Len(t, matchingRules, 1)
 	assert.Equal(t, "t", matchingRules[0].Identifier())
 	assert.Equal(t, "default", matchingRules[0].Namespace())
-	assert.Len(t, matchingRules[0].Patterns(), 0)
+	assert.Empty(t, matchingRules[0].Patterns())
 }
 
 func TestScanner2(t *testing.T) {
@@ -59,7 +61,7 @@ func TestScanner3(t *testing.T) {
 
 	s.SetGlobal("var_bool", false)
 	scanResults, _ = s.Scan([]byte{})
-	assert.Len(t, scanResults.MatchingRules(), 0)
+	assert.Empty(t, scanResults.MatchingRules())
 }
 
 func TestScanner4(t *testing.T) {
@@ -69,17 +71,17 @@ func TestScanner4(t *testing.T) {
 
 	s := NewScanner(r)
 	scanResults, _ := s.Scan([]byte{})
-	assert.Len(t, scanResults.MatchingRules(), 0)
+	assert.Empty(t, scanResults.MatchingRules())
 
-	assert.NoError(t, s.SetGlobal("var_int", 1))
+	require.NoError(t, s.SetGlobal("var_int", 1))
 	scanResults, _ = s.Scan([]byte{})
 	assert.Len(t, scanResults.MatchingRules(), 1)
 
-	assert.NoError(t, s.SetGlobal("var_int", int32(1)))
+	require.NoError(t, s.SetGlobal("var_int", int32(1)))
 	scanResults, _ = s.Scan([]byte{})
 	assert.Len(t, scanResults.MatchingRules(), 1)
 
-	assert.NoError(t, s.SetGlobal("var_int", int64(1)))
+	require.NoError(t, s.SetGlobal("var_int", int64(1)))
 	scanResults, _ = s.Scan([]byte{})
 	assert.Len(t, scanResults.MatchingRules(), 1)
 }
@@ -89,12 +91,12 @@ func TestScanFile(t *testing.T) {
 	s := NewScanner(r)
 
 	// Create a temporary file with some content
-	f, err := os.CreateTemp("", "example")
-	assert.NoError(t, err)
+	f, err := os.CreateTemp(t.TempDir(), "example")
+	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
 	_, err = f.Write([]byte("foobar"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	f.Close()
 
 	scanResults, _ := s.ScanFile(f.Name())


### PR DESCRIPTION
- Addressed `testifylint` errors
- Replaced deprecated `ioutil.TempFile` with `os.CreateTemp`
- Formatted with `gofumpt`