### PR TITLE
feat: Add missing modules to python and dump command.

### DIFF
--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -24,6 +24,8 @@ enum SupportedModules {
     Vba,
     Crx,
     Dex,
+    Msi,
+    Zip,
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/cli/src/commands/dump.rs
+++ b/cli/src/commands/dump.rs
@@ -129,6 +129,9 @@ pub fn exec_dump(args: &ArgMatches) -> anyhow::Result<()> {
         if !requested_modules.contains(&&SupportedModules::Vba) {
             module_output.vba = MessageField::none()
         }
+        if !requested_modules.contains(&&SupportedModules::Msi) {
+            module_output.msi = MessageField::none()
+        }
     } else {
         // Module was not specified, only show those that produced meaningful
         // results, the rest are cleared out.
@@ -160,6 +163,9 @@ pub fn exec_dump(args: &ArgMatches) -> anyhow::Result<()> {
         }
         if !module_output.vba.has_macros() {
             module_output.vba = MessageField::none()
+        }
+        if !module_output.msi.is_signed() {
+            module_output.msi = MessageField::none()
         }
     }
 

--- a/lib/src/modules/mod.rs
+++ b/lib/src/modules/mod.rs
@@ -296,6 +296,15 @@ pub mod mods {
     /// Data structure returned by the `pe` module.
     pub use super::protos::pe::PE;
 
+    /// Data structures defined by the `zip` module.
+    ///
+    /// The main structure produced by the module is [`zip::Zip`]. The rest
+    /// of them are used by one or more fields in the main structure.
+    ///
+    pub use super::protos::zip;
+    /// Data structure returned by the `pe` module.
+    pub use super::protos::zip::Zip;
+
     /// A data structure containing the data returned by all modules.
     pub use super::protos::mods::Modules;
 

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -27,10 +27,14 @@ lnk-module = ["yara-x/lnk-module"]
 macho-module = ["yara-x/macho-module"]
 magic-module = ["yara-x/magic-module"]
 math-module = ["yara-x/math-module"]
+msi-module = ["yara-x/msi-module"]
+olecf-module = ["yara-x/olecf-module"]
 pe-module = ["yara-x/pe-module"]
 string-module = ["yara-x/string-module"]
 time-module = ["yara-x/time-module"]
+vba-module = ["yara-x/vba-module"]
 vt-module = ["yara-x/vt-module"]
+zip-module = ["yara-x/zip-module"]
 test_proto2-module = ["yara-x/test_proto2-module"]
 test_proto3-module = ["yara-x/test_proto3-module"]
 
@@ -46,10 +50,14 @@ default = [
     "lnk-module",
     "macho-module",
     "math-module",
+    "msi-module",
+    "olecf-module",
     "pe-module",
     "string-module",
     "time-module",
+    "vba-module",
     "vt-module",
+    "zip-module",
 ]
 
 [dependencies]

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -71,6 +71,14 @@ enum SupportedModules {
     Crx,
     #[cfg(feature = "dex-module")]
     Dex,
+    #[cfg(feature = "olecf-module")]
+    Olecf,
+    #[cfg(feature = "msi-module")]
+    Msi,
+    #[cfg(feature = "vba-module")]
+    Vba,
+    #[cfg(feature = "zip-module")]
+    Zip,
 }
 
 // These are copies from the checker in the CLI, but exposing them in the API
@@ -424,6 +432,22 @@ impl Module {
                 #[cfg(feature = "dex-module")]
                 SupportedModules::Dex => {
                     yrx::mods::invoke_dyn::<yrx::mods::Dex>(data)
+                }
+                #[cfg(feature = "msi-module")]
+                SupportedModules::Msi=> {
+                    yrx::mods::invoke_dyn::<yrx::mods::Msi>(data)
+                }
+                #[cfg(feature = "olecf-module")]
+                SupportedModules::Olecf=> {
+                    yrx::mods::invoke_dyn::<yrx::mods::Olecf>(data)
+                }
+                #[cfg(feature = "vba-module")]
+                SupportedModules::Vba=> {
+                    yrx::mods::invoke_dyn::<yrx::mods::Vba>(data)
+                }
+                #[cfg(feature = "zip-module")]
+                SupportedModules::Zip=> {
+                    yrx::mods::invoke_dyn::<yrx::mods::Zip>(data)
                 }
                 _ => return Ok(py.None().into_bound(py)),
             };

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -434,19 +434,19 @@ impl Module {
                     yrx::mods::invoke_dyn::<yrx::mods::Dex>(data)
                 }
                 #[cfg(feature = "msi-module")]
-                SupportedModules::Msi=> {
+                SupportedModules::Msi => {
                     yrx::mods::invoke_dyn::<yrx::mods::Msi>(data)
                 }
                 #[cfg(feature = "olecf-module")]
-                SupportedModules::Olecf=> {
+                SupportedModules::Olecf => {
                     yrx::mods::invoke_dyn::<yrx::mods::Olecf>(data)
                 }
                 #[cfg(feature = "vba-module")]
-                SupportedModules::Vba=> {
+                SupportedModules::Vba => {
                     yrx::mods::invoke_dyn::<yrx::mods::Vba>(data)
                 }
                 #[cfg(feature = "zip-module")]
-                SupportedModules::Zip=> {
+                SupportedModules::Zip => {
                     yrx::mods::invoke_dyn::<yrx::mods::Zip>(data)
                 }
                 _ => return Ok(py.None().into_bound(py)),


### PR DESCRIPTION
There has been some new module additions lately that were not exposed in the python API. This adds the msi, olecf, vba and zip module to the python interface so you can invoke them directly from python.

It also adds the msi and zip modules to the dump command, which seems to be an oversight.