### PR TITLE
perf: propagate `filesize` bounds and file header constraints across rule boundaries

### DIFF
--- a/lib/src/compiler/ir/mod.rs
+++ b/lib/src/compiler/ir/mod.rs
@@ -52,7 +52,9 @@ use crate::compiler::ir::dfs::{
     DFSIter, DFSWithScopeIter, Event, EventContext, dfs_common,
 };
 
-use crate::compiler::{FilesizeBounds, HeaderConstraint, RegexSetId};
+use crate::compiler::{
+    FilesizeBounds, HeaderConstraint, RegexSetId, RuleId,
+};
 use crate::re;
 use crate::symbols::Symbol;
 use crate::types::Value::Const;
@@ -1008,7 +1010,10 @@ impl IR {
     /// In contrast, the condition `filesize < 10MB or $a` does not impose a
     /// filesize constraint, since the use of `or` allows files larger than
     /// 10MB to also match.
-    pub fn filesize_bounds(&self) -> FilesizeBounds {
+    pub fn filesize_bounds<'a>(
+        &self,
+        rule_lookup: impl Fn(RuleId) -> Option<&'a FilesizeBounds>,
+    ) -> FilesizeBounds {
         let mut result = FilesizeBounds::default();
         let mut dfs = self.dfs_iter(self.root.unwrap());
 
@@ -1018,6 +1023,13 @@ impl IR {
                 _ => continue,
             };
             match expr {
+                Expr::Symbol(symbol) => {
+                    if let Symbol::Rule { rule_id, .. } = symbol.as_ref() {
+                        if let Some(rule_bounds) = rule_lookup(*rule_id) {
+                            result.merge(rule_bounds);
+                        }
+                    }
+                }
                 Expr::Gt { lhs, rhs } => {
                     match (self.get(*lhs), self.get(*rhs)) {
                         // constant > filesize
@@ -1128,6 +1140,7 @@ impl IR {
     pub fn header_constraints<'a>(
         &self,
         pattern_lookup: impl Fn(PatternIdx) -> &'a Pattern,
+        rule_lookup: impl Fn(RuleId) -> Option<&'a HeaderConstraint>,
     ) -> HeaderConstraint {
         let mut constrained_bytes = BTreeMap::new();
         let mut unsatisfiable = false;
@@ -1139,6 +1152,33 @@ impl IR {
                 _ => continue,
             };
             match expr {
+                Expr::Symbol(symbol) => {
+                    if let Symbol::Rule { rule_id, .. } = symbol.as_ref() {
+                        if let Some(rule_constraints) = rule_lookup(*rule_id) {
+                            match rule_constraints {
+                                HeaderConstraint::Unsatisfiable => {
+                                    unsatisfiable = true;
+                                }
+                                HeaderConstraint::Constrained(bytes) => {
+                                    for (i, &b) in bytes.iter().enumerate() {
+                                        match constrained_bytes.entry(i) {
+                                            Entry::Occupied(entry) => {
+                                                if *entry.get() != b {
+                                                    unsatisfiable = true;
+                                                    break;
+                                                }
+                                            }
+                                            Entry::Vacant(entry) => {
+                                                entry.insert(b);
+                                            }
+                                        }
+                                    }
+                                }
+                                HeaderConstraint::Unconstrained => {}
+                            }
+                        }
+                    }
+                }
                 Expr::Eq { lhs, rhs } => {
                     self.extract_header_constraints_from_eq(
                         *lhs,

--- a/lib/src/compiler/mod.rs
+++ b/lib/src/compiler/mod.rs
@@ -261,6 +261,8 @@ struct Namespace {
     id: NamespaceId,
     ident_id: IdentId,
     symbols: Rc<RefCell<SymbolTable>>,
+    global_filesize_bounds: FilesizeBounds,
+    global_header_constraints: HeaderConstraint,
 }
 
 /// Compiles YARA source code producing a set of compiled [`Rules`].
@@ -471,6 +473,10 @@ pub struct Compiler<'a> {
 
     /// Grouped RegexSets constructed during IR creation for or-expressions.
     regex_sets: FxHashMap<RegexSetId, Vec<RegexId>>,
+
+    /// Constraints on filesize and header associated with each rule. A
+    /// [`RuleId`] is an index in this vector.
+    rule_constraints: Vec<(FilesizeBounds, HeaderConstraint)>,
 }
 
 impl<'a> Compiler<'a> {
@@ -501,6 +507,8 @@ impl<'a> Compiler<'a> {
             id: NamespaceId(0),
             ident_id: ident_pool.get_or_intern("default"),
             symbols: symbol_table.push_new(),
+            global_filesize_bounds: FilesizeBounds::default(),
+            global_header_constraints: HeaderConstraint::default(),
         };
 
         // At this point the symbol table (which is a stacked symbol table) has
@@ -564,6 +572,7 @@ impl<'a> Compiler<'a> {
             includes_enabled: true,
             include_stack: Vec::new(),
             regex_sets: FxHashMap::default(),
+            rule_constraints: Vec::new(),
         }
     }
 
@@ -799,6 +808,8 @@ impl<'a> Compiler<'a> {
             id: NamespaceId(self.current_namespace.id.0 + 1),
             ident_id: self.ident_pool.get_or_intern(namespace),
             symbols: self.symbol_table.push_new(),
+            global_filesize_bounds: FilesizeBounds::default(),
+            global_header_constraints: HeaderConstraint::default(),
         };
         self.rules_depending_on_unsupported_modules.clear();
         self.wasm_mod.new_namespace();
@@ -1274,6 +1285,15 @@ impl Compiler<'_> {
             sub_patterns_len: self.sub_patterns.len(),
             symbol_table_len: self.symbol_table.len(),
             fast_scan_patterns_len: self.fast_scan_patterns.len(),
+            rule_constraints_len: self.rule_constraints.len(),
+            global_filesize_bounds: self
+                .current_namespace
+                .global_filesize_bounds
+                .clone(),
+            global_header_constraints: self
+                .current_namespace
+                .global_header_constraints
+                .clone(),
         }
     }
 
@@ -1289,6 +1309,11 @@ impl Compiler<'_> {
         self.atoms.truncate(snapshot.atoms_len);
         self.symbol_table.truncate(snapshot.symbol_table_len);
         self.fast_scan_patterns.truncate(snapshot.fast_scan_patterns_len);
+        self.rule_constraints.truncate(snapshot.rule_constraints_len);
+        self.current_namespace.global_filesize_bounds =
+            snapshot.global_filesize_bounds;
+        self.current_namespace.global_header_constraints =
+            snapshot.global_header_constraints;
 
         // Pattern IDs that are >= next_pattern_id are being discarded. Any pattern
         // associated to such IDs must be removed.
@@ -1786,13 +1811,38 @@ impl Compiler<'_> {
 
         // Analyze the condition and determine the bounds it imposes to
         // `filesize`, if any.
-        let filesize_bounds = self.ir.filesize_bounds();
+        let mut filesize_bounds = self.ir.filesize_bounds(|rule_id| {
+            self.rule_constraints.get(rule_id.0 as usize).map(|(b, _)| b)
+        });
 
         // Analyze the condition and determine if it imposes some constraint
         // to the file header (ex: `uint16(0) == 0x5a4d`).
-        let header_constraints = self.ir.header_constraints(|pat_idx| {
-            rule_patterns[pat_idx.as_usize()].pattern()
-        });
+        let mut header_constraints = self.ir.header_constraints(
+            |pat_idx| rule_patterns[pat_idx.as_usize()].pattern(),
+            |rule_id| {
+                self.rule_constraints.get(rule_id.0 as usize).map(|(_, c)| c)
+            },
+        );
+
+        let is_global = rule.flags.contains(RuleFlags::Global);
+
+        if is_global {
+            self.current_namespace
+                .global_filesize_bounds
+                .merge(&filesize_bounds);
+            self.current_namespace
+                .global_header_constraints
+                .merge(&header_constraints);
+            filesize_bounds =
+                self.current_namespace.global_filesize_bounds.clone();
+            header_constraints =
+                self.current_namespace.global_header_constraints.clone();
+        } else {
+            filesize_bounds
+                .merge(&self.current_namespace.global_filesize_bounds);
+            header_constraints
+                .merge(&self.current_namespace.global_header_constraints);
+        }
 
         // Set the bounds to all regex patterns in the rule. This must be done
         // before assigning the PatternId to each pattern, as the filesize
@@ -1826,6 +1876,8 @@ impl Compiler<'_> {
                 writeln!(w, "{filesize_bounds:?}\n",).unwrap();
             }
         }
+
+        self.rule_constraints.push((filesize_bounds, header_constraints));
 
         let mut pattern_ids = Vec::with_capacity(rule_patterns.len());
         let mut patterns = Vec::with_capacity(rule_patterns.len());
@@ -3181,6 +3233,9 @@ struct Snapshot {
     sub_patterns_len: usize,
     symbol_table_len: usize,
     fast_scan_patterns_len: usize,
+    rule_constraints_len: usize,
+    global_filesize_bounds: FilesizeBounds,
+    global_header_constraints: HeaderConstraint,
 }
 
 /// Represents a list of warnings.

--- a/lib/src/compiler/rules.rs
+++ b/lib/src/compiler/rules.rs
@@ -952,6 +952,13 @@ impl FilesizeBounds {
         }
         self
     }
+
+    /// Merges another set of filesize bounds into this one (intersection).
+    pub fn merge(&mut self, other: &Self) -> &mut Self {
+        self.max_start(other.start);
+        self.min_end(other.end);
+        self
+    }
 }
 
 /// Describes the requirements on the file header imposed by a rule condition.
@@ -978,6 +985,28 @@ impl HeaderConstraint {
             Self::Unconstrained => true,
             Self::Unsatisfiable => false,
             Self::Constrained(bytes) => data.starts_with(bytes),
+        }
+    }
+
+    /// Merges another header constraint into this one (intersection).
+    pub fn merge(&mut self, other: &Self) {
+        match (&self, other) {
+            (Self::Unsatisfiable, _) => {}
+            (_, Self::Unsatisfiable) => {
+                *self = Self::Unsatisfiable;
+            }
+            (Self::Unconstrained, _) => {
+                *self = other.clone();
+            }
+            (_, Self::Unconstrained) => {}
+            (Self::Constrained(a), Self::Constrained(b)) => {
+                let min_len = a.len().min(b.len());
+                if a[..min_len] != b[..min_len] {
+                    *self = Self::Unsatisfiable;
+                } else if b.len() > a.len() {
+                    *self = other.clone();
+                }
+            }
         }
     }
 }

