### PR TITLE
perf(scanner): track disabled patterns in a bitmap

### DIFF
--- a/lib/src/scanner/context.rs
+++ b/lib/src/scanner/context.rs
@@ -17,11 +17,12 @@ use std::{cmp, mem, thread};
 use base64::Engine;
 use bitvec::order::Lsb0;
 use bitvec::slice::BitSlice;
+use bitvec::vec::BitVec;
 use bstr::{BString, ByteSlice};
 use indexmap::IndexMap;
 use protobuf::{MessageDyn, MessageFull};
 use regex_automata::meta::Regex;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use crate::compiler::{
@@ -86,7 +87,7 @@ pub(crate) struct MatchTracker<'r> {
     /// the maximum number of matches or because they are meant to be ignored
     /// during this scan because they belong to some rule that we know that
     /// can't match.
-    pub disabled_patterns: FxHashSet<PatternId>,
+    pub disabled_patterns: BitVec,
     /// The rules that are being used during the scan.
     pub compiled_rules: &'r Rules,
     /// Indicates whether fast mode is enabled. In fast mode the scanner
@@ -569,7 +570,7 @@ impl ScanContext<'_, '_> {
         self.runtime_objects.clear();
 
         // Clear the set that tracks the patterns that has been disabled.
-        self.tracker.disabled_patterns.clear();
+        self.tracker.disabled_patterns.fill(false);
 
         self.tracker.unconfirmed_matches.clear();
         self.num_matching_private_rules = 0;
@@ -886,7 +887,7 @@ impl ScanContext<'_, '_> {
         let (pattern_id, sub_pattern) =
             &self.compiled_rules.get_sub_pattern(sub_pattern_id);
 
-        if self.tracker.disabled_patterns.contains(pattern_id) {
+        if self.tracker.disabled_patterns[usize::from(*pattern_id)] {
             return;
         }
 
@@ -1149,7 +1150,9 @@ impl ScanContext<'_, '_> {
             let filesize = self.get_filesize();
             for (pattern_id, bounds) in self.compiled_rules.filesize_bounds() {
                 if !bounds.contains(filesize) {
-                    self.tracker.disabled_patterns.insert(*pattern_id);
+                    self.tracker
+                        .disabled_patterns
+                        .set(usize::from(*pattern_id), true);
                 }
             }
         }
@@ -1159,7 +1162,9 @@ impl ScanContext<'_, '_> {
                 self.compiled_rules.header_constraints()
             {
                 if !constraints.is_satisfied(data) {
-                    self.tracker.disabled_patterns.insert(*pattern_id);
+                    self.tracker
+                        .disabled_patterns
+                        .set(usize::from(*pattern_id), true);
                 }
             }
         }
@@ -1216,7 +1221,7 @@ impl ScanContext<'_, '_> {
             .iter()
             .map(|id| (id, self.compiled_rules.get_sub_pattern(*id)))
         {
-            if self.tracker.disabled_patterns.contains(pattern_id) {
+            if self.tracker.disabled_patterns[usize::from(*pattern_id)] {
                 continue;
             }
             match sub_pattern {
@@ -2006,7 +2011,7 @@ fn track_match(
     }
 
     if disable_pattern {
-        tracker.disabled_patterns.insert(pattern_id);
+        tracker.disabled_patterns.set(usize::from(pattern_id), true);
     }
 }
 
@@ -2169,7 +2174,7 @@ pub fn create_wasm_store_and_ctx<'r>(
         tracker: MatchTracker {
             pattern_matches: PatternMatches::new(),
             unconfirmed_matches: FxHashMap::default(),
-            disabled_patterns: FxHashSet::default(),
+            disabled_patterns: BitVec::repeat(false, num_patterns as usize),
             compiled_rules: rules,
             fast_scan: false,
         },


### PR DESCRIPTION
## Summary

Track disabled patterns in a bitmap indexed by `PatternId` instead of a hash
set. The number of patterns is known when the scan context is created, so the
bitmap is allocated once and reset in place between scans.

This removes hashing and per-scan set allocation from pattern pruning while
leaving the pruning rules, pattern IDs, compiled-rules format, and public API
unchanged.

## Results

Measured from `main` at `02a0ddda` on a dedicated 32-vCPU Linux host with
Rust 1.98, release LTO, `target-cpu=native`, clean sequential builds in the
same absolute path, and byte-identical same-inode null arms.

| Workload | Result | 95% CI |
|---|---:|---:|
| Forge Core, 100k x 4 KiB, 32 threads | **+3.850% (12/12)** | **+3.702% to +4.003%** |
| Forge Core, 256 MiB, 1 thread | **+2.149% (11/12)** | **+1.505% to +2.679%** |
| Forge Full/modules, 150 files, 4 threads | +0.906% (7/12) | -0.064% to +1.912% |
| Regex match-positive, 8 x 16 MiB, 1 thread | **+1.066% (11/12)** | **+0.711% to +1.404%** |
| Regex no-match, 1 GiB, 1 thread | **+0.815% (15/18)** | **+0.323% to +1.277%** |
| Literal no-match, 1 GiB, 1 thread | **+1.072% (15/18)** | **+0.480% to +1.623%** |

Core small-file throughput increases from about 45.6k to 47.4k files/s, or
186.8 to 194.0 MB/s. Sorted NDJSON output is byte-identical for all 100,000
Core records, all 150 Full records, and all 8 regex records.

## Validation

- `cargo +1.98.0 test --locked --workspace`
- `cargo +1.98.0 test --locked --workspace --no-default-features`
- `cargo +1.98.0 test --locked -p yara-x-cli`
- `cargo +1.98.0 clippy --locked --workspace --tests --no-deps -- --deny clippy::all`
- `cargo +1.98.0 fmt --all -- --check`
- `git diff --check`