### PR TITLE
perf(regex): use bitmaps for four-range byte classes

### DIFF
--- a/lib/src/re/thompson/compiler.rs
+++ b/lib/src/re/thompson/compiler.rs
@@ -1493,11 +1493,9 @@ impl InstrSeq {
     /// instruction resides.
     pub fn emit_class(&mut self, c: &ClassBytes) -> usize {
         let location = self.location();
-        // When the number of ranges is <= 15 `Instr::ClassRanges` is
-        // preferred over `Instr::ClassBitmap` because of its more compact
-        // representation. With 16 ranges or more `Instr::ClassBitmap` becomes
-        // more compact.
-        if c.ranges().len() < 16 {
+        // Keep very small classes compact. Starting at four ranges, prefer the
+        // constant-time bitmap lookup over scanning each range.
+        if c.ranges().len() < 4 {
             self.seq
                 .write_all(&[
                     OPCODE_PREFIX,

--- a/lib/src/re/thompson/instr.rs
+++ b/lib/src/re/thompson/instr.rs
@@ -186,8 +186,9 @@ pub enum Instr<'a> {
     /// one per byte. If the N-th bit is set, the byte N is part of the class
     /// and should match. This instruction is quite large, it takes 2 bytes
     /// for the opcode plus 32 bytes (256 bits) for the mask. For classes with
-    /// a low number of non-adjacent byte ranges `ClassRanges` is preferred
-    /// due to its more compact representation.
+    /// at most three non-adjacent byte ranges `ClassRanges` is preferred due
+    /// to its more compact representation. Starting at four ranges, the
+    /// compiler prefers the bitmap's constant-time lookup.
     ClassBitmap(ClassBitmap<'a>),
 
     /// Matches a byte class. The class represents one or more byte ranges
@@ -195,9 +196,9 @@ pub enum Instr<'a> {
     /// follows one pair `[u8, u8]` per range, indicating starting and ending
     /// bytes for the range, both inclusive. With 16 ranges this instruction
     /// takes 35 bytes (2 bytes for the opcode + 1 byte for the number of
-    /// ranges + 32 bytes for the ranges), therefore it is used only when the
-    /// number of ranges is <= 15. For a larger number of ranges `ClassBitmap`
-    /// is preferred.
+    /// ranges + 32 bytes for the ranges). The compiler uses this compact form
+    /// for up to three ranges and prefers `ClassBitmap` for larger classes to
+    /// avoid a linear range scan for each input byte.
     ClassRanges(ClassRanges<'a>),
 
     /// Creates a new thread that starts at the current instruction pointer

--- a/lib/src/re/thompson/tests.rs
+++ b/lib/src/re/thompson/tests.rs
@@ -90,6 +90,23 @@ macro_rules! assert_re_num_atoms {
 }
 
 #[test]
+fn class_representation_threshold() {
+    let compile = |regexp| {
+        let parser = re::parser::Parser::new();
+        Compiler::new()
+            .compile_internal(
+                &parser.parse(&Regexp::new(format!("/{regexp}/s"))).unwrap(),
+            )
+            .unwrap()
+            .0
+            .to_string()
+    };
+
+    assert!(compile("[a-ce-gi]").contains("CLASS_RANGES"));
+    assert!(compile("[a-ce-gik]").contains("CLASS_BITMAP"));
+}
+
+#[test]
 fn re_code_1() {
     assert_re_code!(
         "(?s)abcd",


### PR DESCRIPTION
## Summary

Emit `ClassBitmap` for regexp byte classes with four or more ranges. Classes
with up to three ranges keep the compact `ClassRanges` representation.

This avoids a linear range scan for every consumed byte while keeping very
small classes compact. There are no API or compiled-rules format changes; both
instructions were already supported by the scanner.

## What changed

- lower the `ClassRanges`/`ClassBitmap` threshold from 16 to 4 ranges
- document the speed/size tradeoff at the new threshold
- add a regression test for the 3-range and 4-range boundary

## Results

Measured from `9c0b4168` on a Linux c4-standard-32 using `release-lto`, one
worker pinned to one CPU, and 31 interleaved baseline/candidate pairs. Each
binary compiled its own rules package.

The workload contains 200 regexps with the common four-range
`[A-Za-z0-9_]` class and scans eight distinct 16 MiB match-positive files.

| | Before | After |
|---|---:|---:|
| Median time | 1.940479 s | 1.866483 s |
| Throughput | 69.2 MB/s | 71.9 MB/s |

Median speedup is **3.964%**. The paired mean is **3.956%**, with 31/31 wins
and a 95% bootstrap confidence interval of **3.513% to 4.415%**.

Controls:

- regexp no-match, 1 GiB: +0.007% median; CI -0.347% to +0.184%
- YARA Forge Core, 256 MiB: +0.032% median; CI -1.252% to +0.895%
- YARA Forge Full, 256 MiB: +0.085% median

The compiled Core package grows by 934 bytes (+0.0108%) and Full by 8,230
bytes (+0.0377%).

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --tests --no-deps -- --deny clippy::all`
- `cargo fmt --all --check`
- `git diff --check`
- exact sorted NDJSON output comparison on the match-positive corpus
