### PR TITLE
feat(py): add Scanner.set_module_output to Python bindings

### DIFF
--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -1125,6 +1125,54 @@ impl Scanner {
         Ok(())
     }
 
+    /// Specifies the output data structure for a module, as raw data.
+    ///
+    /// Each YARA module generates an output consisting of a data structure
+    /// that contains information about the scanned file. This data
+    /// structure is represented by a Protocol Buffer message. Typically,
+    /// you won't need to provide this data yourself, as the YARA module
+    /// automatically generates different outputs for each file it scans.
+    ///
+    /// However, there are two scenarios in which you may want to provide
+    /// the output for a module yourself:
+    ///
+    /// 1) When the module does not produce any output on its own.
+    /// 2) When you already know the output of the module for the upcoming
+    ///    file to be scanned, and you prefer to reuse this data instead of
+    ///    generating it again.
+    ///
+    /// Case 1) applies to certain modules lacking a main function, thus
+    /// incapable of producing any output on their own. For such modules,
+    /// you must set the output before scanning the associated data. Since
+    /// the module's output typically varies with each scanned file, you
+    /// need to call this function prior to each invocation of `scan`.
+    /// Once `scan` is executed, the module's output is consumed and will
+    /// be empty unless set again before the subsequent call.
+    ///
+    /// Case 2) applies when you have previously stored the module's output
+    /// for certain scanned data. In such cases, when rescanning the data,
+    /// you can utilize this function to supply the module's output,
+    /// thereby preventing redundant computation by the module. This
+    /// optimization enhances performance by eliminating the need for the
+    /// module to reparse the scanned data.
+    ///
+    /// `module` can be either the YARA module name (i.e: "pe", "elf",
+    /// "dotnet", etc.) or the fully-qualified name for the protobuf message
+    /// associated to the module (i.e: "pe.PE", "elf.ELF", "dotnet.Dotnet",
+    /// etc.). `data` must be the Protocol Buffer message corresponding to
+    /// that module, serialized as raw bytes.
+    fn set_module_output(
+        &mut self,
+        module: &str,
+        data: Bound<PyBytes>,
+    ) -> PyResult<()> {
+        let data = data.extract::<Vec<u8>>()?;
+        self.inner
+            .set_module_output_raw(module, data.as_slice())
+            .map_err(map_scan_err)?;
+        Ok(())
+    }
+
     /// Scans in-memory data.
     fn scan(&mut self, data: &[u8]) -> PyResult<Py<ScanResults>> {
         let results = self.inner.scan(data).map_err(map_scan_err)?;

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -1166,9 +1166,8 @@ impl Scanner {
         module: &str,
         data: Bound<PyBytes>,
     ) -> PyResult<()> {
-        let data = data.extract::<Vec<u8>>()?;
         self.inner
-            .set_module_output_raw(module, data.as_slice())
+            .set_module_output_raw(module, data.as_bytes())
             .map_err(map_scan_err)?;
         Ok(())
     }

--- a/py/tests/test_api.py
+++ b/py/tests/test_api.py
@@ -294,6 +294,39 @@ def test_module_outputs():
   assert module_outputs['test_proto2']['bytes_raw'] == b'\xfcH\x83\xe4\xf0\xeb3]\x8bE\x00H'
   assert module_outputs['test_proto2']['timestamp'] == datetime.datetime(2025, 5, 30, 7, 50, 40, tzinfo=datetime.timezone.utc)
 
+def test_scanner_set_module_output():
+  # Raw bytes for a `pe.PE` protobuf message with `is_pe = true` and
+  # `entry_point = 1`.
+  pe_data = b'\x08\x01\x80\x01\x01'
+
+  rules = yara_x.compile('''
+import "pe"
+rule test {
+  condition:
+    pe.entry_point == 1
+}
+''')
+
+  scanner = yara_x.Scanner(rules)
+  scanner.set_module_output('pe', pe_data)
+
+  # The data being scanned is empty, but the output for the `pe` module
+  # was provided directly.
+  matching_rules = scanner.scan(b'').matching_rules
+  assert len(matching_rules) == 1
+
+  # The module's output is consumed by the previous scan, so this second
+  # scan doesn't find `pe.entry_point` defined.
+  matching_rules = scanner.scan(b'').matching_rules
+  assert len(matching_rules) == 0
+
+  with pytest.raises(yara_x.ScanError, match='unknown module `foobar`'):
+    scanner.set_module_output('foobar', b'')
+
+  with pytest.raises(yara_x.ScanError):
+    scanner.set_module_output('pe', b'\xff\xff\xff')
+
+
 def test_ignored_modules():
   compiler = yara_x.Compiler()
   compiler.ignore_module("unsupported_module")

--- a/py/yara_x.pyi
+++ b/py/yara_x.pyi
@@ -300,6 +300,47 @@ class Scanner:
         """
         ...
 
+    def set_module_output(self, module: str, data: bytes) -> None:
+        r"""
+        Specifies the output data structure for a module, as raw data.
+
+        Each YARA module generates an output consisting of a data structure
+        that contains information about the scanned file. This data
+        structure is represented by a Protocol Buffer message. Typically,
+        you won't need to provide this data yourself, as the YARA module
+        automatically generates different outputs for each file it scans.
+
+        However, there are two scenarios in which you may want to provide
+        the output for a module yourself:
+
+        1) When the module does not produce any output on its own.
+        2) When you already know the output of the module for the upcoming
+           file to be scanned, and you prefer to reuse this data instead of
+           generating it again.
+
+        Case 1) applies to certain modules lacking a main function, thus
+        incapable of producing any output on their own. For such modules,
+        you must set the output before scanning the associated data. Since
+        the module's output typically varies with each scanned file, you
+        need to call this function prior to each invocation of `scan`.
+        Once `scan` is executed, the module's output is consumed and will
+        be empty unless set again before the subsequent call.
+
+        Case 2) applies when you have previously stored the module's output
+        for certain scanned data. In such cases, when rescanning the data,
+        you can utilize this function to supply the module's output,
+        thereby preventing redundant computation by the module. This
+        optimization enhances performance by eliminating the need for the
+        module to reparse the scanned data.
+
+        `module` can be either the YARA module name (i.e: "pe", "elf",
+        "dotnet", etc.) or the fully-qualified name for the protobuf message
+        associated to the module (i.e: "pe.PE", "elf.ELF", "dotnet.Dotnet",
+        etc.). `data` must be the Protocol Buffer message corresponding to
+        that module, serialized as raw bytes.
+        """
+        ...
+
     def set_global(self, ident: str, value: Any) -> None:
         r"""
         Sets the value of a global variable.

