### PR TITLE
fix(proto): escape special control characters in JSON and YAML serialization

### DIFF
--- a/lib/src/modules/dotnet/tests/testdata/0224ad9739f5fa64a2a63e23ef6a0e3152020fc7964243fc845cad499d11f9ab.out
+++ b/lib/src/modules/dotnet/tests/testdata/0224ad9739f5fa64a2a63e23ef6a0e3152020fc7964243fc845cad499d11f9ab.out
@@ -70,9 +70,7 @@ assembly_refs:
         build_number: 0
         revision_number: 0
 resources:
-  - name: |
-        
-        
+  - name: "\r\n\x06\x04\x03"
 classes:
   - fullname: "OctopusRPA.Csv.CsvHelper"
     name: "CsvHelper"

--- a/lib/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
+++ b/lib/src/modules/dotnet/tests/testdata/88d0d0692e675cd5fafb57db4f940e98d03e054ca2b88ef5a41f72b5787841b3.out
@@ -1,5 +1,5 @@
 is_dotnet: true
-module_name: "c"
+module_name: "\x01c"
 version: "v4.0.30319"
 number_of_streams: 5
 number_of_guids: 16
@@ -82,8 +82,8 @@ assembly_refs:
 resources:
   - name: ""
 classes:
-  - fullname: "?c"
-    name: "?c"
+  - fullname: "?\x12c"
+    name: "?\x12c"
     visibility: "internal"
     type: "class"
     abstract: false
@@ -92,7 +92,7 @@ classes:
     number_of_generic_parameters: 8
     number_of_methods: 0
     base_types:
-      - "?c"
+      - "?\x12c"
     generic_parameters:
       - "ingleton"
       - "ReflectConfiguration"
@@ -335,7 +335,7 @@ classes:
     number_of_generic_parameters: 0
     number_of_methods: 0
     base_types:
-      - "?c"
+      - "?\x12c"
   - fullname: "ool.ine.Pools"
     name: "Pools"
     namespace: "ool.ine"
@@ -810,7 +810,7 @@ classes:
     number_of_generic_parameters: 0
     number_of_methods: 0
     base_types:
-      - "?c"
+      - "?\x12c"
   - fullname: "ners.ne.Listeners"
     name: "Listeners"
     namespace: "ners.ne"
@@ -1649,7 +1649,7 @@ classes:
     number_of_generic_parameters: 0
     number_of_methods: 0
     base_types:
-      - "?c"
+      - "?\x12c"
       - "ool.tory"
   - fullname: "ool.erPrototype"
     name: "erPrototype"
@@ -2812,7 +2812,7 @@ classes:
     number_of_generic_parameters: 0
     number_of_methods: 0
     base_types:
-      - "?c"
+      - "?\x12c"
       - "erpreterCandidate.ectionResolver"
       - "CommandLine.Listeners"
   - fullname: "ceOption.tegy"
@@ -2950,7 +2950,7 @@ classes:
         static: false
         virtual: false
         final: false
-        return_type: "?c"
+        return_type: "?\x12c"
         number_of_generic_parameters: 0
         number_of_parameters: 2
         parameters:
@@ -3648,9 +3648,9 @@ classes:
     number_of_methods: 0
     base_types:
       - "erSerializer.ContainerSerializer"
-  - fullname: "?c.Model"
+  - fullname: "?\x12c.Model"
     name: "Model"
-    namespace: "?c"
+    namespace: "?\x12c"
     visibility: "private"
     type: "class"
     abstract: false
@@ -7155,7 +7155,7 @@ classes:
     number_of_generic_parameters: 0
     number_of_methods: 0
     base_types:
-      - "?c"
+      - "?\x12c"
   - fullname: "andLine.Producers.ntainerSerializer"
     name: "ntainerSerializer"
     namespace: "andLine.Producers"

