### PR TITLE
refactor: use carrying_add instead of overflowing_add

### DIFF
--- a/lib/src/modules/pe/mod.rs
+++ b/lib/src/modules/pe/mod.rs
@@ -146,21 +146,10 @@ fn calculate_checksum(ctx: &mut ScanContext) -> Option<i64> {
         map(u8, |v| v as u32),
     ));
 
+    let mut carry = false;
+
     for v in &mut nom::combinator::iterator(data, data_parser) {
-        // TODO: use carrying_add when it becomes stable.
-        // This:
-        //   sum = match sum.overflowing_add(v) {
-        //      (s, true) => s + 1,
-        //      (s, false) => s,
-        //   }
-        // Becomes this:
-        //   (sum, carry) = sum.carrying_add(v, carry);
-        //
-        // Where `carry` must be initialized to false outside of the loop.
-        sum = match sum.overflowing_add(v) {
-            (s, true) => s + 1, // carry
-            (s, false) => s,    // no carry
-        }
+        (sum, carry) = sum.carrying_add(v, carry);
     }
 
     sum = match sum.overflowing_sub(pe.checksum?) {


### PR DESCRIPTION
Cleanup a TODO that suggests to change `overflowing_add` to `carrying_add`