### PR TITLE
feat: add debug command for selected atoms

### DIFF
--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -25,6 +25,7 @@ pub fn atoms() -> Command {
                 .help("Path to YARA source file")
                 .value_parser(value_parser!(PathBuf)),
         )
+        .arg(arg!(--json).help("Print output in JSON format"))
 }
 
 pub fn ast() -> Command {
@@ -182,8 +183,60 @@ fn exec_modules(_args: &ArgMatches, _config: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn is_consecutive(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() || a.is_empty() {
+        return false;
+    }
+    let mut carry = 1u16;
+    for (byte_a, byte_b) in a.iter().rev().zip(b.iter().rev()) {
+        let sum = *byte_a as u16 + carry;
+        if (sum as u8) != *byte_b {
+            return false;
+        }
+        carry = sum >> 8;
+    }
+    carry == 0
+}
+
+fn is_printable(atom: &[u8]) -> bool {
+    !atom.is_empty() && atom.iter().all(|b| (0x20..=0x7E).contains(b))
+}
+
+fn print_atom_hex(atom: &[u8]) {
+    for byte in atom {
+        print!("{byte:02X}");
+    }
+}
+
+fn print_range(start: &[u8], end: &[u8]) {
+    print!("    ");
+    print_atom_hex(start);
+    if start != end {
+        print!("..");
+        print_atom_hex(end);
+    }
+    if is_printable(start) && is_printable(end) {
+        let s = std::str::from_utf8(start).unwrap();
+        if start == end {
+            print!(" ({s})");
+        } else {
+            let e = std::str::from_utf8(end).unwrap();
+            print!(" ({s}..{e})");
+        }
+    }
+    println!();
+}
+
+#[derive(serde::Serialize)]
+struct PatternAtomsJson<'a> {
+    rule: &'a str,
+    pattern: &'a str,
+    atoms: Vec<String>,
+}
+
 fn exec_atoms(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
     let rules_path = args.get_one::<PathBuf>("RULES_PATH").unwrap();
+    let json = args.get_flag("json");
 
     let src = fs::read(rules_path)
         .with_context(|| format!("can not read `{}`", rules_path.display()))?;
@@ -197,20 +250,59 @@ fn exec_atoms(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
 
     let rules = compiler.build();
 
-    for (rule_name, strings) in rules.debug_atoms() {
-        println!("rule {rule_name}");
+    if json {
+        let mut output = Vec::new();
 
-        for (string_name, atoms) in strings {
-            println!("  {string_name}");
+        for rule in rules.iter() {
+            for pattern in rule.patterns().include_private(true) {
+                let atoms: Vec<String> = pattern
+                    .atoms()
+                    .map(|atom| {
+                        atom.as_slice()
+                            .iter()
+                            .map(|b| format!("{b:02X}"))
+                            .collect()
+                    })
+                    .collect();
 
-            for atom in atoms {
-                print!("    ");
+                output.push(PatternAtomsJson {
+                    rule: rule.identifier(),
+                    pattern: pattern.identifier(),
+                    atoms,
+                });
+            }
+        }
 
-                for byte in atom {
-                    print!("{byte:02X}");
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        for rule in rules.iter() {
+            println!("rule {}", rule.identifier());
+
+            for pattern in rule.patterns().include_private(true) {
+                println!("  {}", pattern.identifier());
+
+                let mut current_range: Option<(&[u8], &[u8])> = None;
+
+                for atom in pattern.atoms() {
+                    let atom_slice = atom.as_slice();
+                    match current_range {
+                        None => {
+                            current_range = Some((atom_slice, atom_slice));
+                        }
+                        Some((start, end)) => {
+                            if is_consecutive(end, atom_slice) {
+                                current_range = Some((start, atom_slice));
+                            } else {
+                                print_range(start, end);
+                                current_range = Some((atom_slice, atom_slice));
+                            }
+                        }
+                    }
                 }
 
-                println!();
+                if let Some((start, end)) = current_range {
+                    print_range(start, end);
+                }
             }
         }
     }

--- a/cli/src/commands/debug.rs
+++ b/cli/src/commands/debug.rs
@@ -17,6 +17,16 @@ use crate::commands::{
 use crate::config::Config;
 use crate::help;
 
+pub fn atoms() -> Command {
+    super::command("atoms")
+        .about("Print final atoms selected for a YARA source file")
+        .arg(
+            arg!(<RULES_PATH>)
+                .help("Path to YARA source file")
+                .value_parser(value_parser!(PathBuf)),
+        )
+}
+
 pub fn ast() -> Command {
     super::command("ast")
         .about("Print Abstract Syntax Tree (AST) for a YARA source file")
@@ -88,6 +98,7 @@ pub fn debug() -> Command {
         .subcommand(ir())
         .subcommand(wasm())
         .subcommand(modules())
+        .subcommand(atoms())
 }
 
 pub fn exec_debug(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
@@ -97,6 +108,7 @@ pub fn exec_debug(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
         Some(("ir", args)) => exec_ir(args, config),
         Some(("wasm", args)) => exec_wasm(args, config),
         Some(("modules", args)) => exec_modules(args, config),
+        Some(("atoms", args)) => exec_atoms(args, config),
         _ => unreachable!(),
     }
 }
@@ -167,5 +179,41 @@ fn exec_modules(_args: &ArgMatches, _config: &Config) -> anyhow::Result<()> {
     for name in yara_x::mods::module_names() {
         println!("{}", name);
     }
+    Ok(())
+}
+
+fn exec_atoms(args: &ArgMatches, config: &Config) -> anyhow::Result<()> {
+    let rules_path = args.get_one::<PathBuf>("RULES_PATH").unwrap();
+
+    let src = fs::read(rules_path)
+        .with_context(|| format!("can not read `{}`", rules_path.display()))?;
+
+    let src = SourceCode::from(src.as_slice())
+        .with_origin(rules_path.as_os_str().to_str().unwrap());
+
+    let mut compiler = create_compiler(None, args, config)?;
+
+    compiler.add_source(src)?;
+
+    let rules = compiler.build();
+
+    for (rule_name, strings) in rules.debug_atoms() {
+        println!("rule {rule_name}");
+
+        for (string_name, atoms) in strings {
+            println!("  {string_name}");
+
+            for atom in atoms {
+                print!("    ");
+
+                for byte in atom {
+                    print!("{byte:02X}");
+                }
+
+                println!();
+            }
+        }
+    }
+
     Ok(())
 }

--- a/cli/src/tests/debug.rs
+++ b/cli/src/tests/debug.rs
@@ -53,6 +53,7 @@ rule test {
     strings:
         $a = "ABCD"
         $b = { 01 02 03 04 }
+        $c = { 30 ( 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 ) }
 
     condition:
         any of them
@@ -71,9 +72,55 @@ rule test {
             "\
 rule test
   $a
-    41424344
+    41424344 (ABCD)
   $b
     01020304
+  $c
+    3030..3039 (00..09)
+",
+        );
+
+    Command::new(cargo_bin!("yr"))
+        .arg("debug")
+        .arg("atoms")
+        .arg("--json")
+        .arg(input_file.path())
+        .assert()
+        .success()
+        .stdout(
+            "\
+[
+  {
+    \"rule\": \"test\",
+    \"pattern\": \"$a\",
+    \"atoms\": [
+      \"41424344\"
+    ]
+  },
+  {
+    \"rule\": \"test\",
+    \"pattern\": \"$b\",
+    \"atoms\": [
+      \"01020304\"
+    ]
+  },
+  {
+    \"rule\": \"test\",
+    \"pattern\": \"$c\",
+    \"atoms\": [
+      \"3030\",
+      \"3031\",
+      \"3032\",
+      \"3033\",
+      \"3034\",
+      \"3035\",
+      \"3036\",
+      \"3037\",
+      \"3038\",
+      \"3039\"
+    ]
+  }
+]
 ",
         );
 }

--- a/cli/src/tests/debug.rs
+++ b/cli/src/tests/debug.rs
@@ -40,3 +40,40 @@ fn wasm() {
         panic!("`yr debug wasm` didn't create .wasm file")
     }
 }
+
+#[test]
+fn atoms() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_file = temp_dir.child("rule.yar");
+
+    input_file
+        .write_str(
+            r#"
+rule test {
+    strings:
+        $a = "ABCD"
+        $b = { 01 02 03 04 }
+
+    condition:
+        any of them
+}
+"#,
+        )
+        .unwrap();
+
+    Command::new(cargo_bin!("yr"))
+        .arg("debug")
+        .arg("atoms")
+        .arg(input_file.path())
+        .assert()
+        .success()
+        .stdout(
+            "\
+rule test
+  $a
+    41424344
+  $b
+    01020304
+",
+        );
+}

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -265,6 +265,12 @@ pub struct Rules {
     pub(in crate::compiler) rules_profiling_enabled: bool,
 }
 
+#[doc(hidden)]
+pub type DebugPatternAtoms<'a> = (&'a str, Vec<&'a [u8]>);
+
+#[doc(hidden)]
+pub type DebugRuleAtoms<'a> = (&'a str, Vec<DebugPatternAtoms<'a>>);
+
 impl Rules {
     /// An iterator that yields the name of the modules imported by the
     /// rules.
@@ -683,6 +689,44 @@ impl Rules {
     #[inline]
     pub(crate) fn is_fast_scan(&self, pattern_id: PatternId) -> bool {
         *self.fast_scan_patterns.get(usize::from(pattern_id)).unwrap()
+    }
+
+    /// Returns the final atoms selected for each pattern, grouped by rule and
+    /// pattern identifier.
+    #[doc(hidden)]
+    pub fn debug_atoms(&self) -> Vec<DebugRuleAtoms<'_>> {
+        let mut result = Vec::new();
+
+        for rule in &self.rules {
+            let rule_name = self.ident_pool.get(rule.ident_id).unwrap();
+            let mut strings = Vec::new();
+
+            for pattern in &rule.patterns {
+                let string_name =
+                    self.ident_pool.get(pattern.ident_id).unwrap();
+
+                let atoms = self
+                    .atoms
+                    .iter()
+                    .filter_map(|atom| {
+                        let (pattern_id, _) =
+                            self.get_sub_pattern(atom.sub_pattern_id());
+
+                        if *pattern_id == pattern.pattern_id {
+                            Some(atom.as_slice())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                strings.push((string_name, atoms));
+            }
+
+            result.push((rule_name, strings));
+        }
+
+        result
     }
 }
 

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -211,7 +211,7 @@ pub struct Rules {
     /// A vector that contains all the atoms extracted from the patterns. Each
     /// atom has an associated [`SubPatternId`] that indicates the sub-pattern
     /// it belongs to.
-    pub(in crate::compiler) atoms: Vec<SubPatternAtom>,
+    pub(crate) atoms: Vec<SubPatternAtom>,
 
     /// A vector that contains the code for all regexp patterns (this includes
     /// hex patterns which are just a special case of regexp). The code for
@@ -264,12 +264,6 @@ pub struct Rules {
     /// deserialization error.
     pub(in crate::compiler) rules_profiling_enabled: bool,
 }
-
-#[doc(hidden)]
-pub type DebugPatternAtoms<'a> = (&'a str, Vec<&'a [u8]>);
-
-#[doc(hidden)]
-pub type DebugRuleAtoms<'a> = (&'a str, Vec<DebugPatternAtoms<'a>>);
 
 impl Rules {
     /// An iterator that yields the name of the modules imported by the
@@ -689,44 +683,6 @@ impl Rules {
     #[inline]
     pub(crate) fn is_fast_scan(&self, pattern_id: PatternId) -> bool {
         *self.fast_scan_patterns.get(usize::from(pattern_id)).unwrap()
-    }
-
-    /// Returns the final atoms selected for each pattern, grouped by rule and
-    /// pattern identifier.
-    #[doc(hidden)]
-    pub fn debug_atoms(&self) -> Vec<DebugRuleAtoms<'_>> {
-        let mut result = Vec::new();
-
-        for rule in &self.rules {
-            let rule_name = self.ident_pool.get(rule.ident_id).unwrap();
-            let mut strings = Vec::new();
-
-            for pattern in &rule.patterns {
-                let string_name =
-                    self.ident_pool.get(pattern.ident_id).unwrap();
-
-                let atoms = self
-                    .atoms
-                    .iter()
-                    .filter_map(|atom| {
-                        let (pattern_id, _) =
-                            self.get_sub_pattern(atom.sub_pattern_id());
-
-                        if *pattern_id == pattern.pattern_id {
-                            Some(atom.as_slice())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-
-                strings.push((string_name, atoms));
-            }
-
-            result.push((rule_name, strings));
-        }
-
-        result
     }
 }
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -53,6 +53,10 @@ pub use compiler::Rules;
 pub use compiler::RulesIter;
 pub use compiler::SourceCode;
 pub use compiler::compile;
+#[doc(hidden)]
+pub use models::Atom;
+#[doc(hidden)]
+pub use models::Atoms;
 pub use models::Match;
 pub use models::Matches;
 pub use models::MetaValue;

--- a/lib/src/models.rs
+++ b/lib/src/models.rs
@@ -5,7 +5,9 @@ use bstr::{BStr, ByteSlice};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize, Serializer};
 
-use crate::compiler::{IdentId, PatternId, PatternInfo, RuleInfo};
+use crate::compiler::{
+    IdentId, PatternId, PatternInfo, RuleInfo, SubPatternAtom,
+};
 use crate::scanner::{ScanContext, ScanState};
 use crate::{Rules, compiler, scanner};
 
@@ -387,6 +389,23 @@ impl<'a, 'r> Pattern<'a, 'r> {
             }),
         }
     }
+
+    /// Returns an iterator over the atoms extracted from this pattern.
+    #[doc(hidden)]
+    pub fn atoms(&self) -> Atoms<'r> {
+        let atoms = self.rules.atoms.as_slice();
+
+        let start = atoms.partition_point(|atom| {
+            self.rules.get_sub_pattern(atom.sub_pattern_id()).0
+                < self.pattern_id
+        });
+        let end = atoms.partition_point(|atom| {
+            self.rules.get_sub_pattern(atom.sub_pattern_id()).0
+                <= self.pattern_id
+        });
+
+        Atoms { iterator: atoms[start..end].iter() }
+    }
 }
 
 impl<'a, 'r> Serialize for Pattern<'a, 'r> {
@@ -483,5 +502,115 @@ impl<'a, 'r> Serialize for Match<'a, 'r> {
         s.serialize_field("range", &self.range())?;
         s.serialize_field("xor_key", &self.xor_key())?;
         s.end()
+    }
+}
+
+/// Iterator that returns the atoms extracted from a pattern.
+#[doc(hidden)]
+pub struct Atoms<'r> {
+    iterator: Iter<'r, SubPatternAtom>,
+}
+
+impl<'r> Iterator for Atoms<'r> {
+    type Item = Atom<'r>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iterator.next().map(|atom| Atom { inner: atom })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iterator.size_hint()
+    }
+}
+
+impl ExactSizeIterator for Atoms<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iterator.len()
+    }
+}
+
+impl DoubleEndedIterator for Atoms<'_> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iterator.next_back().map(|atom| Atom { inner: atom })
+    }
+}
+
+/// Represents an atom extracted from a pattern.
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct Atom<'r> {
+    inner: &'r SubPatternAtom,
+}
+
+impl<'r> Atom<'r> {
+    /// Returns the atom as a byte slice.
+    #[inline]
+    pub fn as_slice(&self) -> &'r [u8] {
+        self.inner.as_slice()
+    }
+}
+
+impl AsRef<[u8]> for Atom<'_> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl std::ops::Deref for Atom<'_> {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl PartialEq for Atom<'_> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for Atom<'_> {}
+
+impl PartialOrd for Atom<'_> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Atom<'_> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl std::hash::Hash for Atom<'_> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl std::fmt::Debug for Atom<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Atom({:02X?})", self.as_slice())
+    }
+}
+
+impl Serialize for Atom<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.as_slice())
     }
 }

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -4340,3 +4340,102 @@ fn header_constraints_optimization() {
         b"Hello"
     );
 }
