### PR TITLE
fix: align completions with default formatting

### DIFF
--- a/ls/src/features/completion.rs
+++ b/ls/src/features/completion.rs
@@ -45,11 +45,11 @@ const SRC_SUGGESTIONS: [(&str, Option<&str>); 5] = [
         "rule",
         Some(
             r#"rule ${1:ident} {
-  strings:
-    $${2:a} = "${3}"
-  condition:
-    $${2:a}${0}
- }"#,
+    strings:
+        $${2:a} = "${3}"
+    condition:
+        $${2:a}${0}
+}"#,
         ),
     ),
     ("import", Some("import \"${1:}\"${0}")),
@@ -66,9 +66,9 @@ const CONDITION_SUGGESTIONS: [(&str, Option<&str>); 16] = [
     ("none", None),
     ("of", None),
     ("at", Some("at ${1:expression}")),
-    ("in", Some("in ${1:}..${2:}")),
+    ("in", Some("in (${1:}..${2:})")),
     ("filesize", None),
-    ("entrypoint", None),
+    ("entrypoint", "pe.entry_point"),
     ("true", None),
     ("false", None),
     ("not", None),

--- a/ls/src/features/completion.rs
+++ b/ls/src/features/completion.rs
@@ -68,7 +68,7 @@ const CONDITION_SUGGESTIONS: [(&str, Option<&str>); 16] = [
     ("at", Some("at ${1:expression}")),
     ("in", Some("in (${1:}..${2:})")),
     ("filesize", None),
-    ("entrypoint", "pe.entry_point"),
+    ("entrypoint", Some("pe.entry_point")),
     ("true", None),
     ("false", None),
     ("not", None),

--- a/ls/src/tests/testdata/completion1.response.json
+++ b/ls/src/tests/testdata/completion1.response.json
@@ -1,6 +1,6 @@
 [
   {
-    "insertText": "rule ${1:ident} {\n  strings:\n    $${2:a} = \"${3}\"\n  condition:\n    $${2:a}${0}\n }",
+    "insertText": "rule ${1:ident} {\n    strings:\n        $${2:a} = \"${3}\"\n    condition:\n        $${2:a}${0}\n}",
     "insertTextFormat": 2,
     "insertTextMode": 2,
     "kind": 2,

--- a/ls/src/tests/testdata/completion14.response.json
+++ b/ls/src/tests/testdata/completion14.response.json
@@ -37,7 +37,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -47,6 +47,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },

--- a/ls/src/tests/testdata/completion15.response.json
+++ b/ls/src/tests/testdata/completion15.response.json
@@ -44,7 +44,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -54,6 +54,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },

--- a/ls/src/tests/testdata/completion2.response.json
+++ b/ls/src/tests/testdata/completion2.response.json
@@ -51,7 +51,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -61,6 +61,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },

--- a/ls/src/tests/testdata/completion22.response.json
+++ b/ls/src/tests/testdata/completion22.response.json
@@ -30,7 +30,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -40,6 +40,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },

--- a/ls/src/tests/testdata/completion23.response.json
+++ b/ls/src/tests/testdata/completion23.response.json
@@ -44,7 +44,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -54,6 +54,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },

--- a/ls/src/tests/testdata/completion24.response.json
+++ b/ls/src/tests/testdata/completion24.response.json
@@ -37,7 +37,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -47,6 +47,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },

--- a/ls/src/tests/testdata/completion7.response.json
+++ b/ls/src/tests/testdata/completion7.response.json
@@ -1,6 +1,6 @@
 [
   {
-    "insertText": "rule ${1:ident} {\n  strings:\n    $${2:a} = \"${3}\"\n  condition:\n    $${2:a}${0}\n }",
+    "insertText": "rule ${1:ident} {\n    strings:\n        $${2:a} = \"${3}\"\n    condition:\n        $${2:a}${0}\n}",
     "insertTextFormat": 2,
     "insertTextMode": 2,
     "kind": 2,

--- a/ls/src/tests/testdata/completion9.response.json
+++ b/ls/src/tests/testdata/completion9.response.json
@@ -30,7 +30,7 @@
     "label": "at"
   },
   {
-    "insertText": "in ${1:}..${2:}",
+    "insertText": "in (${1:}..${2:})",
     "insertTextFormat": 2,
     "kind": 14,
     "label": "in"
@@ -40,6 +40,8 @@
     "label": "filesize"
   },
   {
+    "insertText": "pe.entry_point",
+    "insertTextFormat": 2,
     "kind": 14,
     "label": "entrypoint"
   },


### PR DESCRIPTION
Aligned the default rule completion with the default formatting, added parens around the range in the `in` completion. 

The `entrypoint` is deprecated, so replacing it with `pe.entry_point` may be desired. An enhancement would be to add `import "pe"` with the other imports on completion, or when `pe.entry_point` is completed, not just for competing `pe`.