### PR TITLE
perf: optimize scans using header constraints

### DIFF
--- a/cli/src/walk.rs
+++ b/cli/src/walk.rs
@@ -476,25 +476,26 @@ impl<'a> ParWalker<'a> {
                         let t_active = start_time.elapsed();
 
                         if let Some(limit) = cpu_limit
-                            && limit < 100 {
-                                // Calculate the required sleep duration to limit
-                                // CPU usage to the target percentage.
-                                //
-                                // Let T_active be the elapsed time scanning the
-                                // file. Let T_sleep be the sleep time. The target
-                                // utilization percentage is P.
-                                //
-                                // P = 100 * T_active / (T_active + T_sleep)
-                                // P * (T_active + T_sleep) = 100 * T_active
-                                // P * T_sleep = (100 - P) * T_active
-                                // T_sleep = T_active * (100 - P) / P
-                                let t_sleep = t_active.mul_f64(
-                                    (100.0 - limit as f64) / limit as f64,
-                                );
-                                if !t_sleep.is_zero() {
-                                    thread::sleep(t_sleep);
-                                }
+                            && limit < 100
+                        {
+                            // Calculate the required sleep duration to limit
+                            // CPU usage to the target percentage.
+                            //
+                            // Let T_active be the elapsed time scanning the
+                            // file. Let T_sleep be the sleep time. The target
+                            // utilization percentage is P.
+                            //
+                            // P = 100 * T_active / (T_active + T_sleep)
+                            // P * (T_active + T_sleep) = 100 * T_active
+                            // P * T_sleep = (100 - P) * T_active
+                            // T_sleep = T_active * (100 - P) / P
+                            let t_sleep = t_active.mul_f64(
+                                (100.0 - limit as f64) / limit as f64,
+                            );
+                            if !t_sleep.is_zero() {
+                                thread::sleep(t_sleep);
                             }
+                        }
 
                         if let Err(err) = res
                             && error(err, &msg_send).is_err()

--- a/cli/src/walk.rs
+++ b/cli/src/walk.rs
@@ -475,8 +475,8 @@ impl<'a> ParWalker<'a> {
                         );
                         let t_active = start_time.elapsed();
 
-                        if let Some(limit) = cpu_limit {
-                            if limit < 100 {
+                        if let Some(limit) = cpu_limit
+                            && limit < 100 {
                                 // Calculate the required sleep duration to limit
                                 // CPU usage to the target percentage.
                                 //
@@ -495,7 +495,6 @@ impl<'a> ParWalker<'a> {
                                     thread::sleep(t_sleep);
                                 }
                             }
-                        }
 
                         if let Err(err) = res
                             && error(err, &msg_send).is_err()

--- a/lib/src/compiler/ir/ast2ir.rs
+++ b/lib/src/compiler/ir/ast2ir.rs
@@ -31,8 +31,8 @@ use crate::compiler::ir::{
 };
 use crate::compiler::report::{Level, ReportBuilder};
 use crate::compiler::{
-    CompileContext, CompileError, FilesizeBounds, ForVars, PatternIdx,
-    RegexId, RegexSetId, TextPatternAsHex, warnings,
+    CompileContext, CompileError, FilesizeBounds, ForVars, HeaderConstraint,
+    PatternIdx, RegexId, RegexSetId, TextPatternAsHex, warnings,
 };
 use crate::errors::CustomError;
 use crate::errors::{MethodNotAllowedInWith, PotentiallySlowLoop};
@@ -258,6 +258,7 @@ pub(in crate::compiler) fn text_pattern_from_ast<'src>(
             base64wide_alphabet,
             anchored_at: None,
             filesize_bounds: FilesizeBounds::default(),
+            header_constraints: HeaderConstraint::default(),
         }),
     })
 }
@@ -312,6 +313,7 @@ pub(in crate::compiler) fn hex_pattern_from_ast<'src>(
             flags: PatternFlags::Ascii,
             anchored_at: None,
             filesize_bounds: FilesizeBounds::default(),
+            header_constraints: HeaderConstraint::default(),
         }),
     })
 }
@@ -448,6 +450,7 @@ pub(in crate::compiler) fn regexp_pattern_from_ast<'src>(
             hir,
             anchored_at: None,
             filesize_bounds: FilesizeBounds::default(),
