### PR TITLE
feat(cli): expose native code serialization

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -49,6 +49,10 @@ stderr-logs = ["yara-x/stderr-logs"]
 # performance.
 rules-profiling = ["yara-x/rules-profiling"]
 
+# Include precompiled native code in serialized rules. This reduces rule load
+# time at the cost of larger, platform-specific compiled-rule files.
+native-code-serialization = ["yara-x/native-code-serialization"]
+
 # Enables the use of wasmtime's Pulley bytecode interpreter instead of the default
 # Cranelift JIT compiler. See the documentation in the `yara-x` core library for details.
 pulley = ["yara-x/pulley"]


### PR DESCRIPTION
# `feat(cli): expose native code serialization`

## Summary

- expose the existing `yara-x/native-code-serialization` feature through the
  `yara-x-cli` crate;
- keep the feature opt-in and disabled by default;
- allow CLI builds to emit compiled-rule packages containing precompiled
  Wasmtime code, avoiding JIT compilation when the package is loaded on a
  compatible platform.

The C API already exposes the same library feature. This adds the equivalent
pass-through to the CLI crate without changing runtime code or default builds.

## Performance

Measurements use the same release-LTO/native executable for both variants and
change only the compiled package from portable to native-code-enabled.

| Workload | Improvement | Median before | Median after |
|---|---:|---:|---:|
| Forge Core, one 4 KiB file, t1 | +2200.66% | 0.61110 s | 0.02667 s |
| Forge Full, one 4 KiB file, t1 | +3337.31% | 2.23288 s | 0.06621 s |
| Forge Core, 256 MiB, t1 | +28.85% | 102.1 MB/s | 131.4 MB/s |
| Forge Core, 100,000 x 4 KiB, t32 | +1.82% | 44,399 files/s | 45,051 files/s |
| Forge Full/modules, t4 | +141.89% | 152.7 files/s | 363.1 files/s |
| Regex match-positive, 8 x 16 MiB, t1 | +0.33% | 47.44 MB/s | 47.60 MB/s |

Every workload won 11/11 or 31/31 interleaved pairs with a wholly positive
bootstrap confidence interval. Startup profiles attribute 87-90% of portable
package CPU to Wasmtime/Cranelift JIT work.

The regex row is a dedicated transfer check for a historical layout concern:
23/31 native-package pairs won and the paired-mean 95% interval is +0.09% to
+0.59%. The earlier negative comparison used a different BOLT-trained binary;
the package-only comparison on the same executable is positive.

Native packages are larger: +35.88% for Core and +51.25% for Full. The raw
WASM module remains in the package, so readers can fall back to JIT compilation
when the serialized native module is not compatible with the current platform.

## Compatibility and validation

- The default release-LTO/native binary is byte-identical before and after the
  Cargo feature alias.
- Default and feature-enabled readers produce identical output with portable
  and native packages.
- 327 feature-enabled library tests pass.
- 52 feature-enabled CLI tests pass.
- 20 runnable doctests pass.
- Clippy, Cargo metadata verification, Rustfmt, and diff checks pass.