--- a/lib/src/tests/mod.rs
+++ b/lib/src/tests/mod.rs
@@ -4342,6 +4342,220 @@ fn header_constraints_optimization() {
 }
 
 #[test]
+fn cross_rule_constraints() {
+    // 1. Header constraint propagated from referenced private rule.
+    let rules = crate::compile(
+        r#"
+        private rule IsPE {
+            condition:
+                uint16(0) == 0x5A4D
+        }
+        rule Amadey {
+            strings:
+                $re = /foo|bar/
+            condition:
+                IsPE and any of them
+        }
+        "#,
+    )
+    .unwrap();
+
+    // Verify header constraint is assigned to pattern.
+    let constraints: Vec<_> = rules.header_constraints().collect();
+    assert_eq!(constraints.len(), 1);
+    assert_eq!(
+        constraints[0].1,
+        &crate::compiler::HeaderConstraint::Constrained(vec![0x4D, 0x5A])
+    );
+
+    // Matches with PE header
+    let mut scanner = crate::Scanner::new(&rules);
+    let results = scanner.scan(b"MZ\0\0foo").unwrap();
+    assert_eq!(results.matching_rules().len(), 1);
+
+    // Does not match with non-PE header (pattern is disabled)
+    let results = scanner.scan(b"\0\0\0\0foo").unwrap();
+    assert_eq!(results.matching_rules().len(), 0);
+
+    // 2. Header constraint propagated from global rule without explicit reference.
+    let rules = crate::compile(
+        r#"
+        global private rule IsPE {
+            condition:
+                uint16(0) == 0x5A4D
+        }
+        rule Amadey {
+            strings:
+                $re = /foo|bar/
+            condition:
+                any of them
+        }
+        "#,
+    )
+    .unwrap();
+
+    let constraints: Vec<_> = rules.header_constraints().collect();
+    assert_eq!(constraints.len(), 1);
+    assert_eq!(
+        constraints[0].1,
+        &crate::compiler::HeaderConstraint::Constrained(vec![0x4D, 0x5A])
+    );
+
+    let mut scanner = crate::Scanner::new(&rules);
+    let results = scanner.scan(b"MZ\0\0foo").unwrap();
+    assert_eq!(results.matching_rules().len(), 1);
+    let results = scanner.scan(b"\0\0\0\0foo").unwrap();
+    assert_eq!(results.matching_rules().len(), 0);
+
+    // 3. Filesize bounds propagated from referenced rule.
+    let rules = crate::compile(
+        r#"
+        rule Small {
+            condition:
+                filesize < 100
+        }
+        rule Test {
+            strings:
+                $re = /foo|bar/
+            condition:
+                Small and $re
+        }
+        "#,
+    )
+    .unwrap();
+
+    let bounds: Vec<_> = rules.filesize_bounds().collect();
+    assert_eq!(bounds.len(), 1);
+    assert_eq!(
+        bounds[0].1,
+        &crate::compiler::FilesizeBounds::from(..100)
+    );
+
+    // 4. Filesize bounds propagated from global rule.
+    let rules = crate::compile(
+        r#"
+        global rule Small {
+            condition:
+                filesize < 100
+        }
+        rule Test {
+            strings:
+                $re = /foo|bar/
+            condition:
+                $re
+        }
+        "#,
+    )
+    .unwrap();
+
+    let bounds: Vec<_> = rules.filesize_bounds().collect();
+    assert_eq!(bounds.len(), 1);
+    assert_eq!(
+        bounds[0].1,
+        &crate::compiler::FilesizeBounds::from(..100)
+    );
+
+    // 5. Chained rule references: A -> B -> C
+    let rules = crate::compile(
+        r#"
+        rule A {
+            condition:
+                uint16(0) == 0x5A4D
+        }
+        rule B {
+            condition:
+                A and uint8(2) == 0x90
+        }
+        rule C {
+            strings:
+                $re = /foo|bar/
+            condition:
+                B and $re
+        }
+        "#,
+    )
+    .unwrap();
+
+    let constraints: Vec<_> = rules.header_constraints().collect();
+    assert_eq!(constraints.len(), 1);
+    assert_eq!(
+        constraints[0].1,
+        &crate::compiler::HeaderConstraint::Constrained(vec![0x4D, 0x5A, 0x90])
+    );
+
+    // 6. Contradictory header constraints (PE vs ELF)
+    let rules = crate::compile(
+        r#"
+        private rule IsPE {
+            condition:
+                uint16(0) == 0x5A4D
+        }
+        private rule IsELF {
+            condition:
+                uint32(0) == 0x464c457f
+        }
+        rule Impossible {
+            strings:
+                $re = /foo|bar/
+            condition:
+                IsPE and IsELF and $re
+        }
+        "#,
+    )
+    .unwrap();
+
+    let constraints: Vec<_> = rules.header_constraints().collect();
+    assert_eq!(constraints.len(), 1);
+    assert_eq!(
+        constraints[0].1,
+        &crate::compiler::HeaderConstraint::Unsatisfiable
+    );
+
+    let mut scanner = crate::Scanner::new(&rules);
+    let results = scanner.scan(b"MZ\0\0foo").unwrap();
+    assert_eq!(results.matching_rules().len(), 0);
+
+    // 7. Multi-namespace isolation: global rule in ns1 does not affect ns2
+    let mut compiler = crate::Compiler::new();
+    compiler.new_namespace("ns1");
+    compiler
+        .add_source(
+            r#"
+            global rule IsPE {
+                condition:
+                    uint16(0) == 0x5A4D
+            }
+            rule Rule1 {
+                strings:
+                    $re1 = /foo1/
+                condition:
+                    $re1
+            }
+            "#,
+        )
+        .unwrap();
+
+    compiler.new_namespace("ns2");
+    compiler
+        .add_source(
+            r#"
+            rule Rule2 {
+                strings:
+                    $re2 = /foo2/
+                condition:
+                    $re2
+            }
+            "#,
+        )
+        .unwrap();
+
+    let rules = compiler.build();
+    let constraints: std::collections::HashMap<_, _> =
+        rules.header_constraints().collect();
+    assert_eq!(constraints.len(), 1);
+}
+
+#[test]
 fn test_pattern_atoms() {
     let rules = crate::compile(
         r#"


### PR DESCRIPTION
Propagate `filesize` bounds and file header constraints across rule boundaries so that rules referencing other rules (or subject to `global` rules in the same namespace) inherit their constraints automatically.

Previously, `IR::filesize_bounds` and `IR::header_constraints` only inspected constraints expressed directly within a single rule's condition. Patterns in rules that factored common checks into helper or `global` rules (e.g. `private rule IsPE { condition: uint16(0) == 0x5A4D }`) did not benefit from header-constraint or filesize-bound pruning.