### PR TITLE
perf(compiler): ignore unused modules

### DIFF
--- a/capi/src/tests.rs
+++ b/capi/src/tests.rs
@@ -245,7 +245,8 @@ fn capi() {
                     some_float == 1.5 and 
                     some_map.str == "foo" and
                     some_map.array[0] == 1 and
-                    some_map.map.str == "bar" )
+                    some_map.map.str == "bar" and
+                    not pe.is_pe )
             }"#;
 
         let some_bool = c"some_bool";

--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -210,6 +210,15 @@ pub(crate) struct EmitContext<'a> {
     /// Pool with literal strings used in the rules.
     pub lit_pool: &'a mut BStringPool<LiteralId>,
 
+    /// Maps root-structure field indexes to imported-module indexes.
+    pub(crate) module_root_indexes: &'a FxHashMap<usize, usize>,
+
+    /// Maps imported-module names to their indexes.
+    pub(crate) module_indexes: &'a FxHashMap<String, usize>,
+
+    /// Indicates which imported modules are referenced by emitted conditions.
+    pub(crate) used_modules: &'a mut [bool],
+
     /// Stack of installed exception handlers for catching undefined values.
     /// When an exception occurs the execution flow will jump out of the block
     /// identified by `InstrSeqId`.
@@ -293,6 +302,8 @@ fn emit_expr(
     expr: ExprId,
     instr: &mut InstrSeqBuilder,
 ) {
+    mark_module_used(ctx, ir, expr);
+
     match ir.get(expr) {
         Expr::Const(type_value) => match type_value {
             TypeValue::Integer { value: Const(value), .. } => {
@@ -694,6 +705,12 @@ fn emit_expr(
         },
 
         Expr::FuncCall(func_call) => {
+            if let Some(module_name) = func_call.plain_name().split('.').next()
+                && let Some(module_index) = ctx.module_indexes.get(module_name)
+            {
+                ctx.used_modules[*module_index] = true;
+            }
+
             // If this is method call, the target object (self or this in some
             // programming languages) is the first argument.
             if let Some(obj) = func_call.object {
@@ -957,6 +974,8 @@ fn emit_field_access(
     field_access: &FieldAccess,
     instr: &mut InstrSeqBuilder,
 ) {
+    mark_module_used(ctx, ir, field_access.operands[0]);
+
     // Iterate over the operands, excluding the last one. While the operands
     // are field identifiers they are simply added to `lookup_list`, and
     // during the last call to `emit_expr` a single field lookup operation
@@ -973,6 +992,15 @@ fn emit_field_access(
     }
 
     emit_expr(ctx, ir, *field_access.operands.last().unwrap(), instr);
+}
+
+fn mark_module_used(ctx: &mut EmitContext, ir: &IR, expr: ExprId) {
+    if let Expr::Symbol(symbol) = ir.get(expr)
+        && let Symbol::Field { index, is_root: true, .. } = symbol.as_ref()
+        && let Some(module_index) = ctx.module_root_indexes.get(index)
+    {
+        ctx.used_modules[*module_index] = true;
+    }
 }
 
 /// Emits code that ensures the pattern search phase is executed if it hasn't

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -425,6 +425,15 @@ pub struct Compiler<'a> {
     /// the [`IdentId`] corresponding to the module's identifier.
     imported_modules: Vec<IdentId>,
 
+    /// Maps root-structure field indexes to imported-module indexes.
+    module_root_indexes: FxHashMap<usize, usize>,
+
+    /// Maps imported-module names to their indexes.
+    module_indexes: FxHashMap<String, usize>,
+
+    /// Indicates which imported modules are used by emitted rule conditions.
+    used_modules: Vec<bool>,
+
     /// Names of modules that are known, but not supported. When an `import`
     /// statement with one of these modules is found, the statement is accepted
     /// without causing an error, but a warning is raised to let the user know
@@ -549,6 +558,9 @@ impl<'a> Compiler<'a> {
             atoms: Vec::new(),
             re_code: Vec::new(),
             imported_modules: Vec::new(),
+            module_root_indexes: FxHashMap::default(),
+            module_indexes: FxHashMap::default(),
+            used_modules: Vec::new(),
             ignored_modules: FxHashSet::default(),
             banned_modules: FxHashMap::default(),
             ignored_rules: Vec::new(),
@@ -860,6 +872,13 @@ impl<'a> Compiler<'a> {
             }
         }
 
+        let imported_modules = self
+            .imported_modules
+            .into_iter()
+            .zip(self.used_modules)
+            .filter_map(|(module, used)| used.then_some(module))
+            .collect();
+
         let mut rules = Rules {
             serialized_globals,
             wasm_mod,
@@ -870,7 +889,7 @@ impl<'a> Compiler<'a> {
             ident_pool: self.ident_pool,
             regex_pool: self.regex_pool,
             lit_pool: self.lit_pool,
-            imported_modules: self.imported_modules,
+            imported_modules,
             rules: self.rules,
             sub_patterns: self.sub_patterns,
             anchored_sub_patterns: self.anchored_sub_patterns,
@@ -1972,6 +1991,9 @@ impl Compiler<'_> {
             regex_pool: &mut self.regex_pool,
             wasm_symbols: &self.wasm_symbols,
             wasm_exports: &self.wasm_exports,
+            module_root_indexes: &self.module_root_indexes,
+            module_indexes: &self.module_indexes,
+            used_modules: &mut self.used_modules,
             exception_handler_stack: Vec::new(),
             lookup_list: Vec::new(),
             emit_search_for_pattern_stack: Vec::new(),
@@ -2025,8 +2047,11 @@ impl Compiler<'_> {
         // `self.imported_modules`, do it.
         if !self.root_struct.has_field(module_name) {
             // Add the module to the list of imported modules.
+            let module_index = self.imported_modules.len();
             self.imported_modules
                 .push(self.ident_pool.get_or_intern(module_name));
+            self.module_indexes.insert(module_name.to_string(), module_index);
+            self.used_modules.push(false);
 
             // Create the `Struct` that describes the module.
             let module_struct = Rc::<Struct>::from(module);
@@ -2041,6 +2066,13 @@ impl Compiler<'_> {
             {
                 panic!("duplicate module `{module_name}`")
             }
+
+            let root_index = self
+                .root_struct
+                .field_and_index_by_name(module_name)
+                .unwrap()
+                .1;
+            self.module_root_indexes.insert(root_index, module_index);
         }
 
         let mut symbol_table =
@@ -3045,7 +3077,7 @@ impl From<PatternId> for usize {
 #[serde(transparent)]
 pub(crate) struct SubPatternId(u32);
 
-/// Iterator that yields the names of the modules imported by the rules.
+/// Iterator that yields the names of the modules used by the rules.
 pub struct Imports<'a> {
     iter: std::slice::Iter<'a, IdentId>,
     ident_pool: &'a StringPool<IdentId>,

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -152,8 +152,9 @@ pub struct Rules {
     )]
     pub(in crate::compiler) compiled_wasm_mod: Option<wasm::runtime::Module>,
 
-    /// Vector with the names of all the imported modules. The vector contains
-    /// the [`IdentId`] corresponding to the module's identifier.
+    /// Vector with the names of the modules used by rule conditions. The
+    /// vector contains the [`IdentId`] corresponding to the module's
+    /// identifier. Imported modules that are not used are omitted.
     pub(in crate::compiler) imported_modules: Vec<IdentId>,
 
     /// Vector containing all the compiled rules. A [`RuleId`] is an index
@@ -266,8 +267,10 @@ pub struct Rules {
 }
 
 impl Rules {
-    /// An iterator that yields the name of the modules imported by the
-    /// rules.
+    /// An iterator that yields the names of modules used by the rules.
+    ///
+    /// Modules that are imported but not used by any rule condition are
+    /// omitted during compilation.
     pub fn imports(&self) -> Imports<'_> {
         Imports {
             iter: self.imported_modules.iter(),

--- a/lib/src/compiler/tests/mod.rs
+++ b/lib/src/compiler/tests/mod.rs
@@ -956,6 +956,78 @@ fn import_modules() {
     );
 }
 
+#[cfg(feature = "test_proto2-module")]
+#[test]
+fn unused_modules_are_not_imported_by_compiled_rules() {
+    let mut compiler = Compiler::new();
+    compiler
+        .add_source(
+            r#"
+            import "test_proto2"
+            rule unused { condition: true }"#,
+        )
+        .unwrap();
+    let rules = compiler.build();
+    assert_eq!(rules.imports().count(), 0);
+    let rules = Rules::deserialize(rules.serialize().unwrap()).unwrap();
+    assert_eq!(rules.imports().count(), 0);
+    let mut scanner = Scanner::new(&rules);
+    assert_eq!(scanner.scan(&[]).unwrap().module_outputs().count(), 0);
+
+    let mut compiler = Compiler::new();
+    compiler
+        .add_source(
+            r#"
+            import "test_proto2"
+            rule field { condition: test_proto2.int32_zero == 0 }"#,
+        )
+        .unwrap();
+    let rules = compiler.build();
+    assert_eq!(rules.imports().collect::<Vec<_>>(), ["test_proto2"]);
+    assert_eq!(
+        Scanner::new(&rules).scan(&[]).unwrap().matching_rules().len(),
+        1
+    );
+
+    let mut compiler = Compiler::new();
+    compiler
+        .add_source(
+            r#"
+            import "test_proto2"
+            rule function {
+                condition:
+                    test_proto2.get_foo() == "foo" and
+                    test_proto2.nested.nested_func()
+            }"#,
+        )
+        .unwrap();
+    let rules =
+        Rules::deserialize(compiler.build().serialize().unwrap()).unwrap();
+    assert_eq!(rules.imports().collect::<Vec<_>>(), ["test_proto2"]);
+    assert_eq!(
+        Scanner::new(&rules).scan(&[]).unwrap().matching_rules().len(),
+        1
+    );
+}
+
+#[cfg(all(feature = "test_proto2-module", feature = "test_proto3-module"))]
+#[test]
+fn only_used_modules_are_imported_by_compiled_rules() {
+    let rules = compile(
+        r#"
+        import "test_proto2"
+        import "test_proto3"
+        rule used { condition: test_proto3.int32_zero == 0 }"#,
+    )
+    .unwrap();
+
+    assert_eq!(rules.imports().collect::<Vec<_>>(), ["test_proto3"]);
+    assert_eq!(
+        Scanner::new(&rules).scan(&[]).unwrap().matching_rules().len(),
+        1
+    );
+}
+
 #[cfg(feature = "pe-module")]
 #[test]
 fn wrong_type() {

--- a/lib/src/modules/tests.rs
+++ b/lib/src/modules/tests.rs
@@ -142,9 +142,18 @@ fn test_modules() {
             return;
         }
 
-        // Construct a dummy YARA rule that only imports the module.
+        // Construct a dummy YARA rule that uses one non-constant field from
+        // the module, ensuring that the module produces its output.
+        let module = mods::module_definition(module_name).unwrap();
+        let field_name = module
+            .fields()
+            .find(|field| {
+                !field.is_const() && !matches!(field.ty(), Type::Func(_))
+            })
+            .unwrap()
+            .name();
         let rule = format!(
-            r#"import "{module_name}" rule test {{ condition: false }}"#
+            r#"import "{module_name}" rule test {{ condition: defined {module_name}.{field_name} }}"#
         );
 
         // Compile the rule.


### PR DESCRIPTION
## Summary

Omit imported modules that are not referenced by any compiled condition.
Module references are collected while emitting conditions, and only the
runtime import list is filtered. Parsing, type checking, module APIs, and the
compiled-rules format remain unchanged.

This implements the compiler-side approach discussed in #630: rules may keep
their import statements for compatibility while avoiding module parsing when
the imported data is not used.

## What changed

- record module roots referenced by fields and static module functions
- retain only referenced modules in the compiled runtime import list
- preserve all imports used by any rule in the compilation unit
- update module tests so their rules actually reference module output
- add coverage for unused imports, used fields, nested/static functions,
  multiple modules, serialization, scanning, and the C import iterator

## Results

Measured from current `main` at `e2ae57c4` on a Linux c4-standard-32 using
`release-lto`, one worker pinned to one CPU, and 11 interleaved pairs. The
same unmodified baseline reader scanned both packages, so only compiler output
differs between variants.

The workload imports `.NET` without referencing it and scans 3,900 decoded
files / 1.620 GB.

| | Before | After |
|---|---:|---:|
| Median time | 5.966496 s | 0.131230 s |
| Throughput | 271.6 MB/s | 12,347.1 MB/s |
| Files/s | 653.6 | 29,718.8 |

The paired mean speedup is **4,446.662%**, with 11/11 wins and a 95%
bootstrap confidence interval of **4,424.568% to 4,469.638%**.

A package whose condition references `.NET` is byte-identical between the two
compilers. The baseline reader loads the optimized package successfully, and
sorted NDJSON output is identical across old/new reader-package combinations.

## Validation

- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- 52 explicit CLI tests
- `cargo clippy --tests --no-deps -- --deny clippy::all`
- `cargo fmt --all -- --check`
- `git diff --check`