+
+#[test]
+fn test_pattern_atoms() {
+    let rules = crate::compile(
+        r#"
+        rule rule1 {
+            strings:
+                $a = "ABCD"
+                $b = { 01 02 03 04 }
+                $c = /foobar/
+            condition:
+                any of them
+        }
+        rule rule2 {
+            strings:
+                $x = "WIDE" wide
+                $y = "NOCASE" nocase
+            condition:
+                any of them
+        }
+        rule rule3 {
+            condition:
+                true
+        }
+        rule rule4 {
+            strings:
+                $anchored = "ANCHORED"
+            condition:
+                $anchored at 0
+        }
+        "#,
+    )
+    .unwrap();
+
+    let mut rules_iter = rules.iter();
+
+    // rule1
+    let rule1 = rules_iter.next().unwrap();
+    assert_eq!(rule1.identifier(), "rule1");
+    let mut patterns = rule1.patterns();
+    assert_eq!(patterns.len(), 3);
+
+    let pa = patterns.next().unwrap();
+    assert_eq!(pa.identifier(), "$a");
+    let pa_atoms: Vec<_> = pa.atoms().collect();
+    assert_eq!(pa_atoms.len(), 1);
+    assert_eq!(pa_atoms[0].as_slice(), b"ABCD");
+    assert_eq!(pa_atoms[0].as_ref(), b"ABCD");
+    assert_eq!(&*pa_atoms[0], b"ABCD");
+
+    let pb = patterns.next().unwrap();
+    assert_eq!(pb.identifier(), "$b");
+    let pb_atoms: Vec<_> = pb.atoms().collect();
+    assert_eq!(pb_atoms.len(), 1);
+    assert_eq!(pb_atoms[0].as_slice(), &[0x01, 0x02, 0x03, 0x04]);
+
+    let pc = patterns.next().unwrap();
+    assert_eq!(pc.identifier(), "$c");
+    let pc_atoms: Vec<_> = pc.atoms().collect();
+    assert_eq!(pc_atoms.len(), 1);
+    assert_eq!(pc_atoms[0].as_slice(), b"obar");
+
+    // rule2
+    let rule2 = rules_iter.next().unwrap();
+    assert_eq!(rule2.identifier(), "rule2");
+    let mut patterns = rule2.patterns();
+
+    let px = patterns.next().unwrap();
+    assert_eq!(px.identifier(), "$x");
+    let px_atoms: Vec<_> = px.atoms().collect();
+    assert_eq!(px_atoms.len(), 1);
+    assert_eq!(px_atoms[0].as_slice(), b"W\0I\0");
+
+    let py = patterns.next().unwrap();
+    assert_eq!(py.identifier(), "$y");
+    let py_atoms = py.atoms();
+    assert!(py_atoms.len() > 1);
+    // ExactSizeIterator check
+    assert_eq!(py_atoms.len(), py.atoms().collect::<Vec<_>>().len());
+    // DoubleEndedIterator check
+    let rev_atoms: Vec<_> = py.atoms().rev().collect();
+    let mut fwd_atoms: Vec<_> = py.atoms().collect();
+    fwd_atoms.reverse();
+    assert_eq!(rev_atoms, fwd_atoms);
+
+    // rule3 (no patterns)
+    let rule3 = rules_iter.next().unwrap();
+    assert_eq!(rule3.identifier(), "rule3");
+    assert_eq!(rule3.patterns().len(), 0);
+
+    // rule4 (anchored pattern has no atoms in Aho-Corasick)
+    let rule4 = rules_iter.next().unwrap();
+    assert_eq!(rule4.identifier(), "rule4");
+    let mut patterns = rule4.patterns();
+    let panchor = patterns.next().unwrap();
+    assert_eq!(panchor.identifier(), "$anchored");
+    assert_eq!(panchor.atoms().len(), 0);
+    assert!(panchor.atoms().next().is_none());
+}


### PR DESCRIPTION
Adds a yr debug atoms command for displaying the final atoms selected by YARA-X for each rule string.

The command is available behind the existing debug-cmd feature and outputs selected atoms grouped by rule and pattern.

## Example

```text
rule test
  $a
    41424344
  $b
    01020304
```
This is intended for tooling and debugging use cases that need visibility into YARA-X's final selected atoms.

One motivating use case is tooling that needs to consume YARA-X's selected atoms externally, for example to feed them into an indexed prefilter/search system such as BigGrep before performing full rule evaluation.

Tests have been added for the new command and the workspace test suite passes.