### PR TITLE
feat: Expose ignore_invalid_rules in python API.

### DIFF
--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -437,6 +437,16 @@ impl Module {
     }
 }
 
+/// Structure that represents invalid rules by the compiler. See
+/// [`Compiler::ignore_invalid_rules`].
+#[pyclass]
+struct IgnoredRule {
+    #[pyo3(get)]
+    name: String,
+    #[pyo3(get)]
+    reason: String,
+}
+
 /// Returns the names of the supported modules.
 ///
 /// These are the modules that can be used in `import` statements in your
@@ -465,6 +475,7 @@ struct Compiler {
     relaxed_re_syntax: bool,
     error_on_slow_pattern: bool,
     includes_enabled: bool,
+    ignore_invalid_rules: bool,
 }
 
 impl Compiler {
@@ -497,19 +508,24 @@ impl Compiler {
     ///
     /// The `error_on_slow_pattern` argument tells the compiler to treat slow
     /// patterns as errors, instead of warnings.
+    ///
+    /// `ignore_invalid_rules` argument tells the compiler to report reasons for
+    /// ignoring invalid rules in [`Compiler::invalid_rules`].
     #[new]
-    #[pyo3(signature = (relaxed_re_syntax=false, error_on_slow_pattern=false, includes_enabled=true)
+    #[pyo3(signature = (relaxed_re_syntax=false, error_on_slow_pattern=false, includes_enabled=true, ignore_invalid_rules=false)
     )]
     fn new(
         relaxed_re_syntax: bool,
         error_on_slow_pattern: bool,
         includes_enabled: bool,
+        ignore_invalid_rules: bool,
     ) -> Self {
         let mut compiler = Self {
             inner: Self::new_inner(relaxed_re_syntax, error_on_slow_pattern),
             relaxed_re_syntax,
             error_on_slow_pattern,
             includes_enabled,
+            ignore_invalid_rules,
         };
         compiler.inner.enable_includes(includes_enabled);
         compiler
@@ -564,9 +580,14 @@ impl Compiler {
             src = src.with_origin(origin)
         }
 
-        self.inner
-            .add_source(src)
-            .map_err(|err| CompileError::new_err(err.to_string()))?;
+        match self.inner.add_source(src) {
+            Ok(_) => {}
+            Err(err) => {
+                if !self.ignore_invalid_rules {
+                    return Err(CompileError::new_err(err.to_string()));
+                }
+            }
+        };
 
         Ok(())
     }
@@ -685,6 +706,20 @@ impl Compiler {
         self.inner.max_warnings(n);
     }
 
+    /// Enables or disables ignoring invalid rules. If `True` the ignored rules
+    /// and the reasons for them being ignored are available in
+    /// [`Compiler::ignored_rules`] method.
+    ///
+    /// # Example
+    /// ```python
+    /// import yara_x
+    ///
+    /// compiler = yara_x.Compiler()
+    /// compiler.ignore_invalid_rules(True)
+    /// ```
+    fn ignore_invalid_rules(&mut self, yes: bool) {
+        self.ignore_invalid_rules = yes
+    }
     /// Builds the source code previously added to the compiler.
     ///
     /// This function returns an instance of [`Rules`] containing all the rules
@@ -729,6 +764,30 @@ impl Compiler {
         let warnings_json = warnings_json
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
         json_loads.call((warnings_json,), None)
+    }
+
+    /// Retrieves all ignored rules from the compiler.
+    ///
+    /// Returns a list of tuples where the first item is the rule name and the
+    /// second item is the reason.
+    fn ignored_rules(&mut self) -> Vec<IgnoredRule> {
+        self.inner
+            .ignored_rules()
+            .map(|(name, reason)| {
+                let reason_str = match reason {
+                    yrx::IgnoredRuleReason::IgnoredModule(module) => {
+                        format!("depends on ignored module `{module}`")
+                    }
+                    yrx::IgnoredRuleReason::IgnoredRule(parent_rule) => {
+                        format!("depends on ignored_rule `{parent_rule}`")
+                    }
+                    yrx::IgnoredRuleReason::CompileError(err) => {
+                        format!("error: {}", err.title())
+                    }
+                };
+                IgnoredRule { name: name.to_string(), reason: reason_str }
+            })
+            .collect()
     }
 
     #[pyo3(signature = (tags, error = false))]
@@ -1574,6 +1633,7 @@ fn yara_x(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Formatter>()?;
     m.add_class::<Module>()?;
     m.add_class::<MetaType>()?;
+    m.add_class::<IgnoredRule>()?;
     // This module still exposes unsendable classes and uses unsafe lifetime
     // extensions in the bindings, so it should not advertise free-threaded
     // safety until the API is properly audited and redesigned.

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -437,6 +437,15 @@ impl Module {
     }
 }
 
