### PR TITLE
chore: bump minimum go version to 1.26

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ '1.25.x', '1.26.x' ]
+        go-version: [ '1.26.x', '1.27.x' ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/VirusTotal/yara-x/go
 
-go 1.25
+go 1.26
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
go `1.25` is no longer supported after the recent release of Go `1.27`.
- `go/go.mod`: drop go `1.25`  support and bump the minimum version to `1.26`.
- `.github/workflows/golang.yaml`: remove go `1.25` and add `1.27`.