--- a/site/content/docs/api/python.md
+++ b/site/content/docs/api/python.md
@@ -557,6 +557,54 @@ options.set_module_metadata("cuckoo", b'{"foo": "bar"}')
 scanner.scan_file_with_options("foo.bin", options)
 ```
 
+#### .set_module_output(module, data)
+
+Specifies the output data structure for a module, as raw data.
+
+Each YARA module generates an output consisting of a data structure that
+contains information about the scanned file. This data structure is
+represented by a Protocol Buffer message. Typically, you won't need to
+provide this data yourself, as the YARA module automatically generates
+different outputs for each file it scans.
+
+However, there are two scenarios in which you may want to provide the
+output for a module yourself:
+
+1.  When the module does not produce any output on its own.
+2.  When you already know the output of the module for the upcoming file
+    to be scanned, and you prefer to reuse this data instead of generating
+    it again.
+
+Case 1 applies to certain modules lacking a main function, thus incapable
+of producing any output on their own. For such modules, you must set the
+output before scanning the associated data. Since the module's output
+typically varies with each scanned file, you need to call this function
+prior to each invocation of [Scanner.scan(...)](#scanbytes-1). Once the
+scan is executed, the module's output is consumed and will be empty
+unless set again before the subsequent call.
+
+Case 2 applies when you have previously stored the module's output for
+certain scanned data. In such cases, when rescanning the data, you can
+utilize this function to supply the module's output, thereby preventing
+redundant computation by the module.
+
+`module` can be either the YARA module name (e.g. `"pe"`, `"elf"`,
+`"dotnet"`) or the fully-qualified name for the protobuf message
+associated to the module (e.g. `"pe.PE"`, `"elf.ELF"`, `"dotnet.Dotnet"`).
+`data` must be the Protocol Buffer message corresponding to that module,
+serialized as raw bytes.
+
+Raises: [yara_x.ScanError](#scanerror)
+
+##### Example
+
+```python
+rules = yara_x.compile('import "pe" rule test { condition: pe.entry_point == 1 }')
+scanner = yara_x.Scanner(rules)
+scanner.set_module_output("pe", pe_data)
+scanner.scan(b"")
+```
+
 #### .set_global(identifier, value)
 
 Sets the value of a global variable. The variable must has been previously


### PR DESCRIPTION
The C API and Go bindings already expose a way to set a module's output
data directly (yrx_scanner_set_module_output / Scanner.SetModuleOutput),
but the Python bindings only had ScanOptions.set_module_metadata, which
doesn't help modules with no main function that need their output
injected before scanning.

Mirrors set_module_metadata and delegates to the same
set_module_output_raw the C API already uses internally. Also documents
the new method in the Python API reference page.

Addresses the last remaining item from #734.