+/// Reasons a rule can be ignored by the compiler.
+#[pyclass(eq, eq_int, from_py_object)]
+#[derive(PartialEq, Clone)]
+enum IgnoredRuleReason {
+    IgnoredModule,
+    IgnoredRule,
+    CompileError,
+}
+
 /// Structure that represents invalid rules by the compiler. See
 /// [`Compiler::ignore_invalid_rules`].
 #[pyclass]
@@ -444,7 +453,9 @@ struct IgnoredRule {
     #[pyo3(get)]
     name: String,
     #[pyo3(get)]
-    reason: String,
+    message: String,
+    #[pyo3(get)]
+    reason: IgnoredRuleReason,
 }
 
 /// Returns the names of the supported modules.
@@ -510,7 +521,7 @@ impl Compiler {
     /// patterns as errors, instead of warnings.
     ///
     /// `ignore_invalid_rules` argument tells the compiler to report reasons for
-    /// ignoring invalid rules in [`Compiler::invalid_rules`].
+    /// ignoring invalid rules in [`Compiler::ignored_rules`].
     #[new]
     #[pyo3(signature = (relaxed_re_syntax=false, error_on_slow_pattern=false, includes_enabled=true, ignore_invalid_rules=false)
     )]
@@ -770,22 +781,29 @@ impl Compiler {
     ///
     /// Returns a list of tuples where the first item is the rule name and the
     /// second item is the reason.
-    fn ignored_rules(&mut self) -> Vec<IgnoredRule> {
+    fn ignored_rules<'py>(&'py self) -> Vec<IgnoredRule> {
         self.inner
             .ignored_rules()
             .map(|(name, reason)| {
-                let reason_str = match reason {
-                    yrx::IgnoredRuleReason::IgnoredModule(module) => {
-                        format!("depends on ignored module `{module}`")
-                    }
-                    yrx::IgnoredRuleReason::IgnoredRule(parent_rule) => {
-                        format!("depends on ignored_rule `{parent_rule}`")
-                    }
-                    yrx::IgnoredRuleReason::CompileError(err) => {
-                        format!("error: {}", err.title())
-                    }
+                let (message, reason_type) = match reason {
+                    yrx::IgnoredRuleReason::IgnoredModule(module) => (
+                        format!("depends on ignored module `{module}`"),
+                        IgnoredRuleReason::IgnoredModule,
+                    ),
+                    yrx::IgnoredRuleReason::IgnoredRule(parent_rule) => (
+                        format!("depends on ignored rule `{parent_rule}`"),
+                        IgnoredRuleReason::IgnoredRule,
+                    ),
+                    yrx::IgnoredRuleReason::CompileError(err) => (
+                        format!("error: {}", err.title()),
+                        IgnoredRuleReason::CompileError,
+                    ),
                 };
-                IgnoredRule { name: name.to_string(), reason: reason_str }
+                IgnoredRule {
+                    name: name.to_string(),
+                    message,
+                    reason: reason_type,
+                }
             })
             .collect()
     }
@@ -1634,6 +1652,7 @@ fn yara_x(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Module>()?;
     m.add_class::<MetaType>()?;
     m.add_class::<IgnoredRule>()?;
+    m.add_class::<IgnoredRuleReason>()?;
     // This module still exposes unsendable classes and uses unsafe lifetime
     // extensions in the bindings, so it should not advertise free-threaded
     // safety until the API is properly audited and redesigned.

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -781,7 +781,7 @@ impl Compiler {
     ///
     /// Returns a list of tuples where the first item is the rule name and the
     /// second item is the reason.
-    fn ignored_rules<'py>(&'py self) -> Vec<IgnoredRule> {
+    fn ignored_rules(&self) -> Vec<IgnoredRule> {
         self.inner
             .ignored_rules()
             .map(|(name, reason)| {

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -42,13 +42,22 @@ def test_invalid_allowed_metadata_regexp():
 
 def test_ignore_invalid_rules():
   compiler = yara_x.Compiler(ignore_invalid_rules=True)
-  compiler.add_source(r'rule test { condition: foo } rule test2 { condition: bar }')
-  assert len(compiler.ignored_rules()) == 2
+  compiler.ignore_module("foo")
+  # "test" should be ignored because it depends on an ignored module.
+  # "test2" should be ignored because it depends on an ignored rule (test).
+  # "test3" should be ignored because it is a compilation error.
+  compiler.add_source(r'import "foo" rule test { condition: foo.bar == 1 } rule test2 { condition: test } rule test3 { condition: AXSERS }')
+  assert len(compiler.ignored_rules()) == 3
   assert compiler.ignored_rules()[0].name == 'test'
-  assert compiler.ignored_rules()[0].reason == 'error: unknown identifier `foo`'
+  assert compiler.ignored_rules()[0].message == 'depends on ignored module `foo`'
+  assert compiler.ignored_rules()[0].reason == yara_x.IgnoredRuleReason.IgnoredModule
   assert compiler.ignored_rules()[1].name == 'test2'
-  assert compiler.ignored_rules()[1].reason == 'error: unknown identifier `bar`'
-  # Turn off ignore_invalid_rules and we should get a compile error now.
+  assert compiler.ignored_rules()[1].message == 'depends on ignored rule `test`'
+  assert compiler.ignored_rules()[1].reason == yara_x.IgnoredRuleReason.IgnoredRule
+  assert compiler.ignored_rules()[2].name == 'test3'
+  assert compiler.ignored_rules()[2].message == 'error: unknown identifier `AXSERS`'
+  assert compiler.ignored_rules()[2].reason == yara_x.IgnoredRuleReason.CompileError
+  # Turn off ignore_invalid_rules and we should raise a compile error now.
   compiler.ignore_invalid_rules(False)
   with pytest.raises(yara_x.CompileError):
     compiler.add_source(r'rule test { condition: AXSERS }')

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -40,6 +40,18 @@ def test_invalid_allowed_metadata_regexp():
   with pytest.raises(ValueError):
     compiler.allowed_metadata('author', yara_x.MetaType.STRING, regexp='(AXS|ERS')
 
+def test_ignore_invalid_rules():
+  compiler = yara_x.Compiler(ignore_invalid_rules=True)
+  compiler.add_source(r'rule test { condition: foo } rule test2 { condition: bar }')
+  assert len(compiler.ignored_rules()) == 2
+  assert compiler.ignored_rules()[0].name == 'test'
+  assert compiler.ignored_rules()[0].reason == 'error: unknown identifier `foo`'
+  assert compiler.ignored_rules()[1].name == 'test2'
+  assert compiler.ignored_rules()[1].reason == 'error: unknown identifier `bar`'
+  # Turn off ignore_invalid_rules and we should get a compile error now.
+  compiler.ignore_invalid_rules(False)
+  with pytest.raises(yara_x.CompileError):
+    compiler.add_source(r'rule test { condition: AXSERS }')
 
 def test_int_globals():
   compiler = yara_x.Compiler()

--- a/py/yara_x.pyi
+++ b/py/yara_x.pyi
@@ -211,6 +211,12 @@ class Compiler:
         ...
 
 @final
+class IgnoredRuleReason(Enum):
+    IgnoredModule: int
+    IgnoredRule: int
+    CompileError: int
+
+@final
 class IgnoredRule:
     r"""
     Names and reasons for any ignored rules during compilation.
@@ -223,9 +229,15 @@ class IgnoredRule:
         """
         ...
 
-    def reason() -> str:
+    def message() -> str:
         r"""
-        Reason the rule was ignored.
+        Message for why the rule was ignored.
+        """
+        ...
+
+    def reason() -> IgnoredRuleReason:
+        r"""
+        Reason for why the rule was ignored.
         """
         ...
 

--- a/py/yara_x.pyi
+++ b/py/yara_x.pyi
@@ -135,6 +135,15 @@ class Compiler:
         """
         ...
 
+    def ignore_invalid_rules(self, yes: bool) -> None:
+        r"""
+        Tell the compiler to ignore any rules that are invalid.
+
+        Any ignored rules and the reasons for them being ignored are available
+        in [`Compiler::ignored_rules`].
+        """
+        ...
+
     def build(self) -> Rules:
         r"""
         Builds the source code previously added to the compiler.

--- a/py/yara_x.pyi
+++ b/py/yara_x.pyi
@@ -144,6 +144,14 @@ class Compiler:
         """
         ...
 
+    def ignored_rules() -> List[IgnoredRule]:
+        r"""
+        Retrieve all ignored rules during compilation.
+
+        Returns a list of [`IgnoredRule`] objects.
+        """
+        ...
+
     def build(self) -> Rules:
         r"""
         Builds the source code previously added to the compiler.
@@ -200,6 +208,25 @@ class Compiler:
             regexp: Optional[str],
             error: bool = False):
         r"""Define expected type and value for metadata on rules."""
+        ...
+
+@final
+class IgnoredRule:
+    r"""
+    Names and reasons for any ignored rules during compilation.
+
+    See [`Compiler::ignore_invalid_rules] for details.
+    """
+    def name() -> str:
+        r"""
+        Name of the ignored rule.
+        """
+        ...
+
+    def reason() -> str:
+        r"""
+        Reason the rule was ignored.
+        """
         ...
 
 @final


### PR DESCRIPTION
This commit exposes the new feature of ignoring invalid rules during
compilation. It is set to False by default but if turned on than errors are not
raised on compilation failure and any ignored rules will be returned when
calling the `Compiler::ignored_rules()` method. It returns a list of IgnoredRule
objects which have two properties: name and reason.