### PR TITLE
perf(wasm): skip empty pattern ranges

### DIFF
--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -3676,6 +3676,19 @@ fn of() {
           strings:
             $a1 = "foo"
             $a2 = "bar"
+          condition:
+            0 of them
+        }
+        "#,
+        &[]
+    );
+
+    rule_true!(
+        r#"
+        rule test {
+          strings:
+            $a1 = "foo"
+            $a2 = "bar"
             $b1 = "baz"
           condition:
             all of ($a*, $b*)

--- a/lib/src/wasm/mod.rs
+++ b/lib/src/wasm/mod.rs
@@ -981,6 +981,11 @@ pub(crate) fn pat_range_match(
     let required = required.try_into().unwrap();
 
     let ctx = caller.data();
+
+    if ctx.tracker.pattern_matches.is_empty() {
+        return required == 0;
+    }
+
     let mut num_matches = 0;
 
     for pattern_id in range {


### PR DESCRIPTION
## Summary

Return immediately from `pat_range_match` when no pattern has matched. In that
case the requested count can only be satisfied when it is zero, so walking the
rule's pattern range cannot change the result.

This adds a five-line fast path plus a regression test for `0 of them`. Pattern
tracking, generated Wasm, serialized rules, and public APIs are unchanged.

## Results

Measured from `main` at `02a0ddda` on a dedicated 32-vCPU Linux host with
Rust 1.98, release LTO, `target-cpu=native`, clean sequential builds in the
same absolute path, and byte-identical same-inode null arms.

| Workload | Result | 95% CI |
|---|---:|---:|
| Forge Core, 100k x 4 KiB, 32 threads | **+6.235% (12/12)** | **+6.128% to +6.345%** |
| Forge Core, 256 MiB, 1 thread | -0.114% | -0.523% to +0.310% |
| Forge Full/modules, 150 files, 4 threads | -0.019% | -0.882% to +1.030% |
| Regex match-positive, 8 x 16 MiB, 1 thread | -0.112% across 3 sessions | -0.796% to +0.572% |
| Regex no-match, 1 GiB, 1 thread | +0.330% across 3 sessions | -0.447% to +1.107% |

Core throughput increases from about 45.7k to 48.6k files/s, or 187.3 to
199.1 MB/s. Sorted NDJSON output is byte-identical for all 100,000 Core
records and all 8 regex records.

## Validation

- `cargo +1.98.0 test --locked --workspace`
- `cargo +1.98.0 test --locked --workspace --no-default-features`
- `cargo +1.98.0 test --locked -p yara-x-cli`
- `cargo +1.98.0 clippy --locked --workspace --tests --no-deps -- --deny clippy::all`
- `cargo +1.98.0 fmt --all -- --check`
- `git diff --check`