### PR TITLE
ci: unify Python testing GHA job steps

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -27,7 +27,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # Non-windows
     - name: Test Python
       run: |
         pip install virtualenv

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -17,6 +17,9 @@ jobs:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eEuo pipefail {0}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,20 +27,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Test Python - Windows
-      if: runner.os == 'Windows'
-      run: |
-        pip install virtualenv
-        virtualenv venv; venv\Scripts\activate.ps1
-        pwd
-        python -m pip install --upgrade pip maturin>=1.7.8
-        python -m pip install pytest
-        maturin develop --manifest-path py/Cargo.toml --features=test_proto2-module,test_proto3-module
-        pytest py
-
     # Non-windows
-    - name: Test Python - Non-Windows
-      if: runner.os != 'Windows'
+    - name: Test Python
       run: |
         pip install virtualenv
         virtualenv venv; source venv/bin/activate
@@ -45,4 +36,3 @@ jobs:
         python -m pip install pytest
         maturin develop --manifest-path py/Cargo.toml --features=test_proto2-module,test_proto3-module
         pytest py
-


### PR DESCRIPTION
Setting `bash` is available in all the VM runtimes making it easy to have fewer branches on the YAML definition level [[1]].

[1]: https://docs.zizmor.sh/audits/#template-injection