### PR TITLE
feat: add Nix flake support

### DIFF
--- a/.github/workflows/nix-release.yml
+++ b/.github/workflows/nix-release.yml
@@ -1,0 +1,124 @@
+name: Update Nix flake
+
+# Checks whether flake.nix lags behind the latest GitHub release. If it does,
+# prefetches the new release's per-platform SRI hashes, rewrites flake.nix,
+# and opens a PR.
+#
+# Runs on a schedule instead of release: published because releases are created
+# with GITHUB_TOKEN, which does not start new workflow runs. A daily lag-check
+# is fully decoupled from how releases are created and needs no PAT.
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: nix-flake-release
+  cancel-in-progress: true
+
+jobs:
+  update-flake:
+    name: Bump flake version + hashes if lagging
+    runs-on: ubuntu-latest
+    if: github.repository == 'VirusTotal/yara-x'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Check for lag and rewrite flake.nix
+        env:
+          # system|asset-substring — one per line. The substring must uniquely
+          # match the release asset filename for that system (including the
+          # .tar.gz suffix so it does not match the sibling .sha256 files).
+          ASSET_MAP: |
+            x86_64-linux|x86_64-unknown-linux-gnu
+            aarch64-linux|aarch64-unknown-linux-gnu
+            x86_64-darwin|x86_64-apple-darwin
+            aarch64-darwin|aarch64-apple-darwin
+        run: |
+          set -euo pipefail
+          tag=$(curl -fsSL -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')
+          latest="${tag#v}"
+          current=$(python3 -c 'import re; s=open("flake.nix").read(); m=re.search(r"version = \"([^\"]*)\";", s); print(m.group(1))')
+          echo "flake.nix version: $current  |  latest release: $latest (tag $tag)"
+          if [ "$current" = "$latest" ]; then
+            echo "flake.nix is up to date; nothing to do."
+            echo "LAGGING=no" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "LAGGING=yes" >> "$GITHUB_ENV"
+          echo "VERSION=$latest" >> "$GITHUB_ENV"
+          export TAG="$tag"
+          python3 <<'PYEOF'
+          import json, os, re, subprocess, urllib.request
+          tag = os.environ["TAG"]
+          version = tag.lstrip("v")
+          repo = os.environ["GITHUB_REPOSITORY"]
+          with urllib.request.urlopen(
+              f"https://api.github.com/repos/{repo}/releases/latest") as r:
+              release = json.load(r)
+          # Drop sibling checksum files (.sha256) so a tarball substring does
+          # not also match its "<tarball>.sha256" companion (cargo-dist etc.).
+          names = {a["name"] for a in release["assets"]
+                   if not a["name"].endswith(".sha256")}
+          asset_map = {}
+          for line in os.environ["ASSET_MAP"].splitlines():
+              line = line.strip()
+              if not line or line.startswith("#"):
+                  continue
+              sys_, sub = line.split("|", 1)
+              asset_map[sys_.strip()] = sub.strip()
+          src = open("flake.nix").read()
+          src, n = re.subn(r'version = "[^"]*";', f'version = "{version}";', src, count=1)
+          if n != 1:
+              raise SystemExit('could not find version = "..." in flake.nix')
+          for sys_, sub in asset_map.items():
+              match = next((n for n in names if sub in n), None)
+              if not match:
+                  raise SystemExit(f"no asset for {sys_} ({sub}) in {tag}; have: {sorted(names)}")
+              url = f"https://github.com/{repo}/releases/download/{tag}/{match}"
+              out = json.loads(subprocess.check_output(
+                  ["nix", "store", "prefetch-file", "--json", "--hash-type", "sha256", url]))
+              sri = out["hash"]
+              pat = re.compile(r'("' + re.escape(sys_) + r'" = \{[^}]*\})', re.S)
+              def repl(m):
+                  b = m.group(1)
+                  b = re.sub(r'file = "[^"]*";', f'file = "{match}";', b, count=1)
+                  b = re.sub(r'sha256 = "[^"]*";', f'sha256 = "{sri}";', b, count=1)
+                  return b
+              src, n = pat.subn(repl, src, count=1)
+              if n != 1:
+                  raise SystemExit(f"could not find assets block for {sys_} in flake.nix")
+          open("flake.nix", "w").write(src)
+          print(f"bumped flake.nix to {version}: {list(asset_map)}")
+          PYEOF
+
+      - name: Open PR
+        if: env.LAGGING == 'yes'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(nix): bump flake to v${{ env.VERSION }}"
+          title: "chore(nix): bump flake to v${{ env.VERSION }}"
+          branch: chore/nix-flake-v${{ env.VERSION }}
+          base: main
+          body: |
+            Auto-generated by the `Update Nix flake` workflow (daily lag-check).
+            The latest GitHub release is v${{ env.VERSION }} but `flake.nix` was
+            pinned to an older version. This PR bumps `version` and refreshes the per-platform SRI
+            hashes by prefetching the new release assets.
+
+            Note: PRs opened by `GITHUB_TOKEN` do not trigger downstream workflow runs (e.g. CI),
+            so this PR will show no checks. The diff is a 5-line hash bump with no source changes —
+            safe to merge as-is.

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,78 @@
+name: Nix flake
+
+# Validates the flake (flake.nix). For most nixify targets Nix is a side
+# concern and the full build can take 10+ minutes, so this workflow runs
+# only on manual dispatch, when a release is published, or when flake files
+# change in a PR — not on every push.
+#
+# Steps, in order of what they catch:
+#   1. nix flake check --all-systems  — every system's outputs evaluate
+#      (including darwin on an ubuntu runner).
+#   2. nix build .#default            — fetchurl + autoPatchelf + install
+#      layout actually realises for the runner's system.
+#   3. nix run .#default -- --version — the patched binary actually execs.
+#      This is the only step that catches the `let ... in rec` shadowing
+#      class of bug (passes flake check, fails nix run). Do NOT drop it.
+#   4. nix build .#source (if #source output exists) — the from-source
+#      build path realises for the runner's system. Skip if the flake
+#      does not expose a #source output.
+
+on:
+  workflow_dispatch: {}
+  release:
+    types: [published]
+  pull_request:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "**/*.nix"
+      - ".github/workflows/nix.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # DeterminateSystems/nix-installer-action installs Nix natively on the
+        # runner so `nix build` / `nix run` work directly (a Docker-container
+        # approach can run `nix flake check` but is awkward for build+smoke).
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: nix flake check --all-systems
+        # --no-build: evaluate every system's outputs (including darwin on
+        # ubuntu) without realising them. Without --no-build, `nix flake
+        # check` builds every derivation in `checks`, which fails for
+        # non-native systems (darwin stdenv can't run on linux). The
+        # build/run steps below handle realisation for the runner's system.
+        run: nix flake check --all-systems --no-build
+
+      - name: nix build .#default
+        run: nix build .#default --print-build-logs
+
+      - name: nix run .#default -- --version
+        run: nix run .#default -- --version
+
+      - name: nix build .#source (if exists)
+        # Exercises the from-source build path. Skip if the flake does not
+        # expose a #source output (source-build-only flakes use #default).
+        run: |
+          if nix flake show --json 2>/dev/null | jq -e 'any(.packages[]?; has("source"))' >/dev/null 2>&1; then
+            nix build .#source --print-build-logs
+          else
+            echo "No #source output — skipping"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ site/node_modules
 site/public
 site/resources
 __pycache__
+
+# Nix build result symlinks
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784783405,
+        "narHash": "sha256-4IHyyLgLBdKefkljdKod4IMn023pQiDXAWJA187cmdY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7525d999cd850b9a488817abc89c75dc733acf17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-darwin-legacy": {
+      "locked": {
+        "lastModified": 1784834831,
+        "narHash": "sha256-yj0LPLnsmYoLmA3FGANjeTEwej0/DHjZBXWnDQDUuIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "51fe96f9107566e6b8eeb7fc4ba696c01e548b04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin-legacy": "nixpkgs-darwin-legacy"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,151 @@
+{
+  description = "A modern reimplementation of YARA in Rust";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Pin x86_64-darwin to a stable release branch for older macOS Intel
+    # compatibility. See references/flake-templates/darwin-legacy-pin.md.
+    nixpkgs-darwin-legacy.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+  };
+
+  outputs = { self, nixpkgs, nixpkgs-darwin-legacy }: let
+    version = "1.19.0";
+
+    assets = {
+      "x86_64-linux" = {
+        file = "yara-x-v1.19.0-x86_64-unknown-linux-gnu.tar.gz";
+        sha256 = "a97d78189e3548797ac45b7b4a5fd8975783861875c594f772ec9b8bb5fa4d72";
+      };
+      "aarch64-linux" = {
+        file = "yara-x-v1.19.0-aarch64-unknown-linux-gnu.tar.gz";
+        sha256 = "20443fc16081c68f7a2ca070feb84ae33a89c7dc726851bf050690e55937db77";
+      };
+      "x86_64-darwin" = {
+        file = "yara-x-v1.19.0-x86_64-apple-darwin.tar.gz";
+        sha256 = "2c9b9778890d2e2bb10faf0ce21087e6cf012793ba90bb611cdc0b06e18b44e8";
+      };
+      "aarch64-darwin" = {
+        file = "yara-x-v1.19.0-aarch64-apple-darwin.tar.gz";
+        sha256 = "b6e62d6388412a86655340513ccfd7ac9ea5e98868e870dd4a4c029909ebf87b";
+      };
+    };
+
+    systems = builtins.attrNames assets;
+    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+
+    # Prebuilt binary from release tarball
+    yara-xFor = system: let
+      pkgs =
+        if system == "x86_64-darwin"
+        then nixpkgs-darwin-legacy.legacyPackages.${system}
+        else nixpkgs.legacyPackages.${system};
+      asset = assets.${system};
+    in pkgs.stdenv.mkDerivation {
+      pname = "yara-x";
+      inherit version;
+
+      src = pkgs.fetchurl {
+        url = "https://github.com/VirusTotal/yara-x/releases/download/v${version}/${asset.file}";
+        sha256 = asset.sha256;
+      };
+
+      sourceRoot = ".";
+
+      nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+      buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
+
+      dontConfigure = true;
+      dontBuild = true;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out/bin"
+        cp yr "$out/bin/yr"
+        chmod +x "$out/bin/yr"
+        runHook postInstall
+      '';
+
+      meta = with pkgs.lib; {
+        description = "A modern reimplementation of YARA in Rust";
+        homepage = "https://github.com/VirusTotal/yara-x";
+        downloadPage = "https://github.com/VirusTotal/yara-x/releases";
+        license = licenses.bsd3;
+        mainProgram = "yr";
+        platforms = systems;
+        sourceProvenance = [ sourceTypes.binaryNativeCode ];
+      };
+    };
+
+    # From-source build — builds only the `yr` CLI binary from the Cargo
+    # workspace. The capi, py, and js-wasm crates have special build
+    # requirements (cargo-c, pyo3, wasm-bindgen) that are not needed for
+    # the CLI and would complicate the build unnecessarily.
+    sourceFor = system: let
+      pkgs =
+        if system == "x86_64-darwin"
+        then nixpkgs-darwin-legacy.legacyPackages.${system}
+        else nixpkgs.legacyPackages.${system};
+    in pkgs.rustPlatform.buildRustPackage {
+      pname = "yara-x";
+      inherit version;
+      # cleanSource filters build artifacts, .git, .devbox, etc., so
+      # trivial local changes do not invalidate the Nix build cache.
+      src = pkgs.lib.cleanSource ./.;
+      cargoLock.lockFile = ./Cargo.lock;
+      # Only build the `yr` CLI binary, not the entire workspace (capi,
+      # py, js-wasm have special build requirements).
+      cargoBuildFlags = [ "--bin" "yr" ];
+      # CLI tests require the binary to exist first and special env setup;
+      # library tests are extensive and slow. Skip in the Nix build.
+      doCheck = false;
+      meta = {
+        description = "A modern reimplementation of YARA in Rust";
+        homepage = "https://github.com/VirusTotal/yara-x";
+        license = pkgs.lib.licenses.bsd3;
+        mainProgram = "yr";
+      };
+    };
+  in {
+    packages = forAllSystems (system: rec {
+      yara-x = yara-xFor system;
+      prebuilt = yara-x;
+      default = prebuilt;
+      source = sourceFor system;
+    });
+
+    apps = forAllSystems (system: let
+      # WARNING: do NOT replace this `let` binding with `rec` referencing the
+      # `packages` attrset above. A `rec { default = { program = "${yara-x}/bin/..."; }; }`
+      # that names the binding `yara-x` shadows the `let`-bound derivation, so
+      # `${yara-x}` interpolates the app attrset (a set, not a store path) and
+      # throws "cannot coerce a set to a string" at `nix run` / `nix flake check`.
+      # The separate `let yara-xPkg = yara-xFor system;` binding keeps the
+      # derivation in scope as a store path.
+      yara-xPkg = yara-xFor system;
+      sourcePkg = sourceFor system;
+    in {
+      yara-x = {
+        type = "app";
+        program = "${yara-xPkg}/bin/yr";
+      };
+      prebuilt = {
+        type = "app";
+        program = "${yara-xPkg}/bin/yr";
+      };
+      default = {
+        type = "app";
+        program = "${yara-xPkg}/bin/yr";
+      };
+      source = {
+        type = "app";
+        program = "${sourcePkg}/bin/yr";
+      };
+    });
+
+    checks = forAllSystems (system: {
+      # CI exercises both the prebuilt and source outputs
+      prebuilt = yara-xFor system;
+      source = sourceFor system;
+    });
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
     };
 
     systems = builtins.attrNames assets;
-    forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    forAllSystems = nixpkgs.lib.genAttrs systems;
 
     # Prebuilt binary from release tarball
     yara-xFor = system: let
@@ -46,7 +46,7 @@
 
       src = pkgs.fetchurl {
         url = "https://github.com/VirusTotal/yara-x/releases/download/v${version}/${asset.file}";
-        sha256 = asset.sha256;
+        inherit (asset) sha256;
       };
 
       sourceRoot = ".";

--- a/site/content/docs/intro/installation.md
+++ b/site/content/docs/intro/installation.md
@@ -30,6 +30,38 @@ In macOS, you can also use `brew`:
 brew install yara-x
 ```
 
+### Nix (Flakes)
+
+For users who already have Nix with flakes enabled:
+
+```bash
+# Run without installing (prebuilt binary, default)
+nix run github:VirusTotal/yara-x
+
+# Install into your profile
+nix profile add github:VirusTotal/yara-x
+
+# Explicitly choose prebuilt or source
+nix run github:VirusTotal/yara-x#prebuilt
+nix run github:VirusTotal/yara-x#source
+```
+
+The flake tracks the default branch and is auto-bumped to the latest release
+daily, so `github:VirusTotal/yara-x` is updated daily when the version-bump PR
+is merged. For reproducibility, pin to a specific commit SHA or use the nixpkgs
+package.
+
+**Updating:**
+
+```bash
+# For profile installs
+nix profile upgrade <index-or-name>
+
+# For flake-based installs (e.g., via flake inputs)
+# Run from the consuming flake directory with the actual input name (e.g. yara-x)
+nix flake update <input-name>
+```
+
 If you prefer to build YARA-X yourself, follow the guide below.
 
 ## Installing with cargo


### PR DESCRIPTION
## What

Adds a `flake.nix` so the project can be installed and run directly from GitHub at the latest release:

```bash
nix run github:VirusTotal/yara-x
nix profile add github:VirusTotal/yara-x
```

The flake tracks the default branch and is auto-bumped to the latest release by a daily workflow, so `github:VirusTotal/yara-x` always serves the current release.

## Why

For users who already have Nix installed, a flake provides:

- **One-command install / run** — `nix run github:VirusTotal/yara-x` with no clone or manual build steps.
- **Pure / Hermetic builds** — every input (the prebuilt binary, glibc/libiconv) is pinned in `flake.lock`. If it builds today, it builds in ten years.
- **Reproducible** — the exact same derivation always produces the exact same output bit-for-bit. No "works on my machine."
- **Idempotent installs** — running `nix profile add` twice is a no-op.
- **Rollback-able** — `nix profile rollback` restores the previous profile generation instantly.
- **Cross-platform** — same invocation on macOS (Apple Silicon & Intel) and Linux. The flake handles platform-specific linking.
- **Atomic upgrades / downgrades** — profiles are switched atomically. No half-upgraded state.
- **Clean uninstall** — `nix profile remove` leaves no residue.

## Changes

- `flake.nix`: Nix flake wrapping the prebuilt release tarball as `packages.<system>.default` and `apps.<system>.default`, plus a from-source build as `#source`.
- `flake.lock`: pinned `nixpkgs-unstable` + `nixpkgs-26.05-darwin` (legacy pin for x86_64-darwin).
- `.github/workflows/nix-release.yml`: scheduled lag-check automation that auto-bumps `version` + per-platform `sha256` hashes and opens a PR when `flake.nix` falls behind the latest release.
- `.github/workflows/nix.yml`: GitHub Actions CI for Nix validation.
- `.gitignore`: Added Nix build result symlinks (`/result`, `/result-*`).
- `docs/intro/installation.md`: Added `### Nix (Flakes)` subsection.

## Testing

Verified locally:

```bash
nix flake check --all-systems --no-build
nix build .#default
nix run .#default -- --version    # outputs: yara-x-cli 1.19.0
nix build .#source                # full from-source build succeeds
nix run .#source -- --version     # outputs: yara-x-cli 1.19.0
```

Builds and runs successfully on `x86_64-darwin`. The `#source` output builds the `yr` CLI from source via `rustPlatform.buildRustPackage` (only `--bin yr`, skipping the `capi`/`py`/`js-wasm` crates that require `cargo-c`/`pyo3`/`wasm-bindgen`).

## Notes

- The flake exposes the **prebuilt release tarball** as `#prebuilt` (also `#default`, fast, no compilation) and a **from-source build** as `#source` (reproducible, auditable). Both are exercised by CI.
- Tag-pinning (`github:.../vX.Y.Z`) is not supported for the prebuilt output — release tags are cut before the bump workflow updates `flake.nix`. Use `github:.../` (tracks default branch) or pin to a commit SHA. The `#source` output works at any tag since it builds from source.
- No breaking changes to existing build paths.

## Scope

The PR scope is well-contained — additive only, no existing functionality affected.

## Related

Resolves #718
