### PR TITLE
perf(regex): fast-path common PikeVM instructions

### DIFF
--- a/lib/src/re/thompson/instr.rs
+++ b/lib/src/re/thompson/instr.rs
@@ -349,6 +349,35 @@ impl<'a> InstrParser<'a> {
         code: &[u8],
         decode_literal_runs: bool,
     ) -> (Instr<'_>, usize) {
+        if code.len() >= 2 && code[0] == OPCODE_PREFIX {
+            match code[1] {
+                Instr::CLASS_BITMAP if code.len() >= 34 => {
+                    let bitmap = unsafe { code.get_unchecked(2..34) };
+                    return (Instr::ClassBitmap(ClassBitmap(bitmap)), 34);
+                }
+                Instr::REPEAT_GREEDY
+                    if code.len()
+                        >= 2 + size_of::<Offset>()
+                            + size_of::<u32>()
+                            + size_of::<u32>() =>
+                {
+                    let offset = Self::decode_offset(&code[2..]);
+                    let min =
+                        Self::decode_u32(&code[2 + size_of::<Offset>()..]);
+                    let max = Self::decode_u32(
+                        &code[2 + size_of::<Offset>() + size_of::<u32>()..],
+                    );
+                    return (
+                        Instr::RepeatGreedy { offset, min, max },
+                        2 + size_of::<Offset>()
+                            + size_of::<u32>()
+                            + size_of::<u32>(),
+                    );
+                }
+                _ => {}
+            }
+        }
+
         match code[..] {
             [OPCODE_PREFIX, Instr::ANY_BYTE, ..] => (Instr::AnyByte, 2),
             [OPCODE_PREFIX, Instr::MASKED_BYTE, byte, mask, ..] => {


### PR DESCRIPTION
## Summary

Fast-path `ClassBitmap` and `RepeatGreedy` before PikeVM's generic
extended-opcode dispatch.

These two instructions dominate prefixed dispatches in the measured
match-positive regex workload. All other instructions continue through the
existing decoder. The matching algorithm, bytecode format, serialized rules,
and public API are unchanged.

## Results

Measured from current `main` at `02a0ddda` with Rust 1.98, release LTO,
`target-cpu=native`, clean sequential builds in the same absolute path, and
byte-identical same-inode null arms on a dedicated 32-vCPU Linux host. Both
binaries scan the same compiled packages.

| Workload | Result | 95% CI |
|---|---:|---:|
| Regex match-positive, 8 x 16 MiB, 1 thread | **+6.283% across 3 sessions (36/36)** | **+5.295% to +7.271%** |
| Forge Core, 100k x 4 KiB, 32 threads | +0.294% (10/12) | +0.128% to +0.464% |
| Forge Core, 256 MiB, 1 thread | -0.311% | -0.890% to +0.194% |
| Forge Full/modules, 150 files, 4 threads | -0.108% across 5 sessions | -0.774% to +0.559% |
| Regex no-match, 1 GiB, 1 thread | -0.125% across 5 sessions | -0.686% to +0.436% |
| Literal no-match, 1 GiB, 1 thread | -0.080% | -0.872% to +0.669% |

Regex throughput increases from about 52.8 to 55.9 MB/s in the fresh gate. A
prior 31-round confirmation on the same `main` measured +6.978% (31/31, 95%
CI +6.745% to +7.213%). Sorted NDJSON output is byte-identical for all 8 regex
records and all 100,000 Core records. The optimized binary file adds 864
bytes.

## Validation

- `cargo +1.98.0 test --locked --workspace`
- `cargo +1.98.0 test --locked --workspace --no-default-features`
- `cargo +1.98.0 test --locked -p yara-x-cli`
- `cargo +1.98.0 clippy --locked --workspace --tests --no-deps -- --deny clippy::all`
- `cargo +1.98.0 fmt --all -- --check`
- `git diff --check`