### PR TITLE
perf(regex): store PikeVM instruction pointers as u32

### DIFF
--- a/lib/src/re/thompson/pikevm.rs
+++ b/lib/src/re/thompson/pikevm.rs
@@ -7,6 +7,8 @@ use super::instr::{Instr, InstrParser, Offset};
 use crate::re::thompson::instr::SplitId;
 use crate::re::{CodeLoc, DEFAULT_SCAN_LIMIT, WideIter};
 
+type Thread = (u32, u32);
+
 /// Represents a [Pike's VM](https://swtch.com/~rsc/regexp/regexp2.html) that
 /// executes VM code produced by the [compiler][`crate::re::compiler::Compiler`].
 pub(crate) struct PikeVM<'r> {
@@ -16,10 +18,10 @@ pub(crate) struct PikeVM<'r> {
     /// position within the VM code, pointing to some VM instruction. Each item
     /// in the set is unique, the VM guarantees that there aren't two active
     /// threads at the same VM instruction.
-    threads: Vec<(usize, u32)>,
+    threads: Vec<Thread>,
     /// The set of threads that will become the active threads when the next
     /// byte is read from the input.
-    next_threads: Vec<(usize, u32)>,
+    next_threads: Vec<Thread>,
     /// Maximum number of bytes to scan. The VM will abort after ingesting
     /// this number of bytes from the input.
     scan_limit: u16,
@@ -195,8 +197,9 @@ impl<'r> PikeVM<'r> {
             let decode_literal_runs = self.threads.len() == 1;
 
             for (ip, rep_count) in self.threads.iter() {
+                let ip = *ip as usize;
                 let (instr, mut instr_size) = InstrParser::decode_instr(
-                    unsafe { self.code.get_unchecked(*ip..) },
+                    unsafe { self.code.get_unchecked(ip..) },
                     decode_literal_runs,
                 );
 
@@ -283,7 +286,7 @@ impl<'r> PikeVM<'r> {
                 if is_match {
                     epsilon_closure(
                         self.code,
-                        C::from(*ip + instr_size),
+                        C::from(ip + instr_size),
                         *rep_count,
                         next_byte,
                         curr_byte,
@@ -313,7 +316,7 @@ impl<'r> PikeVM<'r> {
 pub struct EpsilonClosureState {
     /// Pairs (instruction pointer, repetition count) describing the existing
     /// threads.
-    threads: Vec<(usize, u32)>,
+    threads: Vec<Thread>,
     /// This bit array has one bit per possible value of SplitId. If the
     /// split instruction with SplitId = N is executed, the N-th bit in the
     /// array is set to 1.
@@ -384,20 +387,20 @@ pub(crate) fn epsilon_closure<C: CodeLoc>(
     curr_byte: Option<&u8>,
     prev_byte: Option<&u8>,
     state: &mut EpsilonClosureState,
-    closure: &mut Vec<(usize, u32)>,
+    closure: &mut Vec<Thread>,
 ) {
-    state.threads.push((start.location(), rep_count));
+    state.threads.push((start.location().try_into().unwrap(), rep_count));
     state.dirty = true;
 
     let is_word_char = |c: u8| c == b'_' || c.is_ascii_alphanumeric();
 
-    let apply_offset = |ip: usize, offset: Offset| -> usize {
+    let apply_offset = |ip: u32, offset: Offset| -> u32 {
         (ip as isize).saturating_add(offset.into()).try_into().unwrap()
     };
 
     while let Some((ip, mut rep_count)) = state.threads.pop() {
         let (instr, instr_size) = InstrParser::decode_instr(
-            unsafe { code.get_unchecked(ip..) },
+            unsafe { code.get_unchecked(ip as usize..) },
             false,
         );
         match instr {


### PR DESCRIPTION
## Summary

Keep PikeVM instruction pointers as `u32` while they are stored in active and
pending thread vectors. Compiled regexp locations already use checked
`NonZeroU32` values, so widening every thread to `usize` doubles each entry's
size without extending the supported code range.

Thread entries shrink from 16 to 8 bytes. Conversion to `usize` now happens
only when indexing the bytecode slice. The instruction format, compiled-rules
format, public API, matching algorithm, and overflow checks are unchanged.

## Results

Measured from current `main` at `e2ae57c4` on a Linux c4-standard-32 using
`release-lto`, one worker pinned to one CPU, and 11 interleaved pairs. Both
binaries scan the same package produced after #747.

The match-positive workload contains 200 regular expressions and scans eight
distinct 16 MiB files.

| Workload | Before | After | Paired mean | Wins | 95% CI |
|---|---:|---:|---:|---:|---:|
| Regex match-positive, t1 | 39.7 MB/s | 42.8 MB/s | **+8.033%** | 11/11 | +7.661% to +8.406% |
| Forge Core, 256 MiB, t1 | 98.8 MB/s | 103.1 MB/s | **+4.661%** | 11/11 | +4.341% to +5.017% |
| Regex no-match, 1 GiB, t1 | 1,500.8 MB/s | 1,512.5 MB/s | +0.540% | 7/11 | -0.561% to +1.622% |

The optimized binary's `.text` is 1,360 bytes smaller. Sorted regex and Core
NDJSON output is identical.

## Validation

- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- 52 explicit CLI tests
- `cargo clippy --tests --no-deps -- --deny clippy::all`
- `cargo fmt --all -- --check`
- `git diff --check`
