### PR TITLE
perf(compiler): increase rules per function

### DIFF
--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -514,7 +514,11 @@ impl<'a> Compiler<'a> {
         let mut wasm_mod = WasmModuleBuilder::new();
 
         wasm_mod.namespaces_per_func(20);
-        wasm_mod.rules_per_func(10);
+        wasm_mod.rules_per_func(if cfg!(feature = "rules-profiling") {
+            10
+        } else {
+            40
+        });
 
         let wasm_symbols = wasm_mod.wasm_symbols();
         let wasm_exports = wasm_mod.wasm_exports();


### PR DESCRIPTION
## Summary

Generate up to 40 rules per Wasm function instead of 10. This reduces the
number of generated functions and the package loading/JIT overhead for large
rule sets.

Keep the existing value of 10 when `rules-profiling` is enabled, where smaller
functions preserve per-rule profiling granularity. The compiled Core and Full
profiling packages are byte-identical before and after this change.

## Results

Measured from `main` at `02a0ddda` on a dedicated 32-vCPU Linux host with
Rust 1.98, release LTO, `target-cpu=native`, clean sequential builds, no
allocator tunables, and two byte-identical baseline package arms rotated
across all three physical paths.

| Package/workload | Result | 95% session CI |
|---|---:|---:|
| Native Forge Core, 100k x 4 KiB, 32 threads | **+1.502% (35/36)** | **+1.304% to +1.699%** |
| Portable Forge Full/modules, 150 files, 4 threads | **+5.598% (36/36)** | **+4.575% to +6.622%** |
| Native Forge Core, 256 MiB, 1 thread | +0.103% | -0.341% to +0.546% |
| Native Forge Full/modules, 150 files, 4 threads | +0.299% | -0.651% to +1.248% |

Core small-file throughput increases from about 45.3k to 46.0k files/s, or
185.4 to 188.2 MB/s. Both control workloads pass a predeclared 1%
non-inferiority margin. The aggregate physical placebo is +0.019% for Core and
-0.074% for portable Full, with both confidence intervals crossing zero.

Sorted NDJSON output is byte-identical for all 100,000 Core inputs and all 150
Full inputs. Literal-heavy, regex-heavy, regex-boundary, and hex-heavy rule
sets compile byte-identically because they remain below the grouping threshold.

## Validation

- `cargo +1.98.0 test --locked --workspace`
- `cargo +1.98.0 test --locked --workspace --no-default-features`
- `cargo +1.98.0 test --locked --workspace --features magic-module,rules-profiling`
- `cargo +1.98.0 test --locked -p yara-x-cli`
- `cargo +1.98.0 clippy --locked --tests --no-deps -- --deny clippy::all`
- `cargo +1.98.0 fmt --all --check`
- `git diff --check`
