### PR TITLE
perf(parser): clear speculative errors after each top-level item

### DIFF
--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -860,6 +860,8 @@ impl<'src> ParserImpl<'src> {
     }
 
     fn flush_errors(&mut self) {
+        self.expected_token_errors.clear();
+        self.unexpected_token_errors.clear();
         for (span, error) in self.pending_errors.drain(0..) {
             self.output.push_error(error, span);
         }


### PR DESCRIPTION
`expected_token_errors` and `unexpected_token_errors` are used to choose the
best diagnostic while parsing the current top-level item. Since the parser
error-recovery refactor, speculative failures from successfully parsed items
remain in both maps until the whole ruleset is dropped.

Clear the maps when `flush_errors` finishes a top-level item. This restores
their intended lifetime without changing parser output.

On exact `02a0ddda`, five rotated sessions with physically independent
baseline, byte-identical null, and candidate binaries produced:

| Ruleset | Compile throughput | 95% CI | Peak RSS |
|---|---:|---:|---:|
| Forge Core | +25.37% | +24.16% to +26.58% | -31.30% |
| Forge Full | +34.18% | +33.50% to +34.86% | -39.06% |
| Malpedia | +38.38% | +33.78% to +42.97% | -64.36% |
| ReversingLabs | +19.76% | +17.98% to +21.55% | -22.45% |
| Signature Base | +13.98% | +12.18% to +15.78% | -40.05% |

The null intervals cross zero. Literal-heavy, hex-heavy, regex-heavy, and
small regex control point estimates remain within 1%, with all intervals
crossing zero.

Serialized packages are byte-identical for all six measured inputs. Parser
golden tests, the workspace test suite, feature and no-default-feature
matrices, Clippy, Rustfmt, and an exact smoke scan pass.
