### PR TITLE
docs(ls): document metadata validation regex

### DIFF
--- a/ls/editors/code/README.md
+++ b/ls/editors/code/README.md
@@ -88,6 +88,10 @@ the following properties:
     date string. The format string supports specifiers like `%Y` (year), `%m` (month), `%d` (day), `%H` (hour),
     `%M` (minute), and `%S` (second). For example, for a date like `"2024-01-25"`, the format should be `"%Y-%m-%d"`.
     For more information see: https://docs.rs/chrono/latest/chrono/format/strftime/index.html
+*   `regex` (string, optional): When `type` is `"string"`, this property specifies a regular expression that the
+    metadata value must match. Use `^` and `$` to require a full-value match. For example,
+    `"^(draft|reviewed|approved)$"` restricts the field to those values. Patterns use Rust's regex syntax.
+    For more information see: https://docs.rs/regex/latest/regex/
 
 For accessing these settings go to the Settings
 

--- a/ls/editors/code/package.json
+++ b/ls/editors/code/package.json
@@ -106,6 +106,10 @@
               "format": {
                 "type": "string",
                 "description": "The expected format of the date string (e.g., `%Y-%m-%d`)."
+              },
+              "regex": {
+                "type": "string",
+                "description": "A regular expression that string metadata values must match (e.g., ^(draft|reviewed|approved)$)."
               }
             }
           }


### PR DESCRIPTION
Adds regex to the YARA.metadataValidation schema and documents it in the Language Server README.

The runtime already supports it and accepts it when configured manually. This only makes it discoverable through VS Code settings autocomplete and documents the expected Rust regex syntax for string metadata values.