--- a/proto/src/json.rs
+++ b/proto/src/json.rs
@@ -98,9 +98,9 @@ impl<W: Write> Serializer<W> {
 
     fn escape(s: &str) -> Cow<'_, str> {
         if s.chars().any(|c| {
-            // C0 controls (U+0000–U+001F: NUL–US), including \n, \r, \t —
+            // C0 controls (U+0000–U+001F: NUL–US), including \n, \r, \t
             // all must be escaped per RFC 8259 §7.
-            (c as u32) < 0x20 || matches!(c, '"' | '\\')
+            c.is_ascii_control() || matches!(c, '"' | '\\')
         }) {
             let mut result = String::with_capacity(s.len());
             for c in s.chars() {
@@ -110,9 +110,9 @@ impl<W: Write> Serializer<W> {
                     '\t' => result.push_str(r"\t"),
                     '"' => result.push_str("\\\""),
                     '\\' => result.push_str(r"\\"),
-                    c if (c as u32) < 0x20 => {
-                        // Remaining C0 controls (U+0000–U+001F: NUL–US)
-                        // not covered by the named arms above.
+                    c if c.is_ascii_control() => {
+                        // Remaining C0 controls (U+0000–U+001F: NUL–US) not
+                        // covered by the arms above.
                         // RFC 8259 §7 requires \uXXXX escaping.
                         result.push_str(&format!(r"\u{:04x}", c as u32));
                     }

--- a/proto/src/json.rs
+++ b/proto/src/json.rs
@@ -97,9 +97,11 @@ impl<W: Write> Serializer<W> {
     }
 
     fn escape(s: &str) -> Cow<'_, str> {
-        if s.chars()
-            .any(|c| matches!(c, '\n' | '\r' | '\t' | '\'' | '"' | '\\'))
-        {
+        if s.chars().any(|c| {
+            // C0 controls (U+0000–U+001F: NUL–US), including \n, \r, \t —
+            // all must be escaped per RFC 8259 §7.
+            (c as u32) < 0x20 || matches!(c, '"' | '\\')
+        }) {
             let mut result = String::with_capacity(s.len());
             for c in s.chars() {
                 match c {
@@ -108,6 +110,12 @@ impl<W: Write> Serializer<W> {
                     '\t' => result.push_str(r"\t"),
                     '"' => result.push_str("\\\""),
                     '\\' => result.push_str(r"\\"),
+                    c if (c as u32) < 0x20 => {
+                        // Remaining C0 controls (U+0000–U+001F: NUL–US)
+                        // not covered by the named arms above.
+                        // RFC 8259 §7 requires \uXXXX escaping.
+                        result.push_str(&format!(r"\u{:04x}", c as u32));
+                    }
                     _ => result.push(c),
                 }
             }

--- a/proto/src/tests/testdata_json/1.in
+++ b/proto/src/tests/testdata_json/1.in
@@ -18,6 +18,9 @@ repeated_msg {
     value: "bar"
   }
 }
+repeated_msg {
+  str: "c0-esc\x1b"
+}
 nested_msg {
   i32: 1234
   str: "qux\nfoo\tbar\\baz\"qux"

--- a/proto/src/tests/testdata_json/1.in
+++ b/proto/src/tests/testdata_json/1.in
@@ -21,6 +21,15 @@ repeated_msg {
 repeated_msg {
   str: "c0-esc\x1b"
 }
+repeated_msg {
+  str: "del\x7f"
+}
+repeated_msg {
+  str: "cr\rtest"
+}
+repeated_msg {
+  str: "nul\x00test"
+}
 nested_msg {
   i32: 1234
   str: "qux\nfoo\tbar\\baz\"qux"

--- a/proto/src/tests/testdata_json/1.out
+++ b/proto/src/tests/testdata_json/1.out
@@ -15,6 +15,9 @@
             "map_string_string": {
                 "foo\nbar": "bar"
             }
+        },
+        {
+            "str": "c0-esc\u001b"
         }
     ],
     "nested_msg": {

--- a/proto/src/tests/testdata_json/1.out
+++ b/proto/src/tests/testdata_json/1.out
@@ -18,6 +18,15 @@
         },
         {
             "str": "c0-esc\u001b"
+        },
+        {
+            "str": "del\u007f"
+        },
+        {
+            "str": "cr\rtest"
+        },
+        {
+            "str": "nul\u0000test"
         }
     ],
     "nested_msg": {

--- a/proto/src/tests/testdata_yaml/1.in
+++ b/proto/src/tests/testdata_yaml/1.in
@@ -26,6 +26,9 @@ repeated_msg {
 repeated_msg {
   str: "del-multiline\nhello\x7f"
 }
+repeated_msg {
+  str: "tab-in-literal-block\nhello\tworld"
+}
 nested_msg {
   int32_dec: 1234
   str: "qux\nfoo"

--- a/proto/src/tests/testdata_yaml/1.in
+++ b/proto/src/tests/testdata_yaml/1.in
@@ -14,6 +14,18 @@ repeated_msg {
     value: "bar"
   }
 }
+repeated_msg {
+  str: "c0-esc\x1b"
+}
+repeated_msg {
+  str: "c0-esc-multiline\nhello\x1b"
+}
+repeated_msg {
+  str: "del\x7f"
+}
+repeated_msg {
+  str: "del-multiline\nhello\x7f"
+}
 nested_msg {
   int32_dec: 1234
   str: "qux\nfoo"

--- a/proto/src/tests/testdata_yaml/1.in
+++ b/proto/src/tests/testdata_yaml/1.in
@@ -29,6 +29,33 @@ repeated_msg {
 repeated_msg {
   str: "tab-in-literal-block\nhello\tworld"
 }
+repeated_msg {
+  str: "single'quote"
+}
+repeated_msg {
+  str: "double\"quote"
+}
+repeated_msg {
+  str: "cr-only\rtest"
+}
+repeated_msg {
+  str: "crlf\r\nline1\r\nline2"
+}
+repeated_msg {
+  str: "tab-only\tworld"
+}
+repeated_msg {
+  str: "c1-ctrl\xc2\x80test"
+}
+repeated_msg {
+  str: "c1-ctrl2\xc2\x9ftest"
+}
+repeated_msg {
+  str: "nel-test\xc2\x85printable"
+}
+repeated_msg {
+  str: "non-char\xef\xbf\xbe"
+}
 nested_msg {
   int32_dec: 1234
   str: "qux\nfoo"

--- a/proto/src/tests/testdata_yaml/1.out
+++ b/proto/src/tests/testdata_yaml/1.out
@@ -11,6 +11,10 @@ repeated_msg:
     str: "foo\\bar"
     map_string_string:
         "foo\nbar": "bar"
+  - str: "c0-esc\x1b"
+  - str: "c0-esc-multiline\nhello\x1b"
+  - str: "del\x7f"
+  - str: "del-multiline\nhello\x7f"
 nested_msg:
     int32_dec: 1234
     str: |

--- a/proto/src/tests/testdata_yaml/1.out
+++ b/proto/src/tests/testdata_yaml/1.out
@@ -15,6 +15,9 @@ repeated_msg:
   - str: "c0-esc-multiline\nhello\x1b"
   - str: "del\x7f"
   - str: "del-multiline\nhello\x7f"
+  - str: |
+        tab-in-literal-block
+        hello	world
 nested_msg:
     int32_dec: 1234
     str: |

--- a/proto/src/tests/testdata_yaml/1.out
+++ b/proto/src/tests/testdata_yaml/1.out
@@ -18,6 +18,18 @@ repeated_msg:
   - str: |
         tab-in-literal-block
         hello	world
+  - str: "single\'quote"
+  - str: "double\"quote"
+  - str: "cr-only\rtest"
+  - str: |
+        crlf
+        line1
+        line2
+  - str: "tab-only\tworld"
+  - str: "c1-ctrl\x80test"
+  - str: "c1-ctrl2\x9ftest"
+  - str: "nel-testprintable"
+  - str: "non-char\ufffe"
 nested_msg:
     int32_dec: 1234
     str: |

--- a/proto/src/yaml.rs
+++ b/proto/src/yaml.rs
@@ -200,6 +200,7 @@ impl<W: Write> Serializer<W> {
                 // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
                 // which YAML treats as a printable line-break character
                 || ((0x80..=0x9F).contains(&(c as u32)) && (c as u32) != 0x85)
+                || matches!(c, '\u{FFFE}' | '\u{FFFF}')
         }) {
             let mut result = String::with_capacity(s.len());
             for c in s.chars() {
@@ -220,6 +221,9 @@ impl<W: Write> Serializer<W> {
                             && (c as u32) != 0x85) =>
                     {
                         result.push_str(&format!(r"\x{:02x}", c as u32));
+                    }
+                    '\u{FFFE}' | '\u{FFFF}' => {
+                        result.push_str(&format!(r"\u{:04x}", c as u32));
                     }
                     _ => result.push(c),
                 }
@@ -358,14 +362,16 @@ impl<W: Write> Serializer<W> {
                 // \xXX escapes) whenever such characters are present.
                 let has_other_controls = v.chars().any(|c| {
                     let cp = c as u32;
-                    // C0 controls (U+0000–U+001F: NUL–US), excluding LF
-                    // (U+000A) and CR (U+000D) which are valid in literal blocks
-                    (cp < 0x20 && !matches!(c, '\n' | '\r'))
+                    // C0 controls (U+0000–U+001F: NUL–US), excluding the three
+                    // characters YAML 1.2.1 explicitly keeps printable:
+                    //   TAB (U+0009), LF (U+000A), CR (U+000D)
+                    (cp < 0x20 && !matches!(c, '\t' | '\n' | '\r'))
                         // DEL (U+007F): not in YAML's c-printable set
                         || cp == 0x7F
                         // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
                         // which YAML treats as a printable line-break character
-                        || ((0x80..=0x9F).contains(&cp) && cp != 0x85)
+                        || ((0x80..=0x9F).contains(&cp) && cp != 0x85)                        // U+FFFE and U+FFFF: explicitly excluded by YAML 1.2.1 §1
+                        || matches!(c, '\u{FFFE}' | '\u{FFFF}')
                 });
                 if v.contains('\n') && !has_other_controls {
                     write!(self.output, "{}", "|".paint(self.colors.string))?;

--- a/proto/src/yaml.rs
+++ b/proto/src/yaml.rs
@@ -188,19 +188,23 @@ impl<W: Write> Serializer<W> {
         result
     }
 
+    #[inline]
+    fn is_yaml_control(c: char) -> bool {
+        // C0 controls (U+0000–U+001F: NUL–US), including \n, \r, \t,
+        // and DEL (U+007F): not in YAML's c-printable set.
+        // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
+        // which YAML treats as a printable line-break character.
+        (c.is_control() && c != '\u{85}')
+            // U+FFFE and U+FFFF: explicitly excluded by YAML 1.2.1 §1
+            || matches!(c, '\u{fffe}' | '\u{ffff}')
+    }
+
     fn escape(s: &str) -> Cow<'_, str> {
         if s.chars().any(|c| {
-            // C0 controls (U+0000–U+001F: NUL–US), including \n, \r, \t
-            (c as u32) < 0x20
+            Self::is_yaml_control(c)
                 // Non-control chars that still require escaping in
                 // YAML double-quoted scalars
                 || matches!(c, '\'' | '"' | '\\')
-                // DEL (U+007F): not in YAML's c-printable set
-                || (c as u32) == 0x7F
-                // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
-                // which YAML treats as a printable line-break character
-                || ((0x80..=0x9F).contains(&(c as u32)) && (c as u32) != 0x85)
-                || matches!(c, '\u{FFFE}' | '\u{FFFF}')
         }) {
             let mut result = String::with_capacity(s.len());
             for c in s.chars() {
@@ -215,14 +219,13 @@ impl<W: Write> Serializer<W> {
                     // covered by the named arms above, DEL (U+007F), and
                     // C1 controls (U+0080–U+009F, excl. NEL U+0085).
                     // YAML \xXX escape covers the full U+0000–U+00FF range.
-                    c if (c as u32) < 0x20
-                        || (c as u32) == 0x7F
-                        || ((0x80..=0x9F).contains(&(c as u32))
-                            && (c as u32) != 0x85) =>
-                    {
+                    '\0'..='\u{1f}'
+                    | '\u{7f}'..='\u{84}'
+                    | '\u{86}'..='\u{9f}' => {
                         result.push_str(&format!(r"\x{:02x}", c as u32));
                     }
-                    '\u{FFFE}' | '\u{FFFF}' => {
+                    // U+FFFE and U+FFFF: explicitly excluded by YAML 1.2.1 §1
+                    '\u{fffe}' | '\u{ffff}' => {
                         result.push_str(&format!(r"\u{:04x}", c as u32));
                     }
                     _ => result.push(c),
@@ -360,18 +363,13 @@ impl<W: Write> Serializer<W> {
                 // other than newlines — they appear verbatim, making the YAML
                 // invalid.  Fall back to a double-quoted scalar (which supports
                 // \xXX escapes) whenever such characters are present.
+                //
+                // We check for any YAML control characters, excluding the three
+                // C0 characters YAML 1.2.1 explicitly keeps printable:
+                //   TAB (U+0009), LF (U+000A), CR (U+000D)
                 let has_other_controls = v.chars().any(|c| {
-                    let cp = c as u32;
-                    // C0 controls (U+0000–U+001F: NUL–US), excluding the three
-                    // characters YAML 1.2.1 explicitly keeps printable:
-                    //   TAB (U+0009), LF (U+000A), CR (U+000D)
-                    (cp < 0x20 && !matches!(c, '\t' | '\n' | '\r'))
-                        // DEL (U+007F): not in YAML's c-printable set
-                        || cp == 0x7F
-                        // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
-                        // which YAML treats as a printable line-break character
-                        || ((0x80..=0x9F).contains(&cp) && cp != 0x85)                        // U+FFFE and U+FFFF: explicitly excluded by YAML 1.2.1 §1
-                        || matches!(c, '\u{FFFE}' | '\u{FFFF}')
+                    Self::is_yaml_control(c)
+                        && !matches!(c, '\t' | '\n' | '\r')
                 });
                 if v.contains('\n') && !has_other_controls {
                     write!(self.output, "{}", "|".paint(self.colors.string))?;

--- a/proto/src/yaml.rs
+++ b/proto/src/yaml.rs
@@ -189,9 +189,18 @@ impl<W: Write> Serializer<W> {
     }
 
     fn escape(s: &str) -> Cow<'_, str> {
-        if s.chars()
-            .any(|c| matches!(c, '\n' | '\r' | '\t' | '\'' | '"' | '\\'))
-        {
+        if s.chars().any(|c| {
+            // C0 controls (U+0000–U+001F: NUL–US), including \n, \r, \t
+            (c as u32) < 0x20
+                // Non-control chars that still require escaping in
+                // YAML double-quoted scalars
+                || matches!(c, '\'' | '"' | '\\')
+                // DEL (U+007F): not in YAML's c-printable set
+                || (c as u32) == 0x7F
+                // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
+                // which YAML treats as a printable line-break character
+                || ((0x80..=0x9F).contains(&(c as u32)) && (c as u32) != 0x85)
+        }) {
             let mut result = String::with_capacity(s.len());
             for c in s.chars() {
                 match c {
@@ -201,6 +210,17 @@ impl<W: Write> Serializer<W> {
                     '\'' => result.push_str("\\\'"),
                     '"' => result.push_str("\\\""),
                     '\\' => result.push_str(r"\\"),
+                    // Remaining C0 controls (U+0000–U+001F: NUL–US) not
+                    // covered by the named arms above, DEL (U+007F), and
+                    // C1 controls (U+0080–U+009F, excl. NEL U+0085).
+                    // YAML \xXX escape covers the full U+0000–U+00FF range.
+                    c if (c as u32) < 0x20
+                        || (c as u32) == 0x7F
+                        || ((0x80..=0x9F).contains(&(c as u32))
+                            && (c as u32) != 0x85) =>
+                    {
+                        result.push_str(&format!(r"\x{:02x}", c as u32));
+                    }
                     _ => result.push(c),
                 }
             }
@@ -332,7 +352,22 @@ impl<W: Write> Serializer<W> {
             ReflectValueRef::F64(v) => write!(self.output, "{v:.1}")?,
             ReflectValueRef::Bool(v) => write!(self.output, "{v}")?,
             ReflectValueRef::String(v) => {
-                if v.contains('\n') {
+                // Literal block scalars cannot represent control characters
+                // other than newlines — they appear verbatim, making the YAML
+                // invalid.  Fall back to a double-quoted scalar (which supports
+                // \xXX escapes) whenever such characters are present.
+                let has_other_controls = v.chars().any(|c| {
+                    let cp = c as u32;
+                    // C0 controls (U+0000–U+001F: NUL–US), excluding LF
+                    // (U+000A) and CR (U+000D) which are valid in literal blocks
+                    (cp < 0x20 && !matches!(c, '\n' | '\r'))
+                        // DEL (U+007F): not in YAML's c-printable set
+                        || cp == 0x7F
+                        // C1 controls (U+0080–U+009F), excluding NEL (U+0085)
+                        // which YAML treats as a printable line-break character
+                        || ((0x80..=0x9F).contains(&cp) && cp != 0x85)
+                });
+                if v.contains('\n') && !has_other_controls {
                     write!(self.output, "{}", "|".paint(self.colors.string))?;
                     for line in v.split('\n') {
                         self.newline()?;


### PR DESCRIPTION
The yara-x-proto serializers could emit raw control characters inside JSON and YAML string values, producing output that violates JSON and YAML standards. If a corrupt sample is being parsed by some YARA-X module it can lead to module output dump which is unparseable by commonly available JSON or YAML parsers.

Links to standards that these fixes are based on:
- [JSON RFC8259](https://datatracker.ietf.org/doc/html/rfc8259#section-7)
- [YAML 1.2.1](https://yaml.org/spec/1.2.1/#Characters )






