### PR TITLE
perf(scanner): lower mmap threshold on Linux

### DIFF
--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -105,6 +105,12 @@ static HEARTBEAT_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// Used for spawning the thread that increments `HEARTBEAT_COUNTER`.
 static INIT_HEARTBEAT: Once = Once::new();
 
+#[cfg(target_os = "linux")]
+const MMAP_THRESHOLD: usize = 768 * 1024;
+
+#[cfg(not(target_os = "linux"))]
+const MMAP_THRESHOLD: usize = 500_000_001;
+
 /// Represents the data being scanned.
 ///
 /// The scanned data can be backed by a slice owned by someone else, or a
@@ -573,9 +579,7 @@ impl<'r> Scanner<'r> {
             size = std::cmp::min(size, max_scan_size);
         }
 
-        // For files smaller than ~500MB reading the whole file is faster than
-        // using a memory-mapped file.
-        let data = if self.use_mmap && size > 500_000_000 {
+        let data = if self.use_mmap && size >= MMAP_THRESHOLD {
             let mapped_file = unsafe {
                 MmapOptions::new().map_copy_read_only(&file).map_err(|err| {
                     ScanError::MapError { path: path.to_path_buf(), err }


### PR DESCRIPTION
## Summary

Use memory-mapped input for files of at least 768 KiB on Linux. Other
platforms retain the existing boundary: their first mapped size remains
500,000,001 bytes.

This avoids allocating, reading, and copying the whole input before scanning
large files. The existing `Scanner::use_mmap(false)` API and CLI `--no-mmap`
option remain available for callers that prefer buffered reads.

## Results

Measured from current `main` at `e2ae57c4` on a Linux c4-standard-32 using
Rust 1.98, `release-lto`, `target-cpu=native`, and interleaved baseline versus
candidate runs.

| Workload | Before | After | Paired mean | Wins | 95% CI |
|---|---:|---:|---:|---:|---:|
| Forge Core, 256 MiB, t1 | 98.8 MB/s | 103.2 MB/s | **+4.491%** | 11/11 | +4.158% to +4.812% |
| Literal-heavy, 256 MiB, t1 | 863.1 MB/s | 1,390.0 MB/s | **+61.381%** | 31/31 | +60.568% to +62.198% |
| Forge Full, decoded modules, t32 | 82.3 MB/s | 84.3 MB/s | **+2.255%** | 28/31 | +1.657% to +2.884% |
| Forge Core, 341 x 768 KiB, t32 | 1,254.2 MB/s | 1,307.4 MB/s | **+4.165%** | 31/31 | +3.689% to +4.655% |

Controls that do not change input strategy stay neutral:

- 341 x 768 KiB at t1: -0.253%, CI -0.645% to +0.178%
- 512 x 512 KiB at t32: +0.408%, CI -0.046% to +0.873%
- Forge Core, 100,000 x 4 KiB at t32: +0.464%, CI -0.508% to +1.498%

Forcing `--no-mmap` in the candidate is also neutral versus the baseline on
Core/256 MiB (-0.209%), literal/256 MiB (+0.284%), and Forge Full/t32
(-0.703%); every confidence interval crosses zero. This isolates the gains to
the input strategy rather than binary layout.

The initial read/mmap crossover sweep covered 384 KiB through 1 MiB. It found
that 512 KiB was too low for parallel scans, while 768 KiB was the first useful
general boundary. The current-main measurements above revalidate the final
threshold on both sides of that boundary.

Sorted Forge Full NDJSON output is identical for the baseline, the mmap
candidate, and the candidate with `--no-mmap`.

## Validation

- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- 52 explicit CLI tests
- `cargo clippy --tests --no-deps -- --deny clippy::all`
- `cargo fmt --all -- --check`
- `git diff --check`
