### PR TITLE
perf: apply file size and file header constraints only to regular expressions.

### DIFF
--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -226,6 +226,11 @@ pub(crate) enum Pattern {
 
 impl Pattern {
     #[inline]
+    pub fn is_regex(&self) -> bool {
+        matches!(self, Pattern::Regexp(_) | Pattern::Hex(_))
+    }
+
+    #[inline]
     pub fn flags(&self) -> &PatternFlags {
         match self {
             Pattern::Text(literal) => &literal.flags,

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -1813,19 +1813,25 @@ impl Compiler<'_> {
             rule_patterns[pat_idx.as_usize()].pattern()
         });
 
-        // Set the bounds to all patterns in the rule. This must be done
+        // Set the bounds to all regex patterns in the rule. This must be done
         // before assigning the PatternId to each pattern, as the filesize
         // bounds are taken into account when determining if the pattern
         // is unique or re-used from a previous rule.
         if !filesize_bounds.unbounded() {
-            for pattern in &mut rule_patterns {
+            for pattern in &mut rule_patterns
+                .iter_mut()
+                .filter(|p| p.pattern().is_regex())
+            {
                 pattern.pattern_mut().set_filesize_bounds(&filesize_bounds);
             }
         }
 
-        // Set header constraints to all patterns in the rule.
+        // Set header constraints to all regex patterns in the rule.
         if !header_constraints.unconstrained() {
-            for pattern in &mut rule_patterns {
+            for pattern in &mut rule_patterns
+                .iter_mut()
+                .filter(|p| p.pattern().is_regex())
+            {
                 pattern
                     .pattern_mut()
                     .set_header_constraints(&header_constraints);

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -4142,7 +4142,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "ELF"
+                $a = /EL(F|G)/
             condition:
                 uint32(0) == 0x464c457f and $a
         }
@@ -4154,7 +4154,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "ELF"
+                $a = /EL(F|G)/
             condition:
                 uint32(0) == 0x464c457f and $a
         }
@@ -4167,7 +4167,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "PE"
+                $a = /P(E|F)/
             condition:
                 uint16(0) == 0x5a4d and $a
         }
@@ -4179,7 +4179,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "PE"
+                $a = /P(E|F)/
             condition:
                 uint16(0) == 0x5a4d and $a
         }
@@ -4192,7 +4192,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "MZ"
+                $a = /M(Z|A)/
             condition:
                 $a at 0
         }
@@ -4204,7 +4204,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "MZ"
+                $a = /M(Z|A)/
             condition:
                 $a at 0
         }
@@ -4217,7 +4217,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "ELF"
+                $a = /EL(F|G)/
             condition:
                 uint32(0) == 0x464c457f and uint16(4) == 0x0102 and $a
         }
@@ -4229,7 +4229,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "ELF"
+                $a = /EL(F|G)/
             condition:
                 uint32(0) == 0x464c457f and uint16(4) == 0x0102 and $a
         }
