### PR TITLE
feat(cli): read scan lists from stdin

### DIFF
--- a/cli/src/help.rs
+++ b/cli/src/help.rs
@@ -193,8 +193,9 @@ The default value is automatically determined based on the number of CPU cores."
 
 pub const SCAN_LIST_LONG_HELP: &str = r#"Indicate that TARGET_PATH is a file containing the paths to be scanned
 
-<TARGET_PATH> must be a text file containing one path per line. The paths must
-be either absolute paths, or relative to the current directory."#;
+<TARGET_PATH> must be a text file containing one path per line, or `-` to read
+paths from standard input until EOF. The paths must be either absolute paths,
+or relative to the current directory."#;
 
 pub const SCAN_LONG_HELP: &str = r#"Scan a file or directory
 

--- a/cli/src/tests/scan.rs
+++ b/cli/src/tests/scan.rs
@@ -33,6 +33,21 @@ fn negate() {
 }
 
 #[test]
+fn scan_list_from_stdin() {
+    Command::new(cargo_bin!("yr"))
+        .arg("scan")
+        .arg("--count")
+        .arg("--scan-list")
+        .arg("--threads=1")
+        .arg("src/tests/testdata/foo.yar")
+        .arg("-")
+        .write_stdin("src/tests/testdata/dummy.file\n")
+        .assert()
+        .success()
+        .stdout("src/tests/testdata/dummy.file: 1\n");
+}
+
+#[test]
 fn filter_by_tag() {
     Command::new(cargo_bin!("yr"))
         .arg("scan")

--- a/cli/src/walk.rs
+++ b/cli/src/walk.rs
@@ -142,6 +142,10 @@ impl<'a> Walker<'a> {
         F: FnMut(&Path) -> anyhow::Result<()>,
         E: FnMut(anyhow::Error) -> anyhow::Result<()>,
     {
+        if self.file_list && self.path == Path::new("-") {
+            return self.walk_file_list(f, e);
+        }
+
         let metadata =
             match self.path.metadata().with_context(|| {
                 format!("can't open `{}`", self.path.display())
@@ -170,14 +174,32 @@ impl<'a> Walker<'a> {
         }
     }
 
-    fn walk_file_list<F, E>(self, mut f: F, mut e: E) -> anyhow::Result<()>
+    fn walk_file_list<F, E>(self, f: F, e: E) -> anyhow::Result<()>
     where
         F: FnMut(&Path) -> anyhow::Result<()>,
         E: FnMut(anyhow::Error) -> anyhow::Result<()>,
     {
-        let file = File::open(self.path)?;
+        if self.path == Path::new("-") {
+            let stdin = io::stdin();
+            self.walk_file_list_lines(stdin.lock().lines(), f, e)
+        } else {
+            let file = File::open(self.path)?;
+            self.walk_file_list_lines(io::BufReader::new(file).lines(), f, e)
+        }
+    }
 
-        for line in io::BufReader::new(file).lines() {
+    fn walk_file_list_lines<F, E, I>(
+        self,
+        lines: I,
+        mut f: F,
+        mut e: E,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut(&Path) -> anyhow::Result<()>,
+        E: FnMut(anyhow::Error) -> anyhow::Result<()>,
+        I: Iterator<Item = io::Result<String>>,
+    {
+        for line in lines {
             let path = PathBuf::from(line?);
             let metadata = match path
                 .metadata()


### PR DESCRIPTION
# `feat(cli): read scan lists from stdin`

## Summary

- accept `-` as the target for `yr scan --scan-list`;
- read one path per line from standard input until EOF;
- share the same walker and error handling used for file-backed scan lists.

This makes it possible for a producer to feed batches to one long-lived `yr`
process instead of writing manifests and launching a new process for each
batch. Rules are loaded once and scanner workers are retained for the stream.

## Performance

On 100 consecutive 17-file Forge Core batches at 32 workers, comparing the
same candidate executable and the same 1,700 paths:

| Mode | Median time | Throughput |
|---|---:|---:|
| 100 `yr` invocations | 8.872658 s | 191.6 files/s |
| One `--scan-list -` stream | 0.125403 s | 13,556.2 files/s |

The stdin stream is **70.75x** faster by medians. The paired mean improvement
is **+6,858.92%** over 9/9 pairs, with a bootstrap 95% confidence interval of
**+6,620.82% to +7,016.11%**. This is process, rule-loading, and scanner-reuse
amortization; it does not claim a faster per-byte scan kernel.

The existing file-backed route is neutral versus the unchanged baseline over
121 pairs (+1.09%, CI -0.43% to +2.61%). Reading the same 1,700 paths from
stdin instead of a file is also neutral over 121 pairs (+0.62%, CI -0.50% to
+1.80%). Core-small, Core-large, match-positive regex, and Full/module
controls all have confidence intervals crossing zero.

## Correctness and validation

- Sorted output from 100 launches and one stdin stream is byte-identical.
- Both default and no-default-feature workspace test matrices pass.
- All 53 CLI tests pass, including the new stdin scan-list test.
- Workspace Clippy, Rustfmt, and diff checks pass.