+            header_constraints: HeaderConstraint::default(),
         }),
     })
 }

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -1011,7 +1011,7 @@ impl IR {
         &self,
         pattern_prefix_lookup: impl Fn(PatternIdx) -> Option<Vec<u8>>,
     ) -> HeaderConstraint {
-        let mut temp = BTreeMap::new();
+        let mut constrained_bytes = BTreeMap::new();
         let mut unsatisfiable = false;
         let mut dfs = self.dfs_iter(self.root.unwrap());
 
@@ -1025,31 +1025,31 @@ impl IR {
                     self.extract_header_constraints_from_eq(
                         *lhs,
                         *rhs,
-                        &mut temp,
+                        &mut constrained_bytes,
                         &mut unsatisfiable,
                     );
                 }
                 Expr::PatternMatch { pattern, anchor } => {
                     if let MatchAnchor::At(offset_expr) = anchor
-                        && let Some(0) = self.try_as_const_int(*offset_expr)
-                            && let Some(prefix_bytes) =
-                                pattern_prefix_lookup(*pattern)
-                            {
-                                for (i, &b) in prefix_bytes.iter().enumerate()
-                                {
-                                    match temp.entry(i) {
-                                        Entry::Occupied(entry) => {
-                                            if *entry.get() != b {
-                                                unsatisfiable = true;
-                                                break;
-                                            }
-                                        }
-                                        Entry::Vacant(entry) => {
-                                            entry.insert(b);
-                                        }
+                        && let Some(0) =
+                            self.get(*offset_expr).try_as_const_integer()
+                        && let Some(prefix_bytes) =
+                            pattern_prefix_lookup(*pattern)
+                    {
+                        for (i, &b) in prefix_bytes.iter().enumerate() {
+                            match constrained_bytes.entry(i) {
+                                Entry::Occupied(entry) => {
+                                    if *entry.get() != b {
+                                        unsatisfiable = true;
+                                        break;
                                     }
                                 }
+                                Entry::Vacant(entry) => {
+                                    entry.insert(b);
+                                }
                             }
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -1067,7 +1067,7 @@ impl IR {
 
         let mut bytes = Vec::new();
         let mut offset = 0;
-        while let Some(&byte) = temp.get(&offset) {
+        while let Some(&byte) = constrained_bytes.get(&offset) {
             bytes.push(byte);
             offset += 1;
         }
@@ -1079,70 +1079,26 @@ impl IR {
         }
     }
 
-    fn try_as_const_int(&self, expr_id: ExprId) -> Option<i64> {
-        if let Expr::Const(val) = self.get(expr_id) {
-            val.try_as_integer()
-        } else {
-            None
-        }
-    }
-
-    fn extract_int_read_call(&self, expr_id: ExprId) -> Option<(&str, usize)> {
-        if let Expr::FuncCall(func_call) = self.get(expr_id) {
-            match func_call.plain_name() {
-                "uint8" | "int8" | "uint8be" | "int8be" | "uint16"
-                | "int16" | "uint16be" | "int16be" | "uint32" | "int32"
-                | "uint32be" | "int32be" => {
-                    if let Some(offset) = func_call
-                        .args.first()
-                        .and_then(|arg| self.try_as_const_int(*arg))
-                        && offset >= 0
-                    {
-                        return Some((
-                            func_call.plain_name(),
-                            offset as usize,
-                        ));
-                    }
-                }
-                _ => {}
-            }
-        }
-        None
-    }
-
     fn extract_header_constraints_from_eq(
         &self,
         lhs: ExprId,
         rhs: ExprId,
-        temp: &mut std::collections::BTreeMap<usize, u8>,
+        constrained_bytes: &mut BTreeMap<usize, u8>,
         unsatisfiable: &mut bool,
     ) {
-        if let Some((func_name, offset)) = self.extract_int_read_call(lhs) {
-            if let Some(val) = self.try_as_const_int(rhs) {
-                self.apply_int_read_constraint(
-                    temp,
-                    unsatisfiable,
-                    func_name,
-                    offset,
-                    val,
-                );
-            }
-        } else if let Some((func_name, offset)) =
-            self.extract_int_read_call(rhs)
-            && let Some(val) = self.try_as_const_int(lhs) {
-                self.apply_int_read_constraint(
-                    temp,
-                    unsatisfiable,
-                    func_name,
-                    offset,
-                    val,
-                );
-            }
+        if let Some(val) = self.get(rhs).try_as_const_integer()
+            && self.apply_int_read_constraint(constrained_bytes, unsatisfiable, lhs, val)
+        {
+            return;
+        }
+        if let Some(val) = self.get(lhs).try_as_const_integer() {
+            self.apply_int_read_constraint(constrained_bytes, unsatisfiable, rhs, val);
+        }
     }
 
     fn add_constraint(
         &self,
-        temp: &mut std::collections::BTreeMap<usize, u8>,
+        constrained_bytes: &mut BTreeMap<usize, u8>,
         unsatisfiable: &mut bool,
         offset: usize,
         value: u8,
@@ -1150,13 +1106,13 @@ impl IR {
         if *unsatisfiable {
             return;
         }
-        match temp.entry(offset) {
-            std::collections::btree_map::Entry::Occupied(entry) => {
+        match constrained_bytes.entry(offset) {
+            Entry::Occupied(entry) => {
                 if *entry.get() != value {
                     *unsatisfiable = true;
                 }
             }
-            std::collections::btree_map::Entry::Vacant(entry) => {
+            Entry::Vacant(entry) => {
                 entry.insert(value);
             }
         }
@@ -1164,102 +1120,120 @@ impl IR {
 
     fn apply_int_read_constraint(
         &self,
-        temp: &mut std::collections::BTreeMap<usize, u8>,
+        constrained_bytes: &mut BTreeMap<usize, u8>,
         unsatisfiable: &mut bool,
-        func_name: &str,
-        offset: usize,
+        expr_id: ExprId,
         val: i64,
-    ) {
-        match func_name {
-            "uint8" | "int8" | "uint8be" | "int8be" => {
-                self.add_constraint(temp, unsatisfiable, offset, val as u8);
+    ) -> bool {
+        let func_call = match self.get(expr_id) {
+            Expr::FuncCall(func_call) => func_call,
+            _ => return false,
+        };
+
+        if let Some(offset) = func_call
+            .args
+            .first()
+            .and_then(|arg| self.get(*arg).try_as_const_integer())
+            && offset >= 0
+        {
+            match func_call.plain_name() {
+                "uint8" | "int8" | "uint8be" | "int8be" => {
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize,
+                        val as u8,
+                    );
+                    return true;
+                }
+                "uint16" | "int16" => {
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize,
+                        (val as u16 & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 1,
+                        ((val as u16 >> 8) & 0xff) as u8,
+                    );
+                    return true;
+                }
+                "uint16be" | "int16be" => {
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize,
+                        ((val as u16 >> 8) & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 1,
+                        (val as u16 & 0xff) as u8,
+                    );
+                    return true;
+                }
+                "uint32" | "int32" => {
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize,
+                        (val as u32 & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 1,
+                        ((val as u32 >> 8) & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 2,
+                        ((val as u32 >> 16) & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 3,
+                        ((val as u32 >> 24) & 0xff) as u8,
+                    );
+                    return true;
+                }
+                "uint32be" | "int32be" => {
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize,
+                        ((val as u32 >> 24) & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 1,
+                        ((val as u32 >> 16) & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 2,
+                        ((val as u32 >> 8) & 0xff) as u8,
+                    );
+                    self.add_constraint(
+                        constrained_bytes,
+                        unsatisfiable,
+                        offset as usize + 3,
+                        (val as u32 & 0xff) as u8,
+                    );
+                    return true;
+                }
+                _ => {}
             }
-            "uint16" | "int16" => {
-                let val = val as u16;
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset,
-                    (val & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 1,
-                    ((val >> 8) & 0xff) as u8,
-                );
-            }
-            "uint16be" | "int16be" => {
-                let val = val as u16;
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset,
-                    ((val >> 8) & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 1,
-                    (val & 0xff) as u8,
-                );
-            }
-            "uint32" | "int32" => {
-                let val = val as u32;
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset,
-                    (val & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 1,
-                    ((val >> 8) & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 2,
-                    ((val >> 16) & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 3,
-                    ((val >> 24) & 0xff) as u8,
-                );
-            }
-            "uint32be" | "int32be" => {
-                let val = val as u32;
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset,
-                    ((val >> 24) & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 1,
-                    ((val >> 16) & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 2,
-                    ((val >> 8) & 0xff) as u8,
-                );
-                self.add_constraint(
-                    temp,
-                    unsatisfiable,
-                    offset + 3,
-                    (val & 0xff) as u8,
-                );
-            }
-            _ => {}
         }
+        false
     }
 }
 

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -29,7 +29,8 @@ allows using the same regex engine for matching both types of patterns.
 [Hir]: regex_syntax::hir::Hir
 */
 
-use std::collections::Bound;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, Bound};
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -1010,7 +1011,7 @@ impl IR {
         &self,
         pattern_prefix_lookup: impl Fn(PatternIdx) -> Option<Vec<u8>>,
     ) -> HeaderConstraint {
-        let mut temp = std::collections::BTreeMap::new();
+        let mut temp = BTreeMap::new();
         let mut unsatisfiable = false;
         let mut dfs = self.dfs_iter(self.root.unwrap());
 
@@ -1029,28 +1030,26 @@ impl IR {
                     );
                 }
                 Expr::PatternMatch { pattern, anchor } => {
-                    if let MatchAnchor::At(offset_expr) = anchor {
-                        if let Some(0) = self.try_as_const_int(*offset_expr) {
-                            if let Some(prefix_bytes) =
+                    if let MatchAnchor::At(offset_expr) = anchor
+                        && let Some(0) = self.try_as_const_int(*offset_expr)
+                            && let Some(prefix_bytes) =
                                 pattern_prefix_lookup(*pattern)
                             {
                                 for (i, &b) in prefix_bytes.iter().enumerate()
                                 {
                                     match temp.entry(i) {
-                                        std::collections::btree_map::Entry::Occupied(entry) => {
+                                        Entry::Occupied(entry) => {
                                             if *entry.get() != b {
                                                 unsatisfiable = true;
                                                 break;
                                             }
                                         }
-                                        std::collections::btree_map::Entry::Vacant(entry) => {
+                                        Entry::Vacant(entry) => {
                                             entry.insert(b);
                                         }
                                     }
                                 }
                             }
-                        }
-                    }
                 }
                 _ => {}
             }
@@ -1090,26 +1089,22 @@ impl IR {
 
     fn extract_int_read_call(&self, expr_id: ExprId) -> Option<(&str, usize)> {
         if let Expr::FuncCall(func_call) = self.get(expr_id) {
-            if func_call.object.is_none() {
-                let mangled_name = func_call.signature.mangled_name.as_str();
-                let clean_name = mangled_name.split('@').next()?;
-                let is_int_read = match clean_name {
-                    "uint8" | "int8" | "uint8be" | "int8be" | "uint16"
-                    | "int16" | "uint16be" | "int16be" | "uint32"
-                    | "int32" | "uint32be" | "int32be" => true,
-                    _ => false,
-                };
-                if is_int_read {
-                    if func_call.args.len() == 1 {
-                        if let Some(offset) =
-                            self.try_as_const_int(func_call.args[0])
-                        {
-                            if offset >= 0 {
-                                return Some((clean_name, offset as usize));
-                            }
-                        }
+            match func_call.plain_name() {
+                "uint8" | "int8" | "uint8be" | "int8be" | "uint16"
+                | "int16" | "uint16be" | "int16be" | "uint32" | "int32"
+                | "uint32be" | "int32be" => {
+                    if let Some(offset) = func_call
+                        .args.first()
+                        .and_then(|arg| self.try_as_const_int(*arg))
+                        && offset >= 0
+                    {
+                        return Some((
+                            func_call.plain_name(),
+                            offset as usize,
+                        ));
                     }
                 }
+                _ => {}
             }
         }
         None
@@ -1134,8 +1129,7 @@ impl IR {
             }
         } else if let Some((func_name, offset)) =
             self.extract_int_read_call(rhs)
-        {
-            if let Some(val) = self.try_as_const_int(lhs) {
+            && let Some(val) = self.try_as_const_int(lhs) {
                 self.apply_int_read_constraint(
                     temp,
                     unsatisfiable,
@@ -1144,7 +1138,6 @@ impl IR {
                     val,
                 );
             }
-        }
     }
 
     fn add_constraint(
@@ -2642,6 +2635,12 @@ impl FuncCall {
     /// Returns the mangled function name for this function call.
     pub fn mangled_name(&self) -> &str {
         self.signature().mangled_name.as_str()
+    }
+
+    /// Returns the plain function name, without argument or return type
+    /// information (i.e: everything before the `@` in the name).
+    pub fn plain_name(&self) -> &str {
+        self.signature().mangled_name.plain_name()
     }
 }
 

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -51,7 +51,7 @@ use crate::compiler::ir::dfs::{
     DFSIter, DFSWithScopeIter, Event, EventContext, dfs_common,
 };
 
-use crate::compiler::{FilesizeBounds, RegexSetId};
+use crate::compiler::{FilesizeBounds, HeaderConstraint, RegexSetId};
 use crate::re;
 use crate::symbols::Symbol;
 use crate::types::Value::Const;
@@ -310,6 +310,17 @@ impl Pattern {
             }
         }
     }
+
+    pub fn set_header_constraints(&mut self, constraints: &HeaderConstraint) {
+        match self {
+            Pattern::Text(literal) => {
+                literal.header_constraints = constraints.clone();
+            }
+            Pattern::Regexp(regexp) | Pattern::Hex(regexp) => {
+                regexp.header_constraints = constraints.clone();
+            }
+        }
+    }
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -321,6 +332,7 @@ pub(crate) struct LiteralPattern {
     pub base64_alphabet: Option<String>,
     pub base64wide_alphabet: Option<String>,
     pub filesize_bounds: FilesizeBounds,
+    pub header_constraints: HeaderConstraint,
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -329,6 +341,7 @@ pub(crate) struct RegexpPattern {
     pub hir: re::hir::Hir,
     pub anchored_at: Option<usize>,
     pub filesize_bounds: FilesizeBounds,
+    pub header_constraints: HeaderConstraint,
 }
 
 /// The index of a pattern in the rule that declares it.
@@ -991,6 +1004,269 @@ impl IR {
         }
 
         result
+    }
+
+    pub fn header_constraints(
+        &self,
+        pattern_prefix_lookup: impl Fn(PatternIdx) -> Option<Vec<u8>>,
+    ) -> HeaderConstraint {
+        let mut temp = std::collections::BTreeMap::new();
+        let mut unsatisfiable = false;
+        let mut dfs = self.dfs_iter(self.root.unwrap());
+
+        while let Some(evt) = dfs.next() {
+            let expr = match evt {
+                Event::Enter((_, expr, _)) => expr,
+                _ => continue,
+            };
+            match expr {
+                Expr::Eq { lhs, rhs } => {
+                    self.extract_header_constraints_from_eq(
+                        *lhs,
+                        *rhs,
+                        &mut temp,
+                        &mut unsatisfiable,
+                    );
+                }
+                Expr::PatternMatch { pattern, anchor } => {
+                    if let MatchAnchor::At(offset_expr) = anchor {
+                        if let Some(0) = self.try_as_const_int(*offset_expr) {
+                            if let Some(prefix_bytes) =
+                                pattern_prefix_lookup(*pattern)
+                            {
+                                for (i, &b) in prefix_bytes.iter().enumerate()
+                                {
+                                    match temp.entry(i) {
+                                        std::collections::btree_map::Entry::Occupied(entry) => {
+                                            if *entry.get() != b {
+                                                unsatisfiable = true;
+                                                break;
+                                            }
+                                        }
+                                        std::collections::btree_map::Entry::Vacant(entry) => {
+                                            entry.insert(b);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            if unsatisfiable {
+                break;
+            }
+            if !matches!(expr, Expr::And { .. }) {
+                dfs.prune();
+            }
+        }
+
+        if unsatisfiable {
+            return HeaderConstraint::Unsatisfiable;
+        }
+
+        let mut bytes = Vec::new();
+        let mut offset = 0;
+        while let Some(&byte) = temp.get(&offset) {
+            bytes.push(byte);
+            offset += 1;
+        }
+
+        if bytes.is_empty() {
+            HeaderConstraint::Unconstrained
+        } else {
+            HeaderConstraint::Constrained(bytes)
+        }
+    }
+
+    fn try_as_const_int(&self, expr_id: ExprId) -> Option<i64> {
+        if let Expr::Const(val) = self.get(expr_id) {
+            val.try_as_integer()
+        } else {
+            None
+        }
+    }
+
+    fn extract_int_read_call(&self, expr_id: ExprId) -> Option<(&str, usize)> {
+        if let Expr::FuncCall(func_call) = self.get(expr_id) {
+            if func_call.object.is_none() {
+                let mangled_name = func_call.signature.mangled_name.as_str();
+                let clean_name = mangled_name.split('@').next()?;
+                let is_int_read = match clean_name {
+                    "uint8" | "int8" | "uint8be" | "int8be" | "uint16"
+                    | "int16" | "uint16be" | "int16be" | "uint32"
+                    | "int32" | "uint32be" | "int32be" => true,
+                    _ => false,
+                };
+                if is_int_read {
+                    if func_call.args.len() == 1 {
+                        if let Some(offset) =
+                            self.try_as_const_int(func_call.args[0])
+                        {
+                            if offset >= 0 {
+                                return Some((clean_name, offset as usize));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn extract_header_constraints_from_eq(
+        &self,
+        lhs: ExprId,
+        rhs: ExprId,
+        temp: &mut std::collections::BTreeMap<usize, u8>,
+        unsatisfiable: &mut bool,
+    ) {
+        if let Some((func_name, offset)) = self.extract_int_read_call(lhs) {
+            if let Some(val) = self.try_as_const_int(rhs) {
+                self.apply_int_read_constraint(
+                    temp,
+                    unsatisfiable,
+                    func_name,
+                    offset,
+                    val,
+                );
+            }
+        } else if let Some((func_name, offset)) =
+            self.extract_int_read_call(rhs)
+        {
+            if let Some(val) = self.try_as_const_int(lhs) {
+                self.apply_int_read_constraint(
+                    temp,
+                    unsatisfiable,
+                    func_name,
+                    offset,
+                    val,
+                );
+            }
+        }
+    }
+
+    fn add_constraint(
+        &self,
+        temp: &mut std::collections::BTreeMap<usize, u8>,
+        unsatisfiable: &mut bool,
+        offset: usize,
+        value: u8,
+    ) {
+        if *unsatisfiable {
+            return;
+        }
+        match temp.entry(offset) {
+            std::collections::btree_map::Entry::Occupied(entry) => {
+                if *entry.get() != value {
+                    *unsatisfiable = true;
+                }
+            }
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+        }
+    }
+
+    fn apply_int_read_constraint(
+        &self,
+        temp: &mut std::collections::BTreeMap<usize, u8>,
+        unsatisfiable: &mut bool,
+        func_name: &str,
+        offset: usize,
+        val: i64,
+    ) {
+        match func_name {
+            "uint8" | "int8" | "uint8be" | "int8be" => {
+                self.add_constraint(temp, unsatisfiable, offset, val as u8);
+            }
+            "uint16" | "int16" => {
+                let val = val as u16;
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset,
+                    (val & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 1,
+                    ((val >> 8) & 0xff) as u8,
+                );
+            }
+            "uint16be" | "int16be" => {
+                let val = val as u16;
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset,
+                    ((val >> 8) & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 1,
+                    (val & 0xff) as u8,
+                );
+            }
+            "uint32" | "int32" => {
+                let val = val as u32;
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset,
+                    (val & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 1,
+                    ((val >> 8) & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 2,
+                    ((val >> 16) & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 3,
+                    ((val >> 24) & 0xff) as u8,
+                );
+            }
+            "uint32be" | "int32be" => {
+                let val = val as u32;
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset,
+                    ((val >> 24) & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 1,
+                    ((val >> 16) & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 2,
+                    ((val >> 8) & 0xff) as u8,
+                );
+                self.add_constraint(
+                    temp,
+                    unsatisfiable,
+                    offset + 3,
+                    (val & 0xff) as u8,
+                );
+            }
+            _ => {}
+        }
     }
 }
 

--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -1065,17 +1065,23 @@ impl IR {
             return HeaderConstraint::Unsatisfiable;
         }
 
-        let mut bytes = Vec::new();
-        let mut offset = 0;
-        while let Some(&byte) = constrained_bytes.get(&offset) {
-            bytes.push(byte);
-            offset += 1;
-        }
-
-        if bytes.is_empty() {
-            HeaderConstraint::Unconstrained
+        // If the first byte in `constrained_bytes` is at offset 0, we can
+        // return HeaderConstraint::Constrained.
+        if let Some((0, _)) = constrained_bytes.first_key_value() {
+            HeaderConstraint::Constrained(
+                // Take only the bytes at consecutive offsets starting at 0.
+                constrained_bytes
+                    .into_iter()
+                    .enumerate()
+                    .map_while(
+                        |(i, (offset, byte))| {
+                            if i == offset { Some(byte) } else { None }
+                        },
+                    )
+                    .collect(),
+            )
         } else {
-            HeaderConstraint::Constrained(bytes)
+            HeaderConstraint::Unconstrained
         }
     }
 
@@ -1087,12 +1093,22 @@ impl IR {
         unsatisfiable: &mut bool,
     ) {
         if let Some(val) = self.get(rhs).try_as_const_integer()
-            && self.apply_int_read_constraint(constrained_bytes, unsatisfiable, lhs, val)
+            && self.apply_int_read_constraint(
+                constrained_bytes,
+                unsatisfiable,
+                lhs,
+                val,
+            )
         {
             return;
         }
         if let Some(val) = self.get(lhs).try_as_const_integer() {
-            self.apply_int_read_constraint(constrained_bytes, unsatisfiable, rhs, val);
+            self.apply_int_read_constraint(
+                constrained_bytes,
+                unsatisfiable,
+                rhs,
+                val,
+            );
         }
     }
 

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -337,6 +337,19 @@ pub struct Compiler<'a> {
     /// `FilesizeBounds{start: Bound::Unbounded, end: Bound:Excluded(1000)}`.
     filesize_bounds: FxHashMap<PatternId, FilesizeBounds>,
 
+    /// Map that associates a `PatternId` to a certain constraint on the
+    /// file header (e.g. magic bytes at offset 0), if any.
+    ///
+    /// A condition like `uint16(0) == 0x5A4D and $a` or `$mz at 0 and $a`
+    /// (were $mz = "MZ") only matches if the file starts with "MZ" (0x5A4D).
+    /// In this case the map will contain an entry associating `$a` to a
+    /// `HeaderConstraint` that requires the file to start with those two
+    /// bytes.
+    ///
+    /// This allows skipping pattern checks entirely if the scanned data doesn't
+    /// start with the expected header prefix.
+    header_constraints: FxHashMap<PatternId, HeaderConstraint>,
+
     /// A vector with all the rules that has been compiled. A [`RuleId`] is
     /// an index in this vector.
     rules: Vec<RuleInfo>,
@@ -502,6 +515,7 @@ impl<'a> Compiler<'a> {
             banned_modules: FxHashMap::default(),
             ignored_rules: FxHashMap::default(),
             filesize_bounds: FxHashMap::default(),
+            header_constraints: FxHashMap::default(),
             root_struct: Struct::new().make_root(),
             report_builder: ReportBuilder::new(),
             lit_pool: BStringPool::new(),
@@ -813,6 +827,7 @@ impl<'a> Compiler<'a> {
             re_code: self.re_code,
             warnings: self.warnings.into(),
             filesize_bounds: self.filesize_bounds,
+            header_constraints: self.header_constraints,
             regex_sets: self.regex_sets,
             fast_scan_patterns: self.fast_scan_patterns,
         };
@@ -1668,6 +1683,18 @@ impl Compiler<'_> {
         // `filesize`, if any.
         let filesize_bounds = self.ir.filesize_bounds();
 
+        // Analyze the condition and determine if it imposes some constraint
+        // to the file header (ex: `uint16(0) == 0x5a4d`).
+        let header_constraints = self.ir.header_constraints(|pat_idx| {
+            let pat = &rule_patterns[pat_idx.as_usize()];
+            match pat.pattern() {
+                Pattern::Text(lit) => Some(lit.text.as_bytes().to_vec()),
+                Pattern::Regexp(re) | Pattern::Hex(re) => {
+                    re.hir.as_literal_bytes().map(|bytes| bytes.to_vec())
+                }
+            }
+        });
+
         // Set the bounds to all patterns in the rule. This must be done
         // before assigning the PatternId to each pattern, as the filesize
         // bounds are taken into account when determining if the pattern
@@ -1675,6 +1702,15 @@ impl Compiler<'_> {
         if !filesize_bounds.unbounded() {
             for pattern in &mut rule_patterns {
                 pattern.pattern_mut().set_filesize_bounds(&filesize_bounds);
+            }
+        }
+
+        // Set header constraints to all patterns in the rule.
+        if !header_constraints.unconstrained() {
+            for pattern in &mut rule_patterns {
+                pattern
+                    .pattern_mut()
+                    .set_header_constraints(&header_constraints);
             }
         }
 
@@ -1808,6 +1844,17 @@ impl Compiler<'_> {
                     // This should not happen.
                     panic!(
                         "modifying the file size bounds of an existing pattern"
+                    )
+                }
+                if !header_constraints.unconstrained()
+                    && self
+                        .header_constraints
+                        .insert(*pattern_id, header_constraints.clone())
+                        .is_some()
+                {
+                    // This should not happen.
+                    panic!(
+                        "modifying the header constraints of an existing pattern"
                     )
                 }
                 pending_patterns.remove(pattern_id);

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -866,15 +866,15 @@ impl FilesizeBounds {
 ///
 /// For example, the condition `uint32(0) == 0x464c457f` requires that the first
 /// 4 bytes of the file are `0x7f, 0x45, 0x4c, 0x46`.
-#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Hash, Eq)]
-#[derive(Default)]
+#[derive(
+    Debug, PartialEq, Serialize, Deserialize, Clone, Hash, Eq, Default,
+)]
 pub(crate) enum HeaderConstraint {
     #[default]
     Unconstrained,
     Unsatisfiable,
     Constrained(Vec<u8>),
 }
-
 
 impl HeaderConstraint {
     pub fn unconstrained(&self) -> bool {

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -867,17 +867,14 @@ impl FilesizeBounds {
 /// For example, the condition `uint32(0) == 0x464c457f` requires that the first
 /// 4 bytes of the file are `0x7f, 0x45, 0x4c, 0x46`.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Hash, Eq)]
+#[derive(Default)]
 pub(crate) enum HeaderConstraint {
+    #[default]
     Unconstrained,
     Unsatisfiable,
     Constrained(Vec<u8>),
 }
 
-impl Default for HeaderConstraint {
-    fn default() -> Self {
-        Self::Unconstrained
-    }
-}
 
 impl HeaderConstraint {
     pub fn unconstrained(&self) -> bool {

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -119,6 +119,9 @@ pub struct Rules {
     pub(in crate::compiler) filesize_bounds:
         FxHashMap<PatternId, FilesizeBounds>,
 
+    pub(in crate::compiler) header_constraints:
+        FxHashMap<PatternId, HeaderConstraint>,
+
     /// Vector that contains the [`SubPatternId`] for sub-patterns that can
     /// match only at a fixed offset within the scanned data. These sub-patterns
     /// are not added to the Aho-Corasick automaton.
@@ -578,6 +581,14 @@ impl Rules {
     }
 
     #[inline]
+    pub(crate) fn header_constraints(
+        &self,
+        pattern_id: PatternId,
+    ) -> Option<&HeaderConstraint> {
+        self.header_constraints.get(&pattern_id)
+    }
+
+    #[inline]
     pub(crate) fn is_fast_scan(&self, pattern_id: PatternId) -> bool {
         *self.fast_scan_patterns.get(usize::from(pattern_id)).unwrap()
     }
@@ -848,6 +859,37 @@ impl FilesizeBounds {
             (_, Bound::Unbounded) => {}
         }
         self
+    }
+}
+
+/// Describes the requirements on the file header imposed by a rule condition.
+///
+/// For example, the condition `uint32(0) == 0x464c457f` requires that the first
+/// 4 bytes of the file are `0x7f, 0x45, 0x4c, 0x46`.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Hash, Eq)]
+pub(crate) enum HeaderConstraint {
+    Unconstrained,
+    Unsatisfiable,
+    Constrained(Vec<u8>),
+}
+
+impl Default for HeaderConstraint {
+    fn default() -> Self {
+        Self::Unconstrained
+    }
+}
+
+impl HeaderConstraint {
+    pub fn unconstrained(&self) -> bool {
+        matches!(self, Self::Unconstrained)
+    }
+
+    pub fn is_satisfied(&self, data: &[u8]) -> bool {
+        match self {
+            Self::Unconstrained => true,
+            Self::Unsatisfiable => false,
+            Self::Constrained(bytes) => data.starts_with(bytes),
+        }
     }
 }
 

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -171,6 +171,7 @@ pub struct ScanContext<'r, 'd> {
     pub(crate) console_log: Option<Box<dyn FnMut(String) + 'r>>,
     /// Virtual Machines used for executing regexps.
     pub(crate) vm: VM<'r>,
+    pub(crate) disabled_patterns: bitvec::vec::BitVec,
     /// Hash map that tracks the time spend on each pattern. Keys are pattern
     /// PatternIds and values are the cumulative time spent on verifying each
     /// pattern.
@@ -541,6 +542,9 @@ impl ScanContext<'_, '_> {
         // Free all runtime objects left around by previous scans.
         self.runtime_objects.clear();
 
+        self.disabled_patterns.clear();
+        self.disabled_patterns.resize(num_patterns, false);
+
         // Clear the array that tracks the patterns that reached the maximum
         // number of patterns.
         self.tracker.limit_reached.clear();
@@ -764,10 +768,8 @@ impl ScanContext<'_, '_> {
         &mut self,
         base: usize,
         data: &[u8],
-        block_scanning_mode: bool,
     ) -> Result<(), ScanError> {
         let ac = self.compiled_rules.ac_automaton();
-        let filesize = self.get_filesize();
 
         #[cfg(feature = "logging")]
         let mut atom_matches = 0_usize;
@@ -792,8 +794,6 @@ impl ScanContext<'_, '_> {
                         match_offset,
                         base,
                         data,
-                        filesize,
-                        block_scanning_mode,
                     );
                 });
             }
@@ -814,8 +814,6 @@ impl ScanContext<'_, '_> {
                         ac_match.start(),
                         base,
                         data,
-                        filesize,
-                        block_scanning_mode,
                     );
                 }
             }
@@ -834,8 +832,6 @@ impl ScanContext<'_, '_> {
         match_start: usize,
         base: usize,
         data: &[u8],
-        filesize: i64,
-        block_scanning_mode: bool,
     ) {
         let atoms = self.compiled_rules.atoms();
         let atom = unsafe { atoms.get_unchecked(atom_idx) };
@@ -855,15 +851,11 @@ impl ScanContext<'_, '_> {
         let (pattern_id, sub_pattern) =
             &self.compiled_rules.get_sub_pattern(sub_pattern_id);
 
-        if self.tracker.limit_reached.contains(pattern_id) {
+        if *self.disabled_patterns.get(usize::from(*pattern_id)).unwrap() {
             return;
         }
 
-        if !block_scanning_mode
-            && let Some(bounds) =
-                self.compiled_rules.filesize_bounds(*pattern_id)
-            && !bounds.contains(filesize)
-        {
+        if self.tracker.limit_reached.contains(pattern_id) {
             return;
         }
 
@@ -1073,6 +1065,35 @@ impl ScanContext<'_, '_> {
             _ => panic!(),
         };
 
+        if !block_scanning_mode {
+            let filesize = self.get_filesize();
+            for pattern_id in 0..self.compiled_rules.num_patterns() {
+                let pattern_id = PatternId::from(pattern_id);
+                if let Some(bounds) =
+                    self.compiled_rules.filesize_bounds(pattern_id)
+                {
+                    if !bounds.contains(filesize) {
+                        self.disabled_patterns
+                            .set(usize::from(pattern_id), true);
+                    }
+                }
+            }
+        }
+
+        if base == 0 {
+            for pattern_id in 0..self.compiled_rules.num_patterns() {
+                let pattern_id = PatternId::from(pattern_id);
+                if let Some(constraints) =
+                    self.compiled_rules.header_constraints(pattern_id)
+                {
+                    if !constraints.is_satisfied(data) {
+                        self.disabled_patterns
+                            .set(usize::from(pattern_id), true);
+                    }
+                }
+            }
+        }
+
         #[cfg(any(feature = "rules-profiling", feature = "logging"))]
         let scan_start = self.clock.raw();
 
@@ -1080,8 +1101,7 @@ impl ScanContext<'_, '_> {
         // match at a single known offset within the data.
         self.verify_anchored_patterns(base, data);
 
-        let result = match self.ac_search_loop(base, data, block_scanning_mode)
-        {
+        let result = match self.ac_search_loop(base, data) {
             Ok(_) => {
                 self.scan_state = state;
                 Ok(())
@@ -1128,6 +1148,14 @@ impl ScanContext<'_, '_> {
             .anchored_sub_patterns()
             .iter()
             .map(|id| (id, self.compiled_rules.get_sub_pattern(*id)))
+            // Disabled patterns are ignored.
+            .filter(|(_, (pattern_id, _))| {
+                let disabled = *self
+                    .disabled_patterns
+                    .get(usize::from(*pattern_id))
+                    .unwrap();
+                !disabled
+            })
         {
             match sub_pattern {
                 SubPattern::Literal {
@@ -1924,6 +1952,10 @@ pub fn create_wasm_store_and_ctx<'r>(
             pike_vm: PikeVM::new(rules.re_code()),
             fast_vm: FastVM::new(rules.re_code()),
         },
+        disabled_patterns: bitvec::vec::BitVec::repeat(
+            false,
+            num_patterns as usize,
+        ),
         custom_base64_engine_cache: Vec::new(),
         #[cfg(feature = "rules-profiling")]
         time_spent_in_pattern: FxHashMap::default(),

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -171,7 +171,9 @@ pub struct ScanContext<'r, 'd> {
     pub(crate) console_log: Option<Box<dyn FnMut(String) + 'r>>,
     /// Virtual Machines used for executing regexps.
     pub(crate) vm: VM<'r>,
-    pub(crate) disabled_patterns: bitvec::vec::BitVec,
+    /// Patterns that are disabled for the current scan (e.g. because they don't
+    /// comply with filesize bounds or header constraints).
+    pub(crate) disabled_patterns: FxHashSet<PatternId>,
     /// Hash map that tracks the time spend on each pattern. Keys are pattern
     /// PatternIds and values are the cumulative time spent on verifying each
     /// pattern.
@@ -542,8 +544,8 @@ impl ScanContext<'_, '_> {
         // Free all runtime objects left around by previous scans.
         self.runtime_objects.clear();
 
+        // Clear the set that tracks the disabled patterns.
         self.disabled_patterns.clear();
-        self.disabled_patterns.resize(num_patterns, false);
 
         // Clear the array that tracks the patterns that reached the maximum
         // number of patterns.
@@ -851,7 +853,7 @@ impl ScanContext<'_, '_> {
         let (pattern_id, sub_pattern) =
             &self.compiled_rules.get_sub_pattern(sub_pattern_id);
 
-        if *self.disabled_patterns.get(usize::from(*pattern_id)).unwrap() {
+        if self.disabled_patterns.contains(pattern_id) {
             return;
         }
 
@@ -1073,8 +1075,7 @@ impl ScanContext<'_, '_> {
                     self.compiled_rules.filesize_bounds(pattern_id)
                 {
                     if !bounds.contains(filesize) {
-                        self.disabled_patterns
-                            .set(usize::from(pattern_id), true);
+                        self.disabled_patterns.insert(pattern_id);
                     }
                 }
             }
@@ -1087,8 +1088,7 @@ impl ScanContext<'_, '_> {
                     self.compiled_rules.header_constraints(pattern_id)
                 {
                     if !constraints.is_satisfied(data) {
-                        self.disabled_patterns
-                            .set(usize::from(pattern_id), true);
+                        self.disabled_patterns.insert(pattern_id);
                     }
                 }
             }
@@ -1150,11 +1150,7 @@ impl ScanContext<'_, '_> {
             .map(|id| (id, self.compiled_rules.get_sub_pattern(*id)))
             // Disabled patterns are ignored.
             .filter(|(_, (pattern_id, _))| {
-                let disabled = *self
-                    .disabled_patterns
-                    .get(usize::from(*pattern_id))
-                    .unwrap();
-                !disabled
+                !self.disabled_patterns.contains(pattern_id)
             })
         {
             match sub_pattern {
@@ -1952,10 +1948,7 @@ pub fn create_wasm_store_and_ctx<'r>(
             pike_vm: PikeVM::new(rules.re_code()),
             fast_vm: FastVM::new(rules.re_code()),
         },
-        disabled_patterns: bitvec::vec::BitVec::repeat(
-            false,
-            num_patterns as usize,
-        ),
+        disabled_patterns: FxHashSet::default(),
         custom_base64_engine_cache: Vec::new(),
         #[cfg(feature = "rules-profiling")]
         time_spent_in_pattern: FxHashMap::default(),

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -1073,11 +1073,9 @@ impl ScanContext<'_, '_> {
                 let pattern_id = PatternId::from(pattern_id);
                 if let Some(bounds) =
                     self.compiled_rules.filesize_bounds(pattern_id)
-                {
-                    if !bounds.contains(filesize) {
+                    && !bounds.contains(filesize) {
                         self.disabled_patterns.insert(pattern_id);
                     }
-                }
             }
         }
 
@@ -1086,11 +1084,9 @@ impl ScanContext<'_, '_> {
                 let pattern_id = PatternId::from(pattern_id);
                 if let Some(constraints) =
                     self.compiled_rules.header_constraints(pattern_id)
-                {
-                    if !constraints.is_satisfied(data) {
+                    && !constraints.is_satisfied(data) {
                         self.disabled_patterns.insert(pattern_id);
                     }
-                }
             }
         }
 

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -1073,9 +1073,10 @@ impl ScanContext<'_, '_> {
                 let pattern_id = PatternId::from(pattern_id);
                 if let Some(bounds) =
                     self.compiled_rules.filesize_bounds(pattern_id)
-                    && !bounds.contains(filesize) {
-                        self.disabled_patterns.insert(pattern_id);
-                    }
+                    && !bounds.contains(filesize)
+                {
+                    self.disabled_patterns.insert(pattern_id);
+                }
             }
         }
 
@@ -1084,9 +1085,10 @@ impl ScanContext<'_, '_> {
                 let pattern_id = PatternId::from(pattern_id);
                 if let Some(constraints) =
                     self.compiled_rules.header_constraints(pattern_id)
-                    && !constraints.is_satisfied(data) {
-                        self.disabled_patterns.insert(pattern_id);
-                    }
+                    && !constraints.is_satisfied(data)
+                {
+                    self.disabled_patterns.insert(pattern_id);
+                }
             }
         }
 

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -4099,4 +4099,3 @@ fn header_constraints_optimization() {
         2
     );
 }
-

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -3956,3 +3956,147 @@ fn short_circuit() {
         b"foobar"
     );
 }
+
+#[test]
+fn header_constraints_optimization() {
+    // ELF magic check.
+    rule_true!(
+        r#"
+        rule test {
+            strings:
+                $a = "ELF"
+            condition:
+                uint32(0) == 0x464c457f and $a
+        }
+        "#,
+        b"\x7fELF\0\0\0\0"
+    );
+
+    rule_false!(
+        r#"
+        rule test {
+            strings:
+                $a = "ELF"
+            condition:
+                uint32(0) == 0x464c457f and $a
+        }
+        "#,
+        b"\0\0\0\0ELF"
+    );
+
+    // PE magic check.
+    rule_true!(
+        r#"
+        rule test {
+            strings:
+                $a = "PE"
+            condition:
+                uint16(0) == 0x5a4d and $a
+        }
+        "#,
+        b"MZ\0\0PE"
+    );
+
+    rule_false!(
+        r#"
+        rule test {
+            strings:
+                $a = "PE"
+            condition:
+                uint16(0) == 0x5a4d and $a
+        }
+        "#,
+        b"\0\0MZPE"
+    );
+
+    // Pattern at 0 check.
+    rule_true!(
+        r#"
+        rule test {
+            strings:
+                $a = "MZ"
+            condition:
+                $a at 0
+        }
+        "#,
+        b"MZ"
+    );
+
+    rule_false!(
+        r#"
+        rule test {
+            strings:
+                $a = "MZ"
+            condition:
+                $a at 0
+        }
+        "#,
+        b"\0MZ"
+    );
+
+    // Multiple constraints combined.
+    rule_true!(
+        r#"
+        rule test {
+            strings:
+                $a = "ELF"
+            condition:
+                uint32(0) == 0x464c457f and uint16(4) == 0x0102 and $a
+        }
+        "#,
+        b"\x7fELF\x02\x01"
+    );
+
+    rule_false!(
+        r#"
+        rule test {
+            strings:
+                $a = "ELF"
+            condition:
+                uint32(0) == 0x464c457f and uint16(4) == 0x0102 and $a
+        }
+        "#,
+        b"\x7fELF\x99\x99"
+    );
+
+    // Deduplication test: A pattern used in both a constrained and an unconstrained rule.
+    // When the header does not match, only the unconstrained rule should match (exactly 1 rule).
+    rule_true!(
+        r#"
+        rule constrained {
+            strings:
+                $a = "foo"
+            condition:
+                uint32(0) == 0x464c457f and $a
+        }
+        rule unconstrained {
+            strings:
+                $a = "foo"
+            condition:
+                $a
+        }
+        "#,
+        b"\0\0\0\0foo"
+    );
+
+    // When the header matches, both rules should match (exactly 2 rules).
+    test_rule!(
+        r#"
+        rule constrained {
+            strings:
+                $a = "foo"
+            condition:
+                uint32(0) == 0x464c457f and $a
+        }
+        rule unconstrained {
+            strings:
+                $a = "foo"
+            condition:
+                $a
+        }
+        "#,
+        b"\x7fELFfoo",
+        2
+    );
+}
+

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -4098,4 +4098,17 @@ fn header_constraints_optimization() {
         b"\x7fELFfoo",
         2
     );
+
+    // Non-contiguous offsets for uint8.
+    rule_true!(
+        r#"
+        rule constrained {
+            strings:
+                $a = "MZ"
+            condition:
+                uint8(0) == 0x00 and uint8(2) == 0x5a and $a
+        }
+        "#,
+        b"\0MZ"
+    );
 }

--- a/lib/src/types/func.rs
+++ b/lib/src/types/func.rs
@@ -86,9 +86,13 @@ impl MangledFnName {
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }
-}
 
-impl MangledFnName {
+    /// Returns the plain function name, without argument or return type
+    /// information (i.e: everything before the `@` in the name).
+    pub fn plain_name(&self) -> &str {
+        self.0.as_str().split("@").next().unwrap()
+    }
+
     /// Returns the types of arguments and return value for the function.
     pub fn unmangle(&self) -> (Vec<(&str, TypeValue)>, TypeValue) {
         let (_fn_name, arg_names_and_types, ret_type) =


### PR DESCRIPTION
This change introduces a mechanism to detect and leverage "header constraints" derived from YARA rule conditions. These constraints, such as `uint32(0) == 0x464c457f` or `$a at 0`, specify required byte sequences or integer values at fixed offsets from the start of the file.

During scanning, if the initial bytes of the data do not satisfy a pattern's header constraints, that pattern is disabled before any detailed matching attempts. This early pruning reduces redundant work and improves scan performance, particularly for files with well-defined magic bytes or headers that don't match specific rule conditions.

The existing filesize bounds checks are also refactored to use this new pattern disabling mechanism for consistency and clearer logic.