### PR TITLE
perf(wasm): cache constant input header reads

### DIFF
--- a/lib/src/compiler/emit.rs
+++ b/lib/src/compiler/emit.rs
@@ -21,6 +21,7 @@ use walrus::ir::{
 };
 use walrus::{FunctionId, InstrSeqBuilder, ValType};
 
+use crate::compiler::ir::FuncCall;
 use crate::compiler::ir::{
     Expr, ExprId, ForIn, ForOf, IR, Iterable, MatchAnchor, PatternIdx,
     Quantifier,
@@ -39,6 +40,7 @@ use crate::wasm;
 use crate::wasm::builder::WasmModuleBuilder;
 use crate::wasm::string::RuntimeString;
 use crate::wasm::{
+    CACHED_HEADER_BASE, CACHED_HEADER_CAPACITY, CACHED_HEADER_LEN_BASE,
     LOOKUP_INDEXES_END, LOOKUP_INDEXES_START, MATCHING_RULES_BITMAP_BASE,
     VARS_STACK_START, WasmSymbols,
 };
@@ -284,6 +286,129 @@ pub(crate) fn emit_rule_condition(
     ctx.emit_search_for_pattern_stack.pop();
     assert!(ctx.emit_search_for_pattern_stack.is_empty());
     builder.finish_rule();
+}
+
+/// Emits a direct load for unsigned integer reads at constant header offsets.
+///
+/// The contiguous scanner copies a small input prefix into WASM memory before
+/// evaluating conditions. If the current input is too short, retain the
+/// imported function as a fallback so undefined-value behavior is unchanged.
+fn emit_cached_header_read(
+    ctx: &mut EmitContext,
+    ir: &IR,
+    func_call: &FuncCall,
+    instr: &mut InstrSeqBuilder,
+) -> bool {
+    if func_call.object.is_some() || func_call.args.len() != 1 {
+        return false;
+    }
+
+    let (width, big_endian) = match func_call.plain_name() {
+        "uint16" => (2_usize, false),
+        "uint32" => (4_usize, false),
+        "uint16be" => (2_usize, true),
+        "uint32be" => (4_usize, true),
+        _ => return false,
+    };
+
+    let Some(offset) = ir
+        .get(func_call.args[0])
+        .try_as_const_integer()
+        .and_then(|offset| usize::try_from(offset).ok())
+    else {
+        return false;
+    };
+    let Some(end) = offset.checked_add(width) else {
+        return false;
+    };
+    if end > CACHED_HEADER_CAPACITY {
+        return false;
+    }
+
+    let memory = ctx.wasm_symbols.main_memory;
+    let tmp = ctx.wasm_symbols.i64_tmp_a;
+
+    let emit_value = |instr: &mut InstrSeqBuilder| {
+        instr.i32_const(0);
+        instr.load(
+            memory,
+            match width {
+                2 => LoadKind::I64_16 { kind: ZeroExtend },
+                4 => LoadKind::I64_32 { kind: ZeroExtend },
+                _ => unreachable!(),
+            },
+            MemArg {
+                align: 1,
+                offset: (CACHED_HEADER_BASE as usize + offset) as u64,
+            },
+        );
+
+        if big_endian {
+            instr.local_set(tmp);
+            match width {
+                2 => {
+                    instr
+                        .local_get(tmp)
+                        .i64_const(0xff)
+                        .binop(BinaryOp::I64And)
+                        .i64_const(8)
+                        .binop(BinaryOp::I64Shl)
+                        .local_get(tmp)
+                        .i64_const(8)
+                        .binop(BinaryOp::I64ShrU)
+                        .binop(BinaryOp::I64Or);
+                }
+                4 => {
+                    instr
+                        .local_get(tmp)
+                        .i64_const(0xff)
+                        .binop(BinaryOp::I64And)
+                        .i64_const(24)
+                        .binop(BinaryOp::I64Shl)
+                        .local_get(tmp)
+                        .i64_const(0xff00)
+                        .binop(BinaryOp::I64And)
+                        .i64_const(8)
+                        .binop(BinaryOp::I64Shl)
+                        .binop(BinaryOp::I64Or)
+                        .local_get(tmp)
+                        .i64_const(8)
+                        .binop(BinaryOp::I64ShrU)
+                        .i64_const(0xff00)
+                        .binop(BinaryOp::I64And)
+                        .binop(BinaryOp::I64Or)
+                        .local_get(tmp)
+                        .i64_const(24)
+                        .binop(BinaryOp::I64ShrU)
+                        .binop(BinaryOp::I64Or);
+                }
+                _ => unreachable!(),
+            }
+        }
+    };
+
+    let fn_id = ctx.function_id(func_call.mangled_name());
+
+    instr.i32_const(0);
+    instr.load(
+        memory,
+        LoadKind::I32 { atomic: false },
+        MemArg { align: 4, offset: CACHED_HEADER_LEN_BASE as u64 },
+    );
+    instr.i32_const(end as i32);
+    instr.binop(BinaryOp::I32GeU);
+    instr.if_else(
+        I64,
+        |then_| {
+            emit_value(then_);
+        },
+        |else_| {
+            else_.i64_const(offset as i64);
+            emit_call_and_handle_undef(ctx, else_, fn_id);
+        },
+    );
+
+    true
 }
 
 /// Emits WASM code for `expr` into the instruction sequence `instr`.
@@ -694,6 +819,10 @@ fn emit_expr(
         },
 
         Expr::FuncCall(func_call) => {
+            if emit_cached_header_read(ctx, ir, func_call, instr) {
+                return;
+            }
+
             // If this is method call, the target object (self or this in some
             // programming languages) is the first argument.
             if let Some(obj) = func_call.object {

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -34,7 +34,7 @@ const MAGIC: &[u8] = b"YARA-X\0\0";
 ///
 /// This version is incremented every time a change is made to the binary
 /// format in a way that breaks backwards compatibility.
-const SERIALIZATION_VERSION: u32 = 6;
+const SERIALIZATION_VERSION: u32 = 7;
 
 /// Aho-Corasick automaton bundled with an optional Teddy scanner if the
 /// number of patterns is low enough. If the Teddy scanner is present, and

--- a/lib/src/compiler/tests/mod.rs
+++ b/lib/src/compiler/tests/mod.rs
@@ -27,7 +27,7 @@ fn serialization() {
     // `DecodeError`.
     let mut data = Vec::new();
     data.extend(b"YARA-X\0\0");
-    data.extend(6u32.to_le_bytes());
+    data.extend(7u32.to_le_bytes());
     data.extend(b"foo");
 
     assert!(matches!(

--- a/lib/src/scanner/blocks.rs
+++ b/lib/src/scanner/blocks.rs
@@ -443,6 +443,23 @@ mod tests {
     }
 
     #[test]
+    fn block_scanner_does_not_read_the_contiguous_header_cache() {
+        let rules = compile(
+            r#"
+            rule test {
+              condition:
+                uint16(0) == 0 and uint32(2) == 0
+            }
+            "#,
+        )
+        .unwrap();
+
+        let mut scanner = Scanner::new(&rules);
+        let results = scanner.scan(0, &[0; 6]).unwrap().finish().unwrap();
+        assert!(results.matching_rules().next().is_none());
+    }
+
+    #[test]
     fn block_scanner_2() {
         let rules = compile(
             r#"

--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -41,10 +41,13 @@ use crate::scanner::matches::{
 use crate::scanner::{DataSnippets, ScanError, ScannedData};
 use crate::scanner::{HEARTBEAT_COUNTER, INIT_HEARTBEAT};
 use crate::types::{Array, Map, Struct, TypeValue};
-use crate::wasm::MATCHING_RULES_BITMAP_BASE;
 use crate::wasm::runtime::{
     AsContext, AsContextMut, Global, GlobalType, Instance, MemoryType,
     Mutability, Store, TypedFunc, Val, ValType,
+};
+use crate::wasm::{
+    CACHED_HEADER_BASE, CACHED_HEADER_CAPACITY, CACHED_HEADER_LEN_BASE,
+    MATCHING_RULES_BITMAP_BASE,
 };
 use crate::{Variable, wasm};
 
@@ -440,6 +443,18 @@ impl ScanContext<'_, '_> {
             .unwrap();
     }
 
+    /// Copies the beginning of a contiguous input into WASM memory.
+    pub(crate) fn cache_input_header(&mut self, data: &[u8]) {
+        let len = data.len().min(CACHED_HEADER_CAPACITY);
+        let store = self.wasm_store_mut();
+        let mem = self.wasm.main_memory.unwrap().data_mut(store);
+        mem[CACHED_HEADER_LEN_BASE as usize
+            ..CACHED_HEADER_LEN_BASE as usize + 4]
+            .copy_from_slice(&(len as u32).to_le_bytes());
+        mem[CACHED_HEADER_BASE as usize..CACHED_HEADER_BASE as usize + len]
+            .copy_from_slice(&data[..len]);
+    }
+
     /// Sets the value of the flag that indicates if the pattern search
     /// phase was already executed.
     pub(crate) fn set_pattern_search_done(&mut self, done: bool) {
@@ -564,6 +579,14 @@ impl ScanContext<'_, '_> {
         let num_patterns = self.compiled_rules.num_patterns();
 
         self.scan_state = ScanState::Idle;
+
+        {
+            let store = self.wasm_store_mut();
+            let mem = self.wasm.main_memory.unwrap().data_mut(store);
+            mem[CACHED_HEADER_LEN_BASE as usize
+                ..CACHED_HEADER_LEN_BASE as usize + 4]
+                .fill(0);
+        }
 
         // Free all runtime objects left around by previous scans.
         self.runtime_objects.clear();

--- a/lib/src/scanner/mod.rs
+++ b/lib/src/scanner/mod.rs
@@ -614,6 +614,8 @@ impl<'r> Scanner<'r> {
         // Set the global variable `filesize` to the size of the scanned data.
         ctx.set_filesize(data.len() as i64);
 
+        ctx.cache_input_header(data.as_ref());
+
         // Create the context that will be passed to the main function of each
         // module.
         let mut mod_ctx = ModuleContext::default();

--- a/lib/src/scanner/tests.rs
+++ b/lib/src/scanner/tests.rs
@@ -979,6 +979,56 @@ fn max_scan_size() {
     );
 }
 
+#[test]
+fn cached_header_reads_preserve_integer_semantics_and_scanner_reuse() {
+    let rules = crate::compile(
+        r#"
+        rule little_endian {
+          condition:
+            uint16(0) == 0x0201 and uint32(2) == 0x06050403
+        }
+        rule big_endian {
+          condition:
+            uint16be(0) == 0x0102 and uint32be(2) == 0x03040506
+        }
+        rule cache_boundary {
+          condition:
+            uint32(124) == 0x04030201
+        }
+        rule outside_cache {
+          condition:
+            uint32(125) == 0x05040302
+        }
+        "#,
+    )
+    .unwrap();
+
+    let mut data = [0_u8; 129];
+    data[..6].copy_from_slice(&[1, 2, 3, 4, 5, 6]);
+    data[124..].copy_from_slice(&[1, 2, 3, 4, 5]);
+
+    let mut scanner = Scanner::new(&rules);
+    let matching_rules: Vec<_> = scanner
+        .scan(&data)
+        .unwrap()
+        .matching_rules()
+        .map(|rule| rule.identifier())
+        .collect();
+    assert_eq!(
+        matching_rules,
+        ["little_endian", "big_endian", "cache_boundary", "outside_cache"]
+    );
+
+    // A short scan after a long one must not observe bytes left in the cache.
+    let matching_rules: Vec<_> = scanner
+        .scan(&data[..2])
+        .unwrap()
+        .matching_rules()
+        .map(|rule| rule.identifier())
+        .collect();
+    assert!(matching_rules.is_empty());
+}
+
 #[cfg(feature = "test_proto2-module")]
 #[test]
 fn regex_set_optimization() {

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -36,6 +36,8 @@ The memory of these WASM modules is organized as follows.
   │                          │
   ├──────────────────────────┤ LOOKUP_INDEXES_START
   │ Field lookup indexes     │
+  ├──────────────────────────┤ CACHED_HEADER_LEN_BASE
+  │ Cached input header      │
   ├──────────────────────────┤ MATCHING_RULES_BITMAP_BASE
   │ Matching rules bitmap    │
   │                          │
@@ -123,10 +125,18 @@ pub(crate) const LOOKUP_INDEXES_START: i32 = VARS_STACK_END;
 /// Offset in module's main memory where the space for lookup indexes end.
 pub(crate) const LOOKUP_INDEXES_END: i32 = LOOKUP_INDEXES_START + 1024;
 
+/// Offset of the cached input-header length.
+pub(crate) const CACHED_HEADER_LEN_BASE: i32 = LOOKUP_INDEXES_END;
+/// Offset of the cached input bytes.
+pub(crate) const CACHED_HEADER_BASE: i32 = CACHED_HEADER_LEN_BASE + 4;
+/// Number of input-header bytes copied into WASM memory for direct reads.
+pub(crate) const CACHED_HEADER_CAPACITY: usize = 128;
+
 /// Offset in module's main memory where resides the bitmap that tells if a
 /// rule matches or not. This bitmap contains one bit per rule, if the N-th
 /// bit is set, it indicates that the rule with RuleId = N matched.
-pub(crate) const MATCHING_RULES_BITMAP_BASE: i32 = LOOKUP_INDEXES_END;
+pub(crate) const MATCHING_RULES_BITMAP_BASE: i32 =
+    CACHED_HEADER_BASE + CACHED_HEADER_CAPACITY as i32;
 
 inventory::collect!(WasmExport);
 


### PR DESCRIPTION
## Summary

Cache the first 128 bytes of contiguous input in WASM memory and emit direct
guest loads for constant unsigned 16- and 32-bit integer reads within that
prefix. This avoids repeated host calls for common header checks such as
uint16(0) and uint32(0x3c).

Dynamic offsets, signed reads, reads outside the cached prefix, short inputs,
and block scans retain the existing host fallback and undefined-value
semantics. Scanner reset clears the cached length so a short scan cannot see
bytes left by a previous longer scan.

The reserved memory moves the matching-rules bitmap, so the compiled-rules
serialization version is intentionally bumped from 6 to 7. Old and new
readers reject the opposite package version explicitly instead of interpreting
different WASM memory offsets.

## Results

Measured from current main at 24cd993c on a Linux c4-standard-32 using
release-lto, target-cpu=native, glibc transparent huge pages, and 11
interleaved pairs.

| Workload | Before | After | Paired mean | Wins | 95% CI |
|---|---:|---:|---:|---:|---:|
| Forge Core, 10,000 x 4 KiB, t1 | 1,088.8 files/s | 1,156.8 files/s | **+6.039%** | 11/11 | +5.568% to +6.449% |
| Forge Core, 100,000 x 4 KiB, t32 | 25,755 files/s | 27,293 files/s | **+6.089%** | 11/11 | +5.438% to +6.777% |

A same-runtime package-only comparison isolates the generated-code change at
**+5.411%** on the 100,000-file t32 workload, with 11/11 wins and a 95%
bootstrap confidence interval of +4.925% to +5.958%.

Controls:

- Forge Core, 256 MiB, t1: +0.192%; CI -1.234% to +1.595%
- Forge Full modules, t4: -0.380%; CI -1.507% to +0.779%
- regex-heavy, 1 GiB, t1: +0.387%; CI -0.029% to +0.800%

Sorted Forge Full output is identical. A same-runtime Core comparison between
packages with and without direct cached loads is also identical.

## Validation

- cargo test --no-default-features --features=default-modules,magic-module
- cargo test --features=magic-module,rules-profiling
- 52 explicit CLI tests
- focused little-/big-endian, cache-boundary, scanner-reuse, block-scan, and serialization tests
- cargo clippy --tests --no-deps -- --deny clippy::all
- cargo fmt --all -- --check
- git diff --check