@@ -4243,13 +4243,13 @@ fn header_constraints_optimization() {
         r#"
         rule constrained {
             strings:
-                $a = "foo"
+                $a = /foo|bar/
             condition:
                 uint32(0) == 0x464c457f and $a
         }
         rule unconstrained {
             strings:
-                $a = "foo"
+                $a = /foo|bar/
             condition:
                 $a
         }
@@ -4262,13 +4262,13 @@ fn header_constraints_optimization() {
         r#"
         rule constrained {
             strings:
-                $a = "foo"
+                $a = /foo|bar/
             condition:
                 uint32(0) == 0x464c457f and $a
         }
         rule unconstrained {
             strings:
-                $a = "foo"
+                $a = /foo|bar/
             condition:
                 $a
         }
@@ -4282,7 +4282,7 @@ fn header_constraints_optimization() {
         r#"
         rule constrained {
             strings:
-                $a = "MZ"
+                $a = /M(Z|A)/
             condition:
                 uint8(0) == 0x00 and uint8(2) == 0x5a and $a
         }
@@ -4291,74 +4291,22 @@ fn header_constraints_optimization() {
     );
 
     // Patterns whose on-disk bytes differ from their literal text (because of
-    // the `xor`, `nocase`, `wide`, `base64` or `base64wide` modifiers) must not
-    // derive a header constraint from the literal text. Otherwise `$a at 0`
-    // would wrongly require the file to start with the plaintext bytes and the
-    // pattern would be pruned even though it matches at offset 0.
-
-    // `xor`: "Hello" XORed with key 0x01 -> 49 64 6d 6d 6e.
-    rule_true!(
-        r#"
-        rule test {
-            strings:
-                $a = "Hello" xor
-            condition:
-                $a at 0
-        }
-        "#,
-        b"\x49\x64\x6d\x6d\x6e"
-    );
+    // the `nocase` or `wide`) must not derive a header constraint from the
+    // literal text. Otherwise, `$a at 0` would wrongly require the file to
+    // start with the plaintext bytes and the pattern would be pruned even
+    // though it matches at offset 0.
 
     // `nocase`: data has a different case than the literal.
     rule_true!(
         r#"
         rule test {
             strings:
-                $a = "HELLO" nocase
+                $a = /HELLO|WORLD/ nocase
             condition:
                 $a at 0
         }
         "#,
         b"hello"
-    );
-
-    // `wide`: the literal bytes are interleaved with zeroes.
-    rule_true!(
-        r#"
-        rule test {
-            strings:
-                $a = "Hello" wide
-            condition:
-                $a at 0
-        }
-        "#,
-        b"H\0e\0l\0l\0o\0"
-    );
-
-    // `base64`: "Hello" base64-encoded.
-    rule_true!(
-        r#"
-        rule test {
-            strings:
-                $a = "Hello" base64
-            condition:
-                $a at 0
-        }
-        "#,
-        b"SGVsbG8="
-    );
-
-    // `base64wide`: "Hello" base64-encoded and then made wide.
-    rule_true!(
-        r#"
-        rule test {
-            strings:
-                $a = "Hello" base64wide
-            condition:
-                $a at 0
-        }
-        "#,
-        b"S\0G\0V\0s\0b\0G\08\0"
     );
 
     // A regexp that reduces to a literal, with the `wide` modifier. For regexps
@@ -4369,45 +4317,12 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = /Hello/ wide
+                $a = /Hello|World/ wide
             condition:
                 $a at 0
         }
         "#,
         b"H\0e\0l\0l\0o\0"
-    );
-
-    // The bytes that actually appear in the data are not constrained to the
-    // literal text, but matching itself must still work correctly: a pattern
-    // with a byte-transforming modifier anchored at 0 must not match when its
-    // encoded form is absent at offset 0.
-    rule_false!(
-        r#"
-        rule test {
-            strings:
-                $a = "Hello" xor
-            condition:
-                $a at 0
-        }
-        "#,
-        b"\0\0\0\0\x49\x64\x6d\x6d\x6e"
-    );
-
-    // A modifier pattern anchored at 0 must not contaminate the header
-    // constraint derived from a plain literal in the same rule. Here the file
-    // starts with "MZ" (so `$plain at 0` holds) and contains "Hello" XORed with
-    // key 0x01 somewhere; `$x` must not be pruned by `$plain`'s constraint.
-    rule_true!(
-        r#"
-        rule test {
-            strings:
-                $plain = "MZ"
-                $x = "Hello" xor
-            condition:
-                $plain at 0 and $x
-        }
-        "#,
-        b"MZ\x49\x64\x6d\x6d\x6e"
     );
 
     // Pattern sets anchored at an offset (e.g. `any of ($a) at 0`) anchor their
@@ -4417,7 +4332,7 @@ fn header_constraints_optimization() {
         r#"
         rule test {
             strings:
-                $a = "Hello"
+                $a = /Hello|World/
             condition:
                 any of ($a) at 0 and $a
         }


### PR DESCRIPTION
This a mitigation to #737. The idea here is applying constraints only to patterns that may be slow (like regular expressions), which would reduce the total number of constraints.